### PR TITLE
never ever stop or disable uuidd.socket in saptune (bsc#1100107)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go_import_path: github.com/HouzuoGuo/saptune
+go_import_path: github.com/SUSE/saptune
 go:
   - 1.7.x
 os:

--- a/sap/note/common.go
+++ b/sap/note/common.go
@@ -189,8 +189,6 @@ func (inst AfterInstallation) Apply() error {
 	var err error
 	if inst.UuiddSocketStatus {
 		err = system.SystemctlEnableStart("uuidd.socket")
-	} else {
-		err = system.SystemctlDisableStop("uuidd.socket")
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
As a running uuidd.socket is needed for every SAP system and as it is normally enabled and started by vendor preset, there is no reason to stop and/or disable uuidd.socket in saptune.