### PR TITLE
 support 'saptune note revert <id>' and 'saptune solution revert <sol…

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -201,7 +201,9 @@ func TestOptimiseNoteOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	VerifyConfig(t, tuneApp, []string{"1001", "1002"}, []string{})
-	VerifyFileContent(t, SampleParamFile, "optimised2")
+	// change expected value from "optimised2" to "optimised1", as we do no
+	// longer apply a note again, which was already applied before.
+	VerifyFileContent(t, SampleParamFile, "optimised1")
 	if err := tuneApp.RevertAll(true); err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +262,9 @@ func TestOptimiseSolutionOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	VerifyConfig(t, tuneApp, []string{}, []string{"sol1", "sol2"})
-	VerifyFileContent(t, SampleParamFile, "optimised2")
+	// change expected value from "optimised2" to "optimised1", as we do no
+	// longer apply a note again, which was already applied before.
+	VerifyFileContent(t, SampleParamFile, "optimised1")
 	if err := tuneApp.RevertAll(true); err != nil {
 		t.Fatal(err)
 	}
@@ -277,7 +281,9 @@ func TestOptimiseSolutionOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	VerifyConfig(t, tuneApp, []string{}, []string{"sol1", "sol12"})
-	VerifyFileContent(t, SampleParamFile, "optimised1")
+	// change expected value from "optimised1" to "optimised2", as we do no
+	// longer apply a note again, which was already applied before.
+	VerifyFileContent(t, SampleParamFile, "optimised2")
 	if err := tuneApp.RevertSolution("sol12"); err != nil {
 		t.Fatal(err)
 	}
@@ -325,7 +331,7 @@ func TestOverlappingSolutions(t *testing.T) {
 	tuneApp := InitialiseApp(path.Join(SampleNoteDataDir, "conf"), path.Join(SampleNoteDataDir, "data"), AllTestNotes, AllTestSolutions)
 	VerifyConfig(t, tuneApp, []string{}, []string{})
 
-	// Optimise sol1, sol2, sol12, and then revert sol12
+	// Optimise sol2, sol1, sol12, and then revert sol12
 	if _, err := tuneApp.TuneSolution("sol2"); err != nil {
 		t.Fatal(err)
 	}
@@ -340,13 +346,17 @@ func TestOverlappingSolutions(t *testing.T) {
 		t.Fatal(err)
 	}
 	VerifyConfig(t, tuneApp, []string{}, []string{"sol1", "sol12", "sol2"})
-	VerifyFileContent(t, SampleParamFile, "optimised2")
+	// change expected value from "optimised2" to "optimised1", as we do no
+	// longer apply a note again, which was already applied before.
+	VerifyFileContent(t, SampleParamFile, "optimised1")
 	if err := tuneApp.RevertSolution("sol12"); err != nil {
 		t.Fatal(err)
 	}
 	VerifyConfig(t, tuneApp, []string{}, []string{"sol1", "sol2"})
 	// Reverting sol12 should not affect anything
-	VerifyFileContent(t, SampleParamFile, "optimised2")
+	// change expected value from "optimised2" to "optimised1", as we do no
+	// longer apply a note again, which was already applied before.
+	VerifyFileContent(t, SampleParamFile, "optimised1")
 }
 
 func TestCombiningSolutionAndNotes(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -43,10 +43,10 @@ Daemon control:
   saptune daemon [ start | status | stop ]
 Tune system according to SAP and SUSE notes:
   saptune note [ list | verify ]
-  saptune note [ apply | simulate | verify | customise ] NoteID
+  saptune note [ apply | simulate | verify | customise | revert ] NoteID
 Tune system for all notes applicable to your SAP solution:
   saptune solution [ list | verify ]
-  saptune solution [ apply | simulate | verify ] SolutionName
+  saptune solution [ apply | simulate | verify | revert ] SolutionName
 Revert all parameters tuned by the SAP notes or solutions:
   saptune revert all`)
 	os.Exit(exitStatus)
@@ -538,7 +538,6 @@ func NoteAction(actionName, noteID string) {
 		if err := syscall.Exec(editor, []string{editor, editFileName}, os.Environ()); err != nil {
 			errorExit("Failed to start launch editor %s: %v", editor, err)
 		}
-/*
 	case "revert":
 		if noteID == "" {
 			PrintHelpAndExit(1)
@@ -548,7 +547,6 @@ func NoteAction(actionName, noteID string) {
 		}
 		fmt.Println("Parameters tuned by the note have been successfully reverted.")
 		fmt.Println("Please note: the reverted note may still show up in list of enabled notes, if an enabled solution refers to it.")
-*/
 	default:
 		PrintHelpAndExit(1)
 	}
@@ -627,7 +625,6 @@ func SolutionAction(actionName, solName string) {
 			fmt.Printf("If you run `saptune solution apply %s`, the following changes will be applied to your system:\n", solName)
 			PrintNoteFields("NONE", comparisons, false)
 		}
-/*
 	case "revert":
 		if solName == "" {
 			PrintHelpAndExit(1)
@@ -636,7 +633,6 @@ func SolutionAction(actionName, solName string) {
 			errorExit("Failed to revert tuning for solution %s: %v", solName, err)
 		}
 		fmt.Println("Parameters tuned by the notes referred by the SAP solution have been successfully reverted.")
-*/
 	default:
 		PrintHelpAndExit(1)
 	}

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -1,6 +1,6 @@
 .\"/* 
+.\" * Copyright (c) 2018 SUSE LLC.
 .\" * All rights reserved
-.\" * Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
 .\" * Authors: Angela Briel
 .\" *
 .\" * This program is free software; you can redistribute it and/or

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -1,6 +1,6 @@
 .\"/*
+.\" * Copyright (c) 2017-2018 SUSE LLC.
 .\" * All rights reserved
-.\" * Copyright (c) 2017-2018 SUSE LINUX GmbH, Nuernberg, Germany.
 .\" * Authors: Howard Guo, Angela Briel
 .\" *
 .\" * This program is free software; you can redistribute it and/or

--- a/ospackage/profile/script.sh
+++ b/ospackage/profile/script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2016 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2016 SUSE LLC.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sap/note/parameter.go
+++ b/sap/note/parameter.go
@@ -1,0 +1,213 @@
+/*
+SAP notes tune one or more parameters at a time.
+*/
+package note
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+)
+
+type ParameterNoteEntry struct {
+	NoteId   string
+	Value    string
+}
+
+type ParameterNotes struct {
+	AllNotes []ParameterNoteEntry	// list of applied notes, which manipulate the given system parameter
+}
+
+// Directory where to store the parameter state files
+// separated from the note state file directory
+const SaptuneParameterStateDir = "/var/lib/saptune/parameter"
+
+// Return path to the serialised parameter state file.
+func GetPathToParameter(param string) string {
+        return path.Join(SaptuneParameterStateDir, param)
+}
+
+// Check, if given noteID is already part of the parameter list of notes
+func NoteInParameterList(noteID string, list []ParameterNoteEntry) bool {
+	for _, note := range list {
+		if note.NoteId == noteID {
+			return true
+		}
+	}
+	return false
+}
+
+// List all stored paramter states. Return paramter names
+func ListParams() (ret []string, err error) {
+	if err = os.MkdirAll(SaptuneParameterStateDir, 0755); err != nil {
+		return
+	}
+	// List SaptuneParameterStateDir and collect parameter names from file names
+	dirContent, err := ioutil.ReadDir(SaptuneParameterStateDir)
+	if os.IsNotExist(err) {
+		return []string{}, nil
+	} else if err != nil {
+		return
+	}
+	ret = make([]string, 0, len(dirContent))
+	for _, pname := range dirContent {
+		ret = append(ret, pname.Name())
+	}
+	return
+}
+
+// Create parameter state file and insert the start values.
+func CreateParameterStartValues(param, value string) {
+	pEntries := ParameterNotes {
+		AllNotes: make([]ParameterNoteEntry, 0, 64),
+	}
+	pEntries = GetSavedParameterNotes(param)
+	if len(pEntries.AllNotes) == 0 {
+		log.Printf("Write parameter start value '%s' to file '%s'", value, GetPathToParameter(param))
+		// file does not exist, create start entry
+		pEntry := ParameterNoteEntry{
+			NoteId:   "start",
+			Value:    value,
+		}
+		pEntries.AllNotes = append(pEntries.AllNotes, pEntry)
+		err := StoreParameter(param, pEntries, true)
+		if err != nil {
+			log.Printf("Failed to store start values for parameter file '%s' for parameter '%s'", GetPathToParameter(param), param)
+		}
+	}
+}
+
+// Add note parameter values to the state file.
+func AddParameterNoteValues(param, value, noteID string) {
+	pEntries := ParameterNotes {
+		AllNotes: make([]ParameterNoteEntry, 0, 64),
+	}
+	pEntries = GetSavedParameterNotes(param)
+	if len(pEntries.AllNotes) != 0 && !NoteInParameterList(noteID, pEntries.AllNotes) {
+		log.Printf("Write note '%s' parameter value '%s' to file '%s'", noteID, value, GetPathToParameter(param))
+		// file exis
+		pEntry := ParameterNoteEntry{
+			NoteId:   noteID,
+			Value:    value,
+		}
+		pEntries.AllNotes = append(pEntries.AllNotes, pEntry)
+		err := StoreParameter(param, pEntries, true)
+		if err != nil {
+			log.Printf("Failed to store note '%s' values for parameter file '%s' for parameter '%s'", noteID, GetPathToParameter(param), param)
+		}
+	}
+}
+
+// Read content of stored paramter states. Return the content as ParameterNotes
+func GetSavedParameterNotes(param string) (ParameterNotes) {
+	pEntries := ParameterNotes {
+		AllNotes: make([]ParameterNoteEntry, 0, 64),
+	}
+	content, err := ioutil.ReadFile(GetPathToParameter(param))
+	if err != nil {
+		return pEntries
+	}
+	err = json.Unmarshal(content, &pEntries)
+	return pEntries
+}
+
+// read all saved parameters from the state directory
+// fill structure app.AllParameters
+func GetAllSavedParameters() (map[string]ParameterNotes) {
+	params := make(map[string]ParameterNotes)
+	allParams, err := ListParams()
+	if err == nil {
+		for _, param := range allParams {
+			pEntries := GetSavedParameterNotes(param)
+			if len(pEntries.AllNotes) == 0 {
+				return params
+			}
+			params[param] = pEntries
+		}
+	}
+	return params
+}
+
+// Store parameter values to state directory
+// Write a json file with the name of the given parameter containing the 
+// applied noteIDs for this parameter and the associated parameter values
+func StoreParameter(param string, obj ParameterNotes, overwriteExisting bool) error {
+	content, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	if err = os.MkdirAll(SaptuneParameterStateDir, 0755); err != nil {
+		return err
+	}
+	if _, err := os.Stat(GetPathToParameter(param)); os.IsNotExist(err) || overwriteExisting {
+		return ioutil.WriteFile(GetPathToParameter(param), content, 0644)
+	}
+	return nil
+}
+
+// for a given noteID get the position in the slice AllNotes
+// return the position of the note within the slice.
+// do not sort the slice
+func PositionInParameterList(noteID string, list []ParameterNoteEntry) int {
+	for cnt, note := range list {
+		if note.NoteId == noteID {
+			return cnt
+		}
+	}
+	return 0
+}
+
+// Revert parameter value and remove noteID reference from parameter file
+// return value of parameter, if needed to change, empty string else
+func RevertParameter(param string, noteID string) (string) {
+	pvalue := ""
+	pEntries := ParameterNotes {
+		AllNotes: make([]ParameterNoteEntry, 0, 64),
+	}
+	// read values from the parameter state file
+	pEntries = GetSavedParameterNotes(param)
+	if len(pEntries.AllNotes) == 0 {
+		return pvalue
+	}
+	lastNote := pEntries.AllNotes[len(pEntries.AllNotes)-1]
+	pvalue = lastNote.Value
+	if lastNote.NoteId == noteID {
+		// if the requested noteID is the last one in AllNotes
+		// remove this entry and set the parameter value to the 'next to last'
+		pEntries.AllNotes = pEntries.AllNotes[:len(pEntries.AllNotes)-1]
+		next2lastNote := pEntries.AllNotes[len(pEntries.AllNotes)-1]
+		pvalue = next2lastNote.Value
+	} else {
+		// if the requested noteID is NOT the last one in AllNotes
+		// remove this entry but do not set a new parameter value
+		entry := PositionInParameterList(noteID, pEntries.AllNotes)
+		pEntries.AllNotes = append(pEntries.AllNotes[0:entry], pEntries.AllNotes[entry+1:]...)
+	}
+	if len(pEntries.AllNotes) == 1 {
+		// remove parameter state file, if only one entry ('start') is left.
+		remFileName := GetPathToParameter(param)
+		if _, err := os.Stat(remFileName); err == nil {
+			os.Remove(remFileName)
+		}
+	} else {
+		//store changes pEntries
+		err := StoreParameter(param, pEntries, true)
+		if err != nil {
+			fmt.Println("Problems during storing new parameter values")
+		}
+	}
+	return pvalue
+}
+
+/*
+For just reading the last element of a slice:
+
+sl[len(sl)-1]
+
+For removing it:
+
+sl = sl[:len(sl)-1]
+*/


### PR DESCRIPTION
…>' again.

add parameter based saved state files to support proper revert functionality
change company name in copyright lines
apply each note only once, write a log message ('note already applied' ), if the same note should be applied again (may be as part of a solution)
adapt the existing unit tests to this changes, but the unit tests for the new parameter based state files is missing. This will come next.

