### PR TITLE
improve error messages and exclude special block devices from 'number…

### DIFF
--- a/sap/note/ini.go
+++ b/sap/note/ini.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SUSE/saptune/system"
 	"github.com/SUSE/saptune/txtparser"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -91,6 +92,9 @@ func GetBlockVal(key string) (string, error) {
 			ret_val = ret_val + fmt.Sprintf("%s@%s ", k, strconv.Itoa(v))
 		}
 	}
+	fields := strings.Fields(ret_val)
+	sort.Strings(fields)
+	ret_val = strings.Join(fields, " ")
 	return ret_val, nil
 }
 
@@ -108,9 +112,12 @@ func OptBlkVal(parameter, act_value, cfg_value string) string {
 	}
 	for _, entry := range strings.Fields(val) {
 		fields := strings.Split(entry, "@")
-		ret_val = ret_val + fmt.Sprintf("%s@%s ", fields[0], sval)
+		if ret_val == "" {
+			ret_val = ret_val + fmt.Sprintf("%s@%s", fields[0], sval)
+		} else {
+			ret_val = ret_val + " " + fmt.Sprintf("%s@%s", fields[0], sval)
+		}
 	}
-
 	return ret_val
 }
 

--- a/system/sys.go
+++ b/system/sys.go
@@ -62,14 +62,9 @@ func TestSysString(parameter, value string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get sys key '%s': %v", parameter, err)
 	}
-	err = ioutil.WriteFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644)
-	if err != nil {
-		fmt.Errorf("failed to set sys key '%s' to string '%s': %v", parameter, value, err)
-	} else {
+	if err = ioutil.WriteFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644); err == nil {
+		// set key back to previous value, because this was only a test
 		err = ioutil.WriteFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)), []byte(save), 0644)
-		if err != nil {
-			return fmt.Errorf("failed to set sys key '%s' back to string '%s': %v", parameter, value, err)
-		}
 	}
 	return err
 }


### PR DESCRIPTION
… of request' settings. Improve the verify option for the block devices. (bsc#1079599)

Please review and merge. I will submit these changes as version 1.1.6 to SLE15 and SLE12SP1/2/3