### PR TITLE
Saptune improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,19 @@
 language: go
 go_import_path: github.com/SUSE/saptune
 go:
-  - 1.7.x
+  - 1.10.x
 os:
   - linux
 sudo: required
+
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
 script:
-  - sudo -E env "PATH=$PATH" go test -v -cover ./...
+  - sudo -E env "PATH=$PATH" go test -v -coverprofile=c.out -cover ./...
   - go build
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
 [![Build Status](https://travis-ci.org/SUSE/saptune.svg?branch=master)](https://travis-ci.org/SUSE/saptune)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/5375e2ca293dd0e8b322/test_coverage)](https://codeclimate.com/github/SUSE/saptune/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/5375e2ca293dd0e8b322/maintainability)](https://codeclimate.com/github/SUSE/saptune/maintainability)
 
 # saptune
 The utility adjusts system parameters such as kernel parameters and resource limits

--- a/app/app.go
+++ b/app/app.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 )
 
+// define saptunes main configuration file and variables
 const (
 	SysconfigSaptuneFile = "/etc/sysconfig/saptune"
 	TuneForSolutionsKey  = "TUNE_FOR_SOLUTIONS"
@@ -21,7 +22,7 @@ const (
 	NoteApplyOrderKey    = "NOTE_APPLY_ORDER"
 )
 
-// Application configuration and serialised state information.
+// App defines the application configuration and serialised state information.
 type App struct {
 	SysconfigPrefix  string
 	AllNotes         map[string]note.Note         // all notes
@@ -55,9 +56,8 @@ func InitialiseApp(sysconfigPrefix, stateDirPrefix string, allNotes map[string]n
 	return
 }
 
-// PositionInNoteApplyOrder
+// PositionInNoteApplyOrder returns the position of the note within the slice.
 // for a given noteID get the position in the slice NoteApplyOrder
-// return the position of the note within the slice.
 // do not sort the slice
 func PositionInNoteApplyOrder(list []string, noteID string) int {
 	for cnt, note := range list {
@@ -80,8 +80,8 @@ func (app *App) SaveConfig() error {
 	return ioutil.WriteFile(path.Join(app.SysconfigPrefix, SysconfigSaptuneFile), []byte(sysconf.ToText()), 0644)
 }
 
-// GetSortedSolutionEnabledNotes
-// Return the number of all solution-enabled SAP notes, sorted.
+// GetSortedSolutionEnabledNotes returns the number of all solution-enabled
+// SAP notes, sorted.
 func (app *App) GetSortedSolutionEnabledNotes() (allNoteIDs []string) {
 	allNoteIDs = make([]string, 0, 0)
 	for _, sol := range app.TuneForSolutions {
@@ -101,9 +101,9 @@ func (app *App) GetNoteByID(id string) (note.Note, error) {
 	if n, exists := app.AllNotes[id]; exists {
 		return n, nil
 	}
-	return nil, fmt.Errorf(`Note ID "%s" is not recognised by saptune.
+	return nil, fmt.Errorf(`the Note ID "%s" is not recognised by saptune.
 Run "saptune note list" for a complete list of supported notes.
-and then please double check your input and /etc/sysconfig/saptune.`, id)
+and then please double check your input and /etc/sysconfig/saptune`, id)
 }
 
 // GetSolutionByName return the solution corresponding to the name,
@@ -112,9 +112,9 @@ func (app *App) GetSolutionByName(name string) (solution.Solution, error) {
 	if n, exists := app.AllSolutions[name]; exists {
 		return n, nil
 	}
-	return nil, fmt.Errorf(`Solution name "%s" is not recognised by saptune.
+	return nil, fmt.Errorf(`solution name "%s" is not recognised by saptune.
 Run "saptune solution list" for a complete list of supported solutions,
-and then please double check your input and /etc/sysconfig/saptune.`, name)
+and then please double check your input and /etc/sysconfig/saptune`, name)
 }
 
 // TuneNote apply tuning for a note.
@@ -396,7 +396,7 @@ func (app *App) RevertAll(permanent bool) error {
 // to the note's guidelines.
 // The note comparison results will always contain all fields, no matter
 // the note is currently conforming or not.
-func (app *App) VerifyNote(noteID string) (conforming bool, comparisons map[string]note.NoteFieldComparison, valApplyList []string, err error) {
+func (app *App) VerifyNote(noteID string) (conforming bool, comparisons map[string]note.FieldComparison, valApplyList []string, err error) {
 	theNote, err := app.GetNoteByID(noteID)
 	if err != nil {
 		return
@@ -437,9 +437,9 @@ func (app *App) VerifyNote(noteID string) (conforming bool, comparisons map[stri
 // VerifySolution inspect the system and verify that all parameters conform
 // to all of the notes associated to the solution.
 // The note comparison results will always contain all fields from all notes.
-func (app *App) VerifySolution(solName string) (unsatisfiedNotes []string, comparisons map[string]map[string]note.NoteFieldComparison, err error) {
+func (app *App) VerifySolution(solName string) (unsatisfiedNotes []string, comparisons map[string]map[string]note.FieldComparison, err error) {
 	unsatisfiedNotes = make([]string, 0, 0)
-	comparisons = make(map[string]map[string]note.NoteFieldComparison)
+	comparisons = make(map[string]map[string]note.FieldComparison)
 	sol, err := app.GetSolutionByName(solName)
 	if err != nil {
 		return nil, nil, err
@@ -459,9 +459,9 @@ func (app *App) VerifySolution(solName string) (unsatisfiedNotes []string, compa
 // VerifyAll inspect the system and verify all parameters against all enabled
 // notes/solutions.
 // The note comparison results will always contain all fields from all notes.
-func (app *App) VerifyAll() (unsatisfiedNotes []string, comparisons map[string]map[string]note.NoteFieldComparison, err error) {
+func (app *App) VerifyAll() (unsatisfiedNotes []string, comparisons map[string]map[string]note.FieldComparison, err error) {
 	unsatisfiedNotes = make([]string, 0, 0)
-	comparisons = make(map[string]map[string]note.NoteFieldComparison)
+	comparisons = make(map[string]map[string]note.FieldComparison)
 	for _, solName := range app.TuneForSolutions {
 		// Collect field comparison results from solution notes
 		unsatisfiedSolNotes, noteComparisons, err := app.VerifySolution(solName)

--- a/app/state.go
+++ b/app/state.go
@@ -8,9 +8,10 @@ import (
 	"path"
 )
 
+// SaptuneStateDir defines saptunes saved state directory
 const SaptuneStateDir = "/var/lib/saptune/saved_state"
 
-// Store and manage serialised note states.
+// State stores and manages serialised note states.
 type State struct {
 	StateDirPrefix string
 }

--- a/app/state.go
+++ b/app/state.go
@@ -15,12 +15,13 @@ type State struct {
 	StateDirPrefix string
 }
 
-// Return path to the serialised note state file.
+// GetPathToNote returns path to the serialised note state file.
 func (state *State) GetPathToNote(noteID string) string {
 	return path.Join(state.StateDirPrefix, SaptuneStateDir, noteID)
 }
 
-// Create a file under state directory with the object serialised into JSON. Overwrite existing file if there is any.
+// Store creates a file under state directory with the object serialised
+// into JSON. Overwrite existing file if there is any.
 func (state *State) Store(noteID string, obj note.Note, overwriteExisting bool) error {
 	content, err := json.Marshal(obj)
 	if err != nil {
@@ -54,7 +55,8 @@ func (state *State) List() (ret []string, err error) {
 	return
 }
 
-// Deserialise an SAP note into the destination pointer. The destination must be a pointer.
+// Retrieve deserialises a SAP note into the destination pointer.
+// The destination must be a pointer.
 func (state *State) Retrieve(noteID string, dest interface{}) error {
 	content, err := ioutil.ReadFile(state.GetPathToNote(noteID))
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 )
 
+// constant definitions
 const (
 	SapconfService        = "sapconf.service"
 	TunedService          = "tuned.service"
@@ -26,17 +27,16 @@ const (
 	ExitNotTuned          = 3
 	NoteTuningSheets      = "/usr/share/saptune/notes/"
 	OverrideTuningSheets  = "/etc/saptune/override/"
-	// ExtraTuningSheets is a directory located on file system for external parties to place their tuning option files.
-	ExtraTuningSheets     = "/etc/saptune/extra/"
+	ExtraTuningSheets     = "/etc/saptune/extra/" // ExtraTuningSheets is a directory located on file system for external parties to place their tuning option files.
 	SetGreenText          = "\033[32m"
 	SetRedText            = "\033[31m"
 	ResetTextColor        = "\033[0m"
 	footnote1             = "[1] setting is not supported by the system"
 	footnote2             = "[2] setting is not available on the system"
 	footnote3             = "[3] value is only checked, but NOT set"
-
 )
 
+// PrintHelpAndExit Print the usage and exit
 func PrintHelpAndExit(exitStatus int) {
 	fmt.Println(`saptune: Comprehensive system optimisation management for SAP solutions.
 Daemon control:
@@ -79,13 +79,13 @@ func main() {
 		errorExit("Please run saptune with root privilege.")
 		return
 	}
-	var saptune_log io.Writer
-	saptune_log, err := os.OpenFile("/var/log/tuned/tuned.log", os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
+	var saptuneLog io.Writer
+	saptuneLog, err := os.OpenFile("/var/log/tuned/tuned.log", os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
 	if err != nil {
 		panic(err.Error())
 	}
-	saptune_writer := io.MultiWriter(os.Stderr, saptune_log)
-	log.SetOutput(saptune_writer)
+	saptuneWriter := io.MultiWriter(os.Stderr, saptuneLog)
+	log.SetOutput(saptuneWriter)
 	if system.IsPagecacheAvailable() {
 		solutionSelector = solutionSelector + "_PC"
 	}
@@ -112,6 +112,7 @@ func main() {
 	}
 }
 
+// RevertAction Revert all notes and solutions
 func RevertAction(actionName string) {
 	if actionName != "all" {
 		PrintHelpAndExit(1)
@@ -124,6 +125,7 @@ func RevertAction(actionName string) {
 	fmt.Println("Parameters tuned by the notes and solutions have been successfully reverted.")
 }
 
+// Handle daemon actions like start, stop, status asm.
 func DaemonAction(actionName string) {
 	switch actionName {
 	case "start":
@@ -189,22 +191,22 @@ func DaemonAction(actionName string) {
 	}
 }
 
-// Print mismatching fields in the note comparison result.
+// PrintNoteFields Print mismatching fields in the note comparison result.
 func PrintNoteFields(header string, noteComparisons map[string]map[string]note.NoteFieldComparison, printComparison bool) {
 
 	var fmtlen0, fmtlen1, fmtlen2, fmtlen3, fmtlen4 int
 	// initialise
-	printHead := ""
-	sortkeys  := make([]string, 0, len(noteComparisons))
-	remskeys  := make([]string, 0, len(noteComparisons))
-	footnote  := make([]string, 3, 3)
-	hasDiff   := false
 	compliant := "yes"
-	comment   := ""
-	override  := ""
-	format    := "\t%s : %s\n"
+	printHead := ""
 	noteField := ""
-	reminder  := make(map[string]string)
+	sortkeys := make([]string, 0, len(noteComparisons))
+	remskeys := make([]string, 0, len(noteComparisons))
+	footnote := make([]string, 3, 3)
+	reminder := make(map[string]string)
+	override := ""
+	comment := ""
+	hasDiff := false
+	format := "\t%s : %s\n"
 
 	if printComparison {
 		// verify
@@ -226,9 +228,9 @@ func PrintNoteFields(header string, noteComparisons map[string]map[string]note.N
 		for _, comparison := range comparisons {
 			if len(comparison.ReflectMapKey) != 0 && comparison.ReflectFieldName != "OverrideParams" {
 				if comparison.ReflectMapKey != "reminder" {
-					sortkeys = append(sortkeys, noteID + "@" + comparison.ReflectMapKey)
+					sortkeys = append(sortkeys, noteID+"@"+comparison.ReflectMapKey)
 				} else {
-					remskeys = append(remskeys, noteID + "@" + comparison.ReflectMapKey)
+					remskeys = append(remskeys, noteID+"@"+comparison.ReflectMapKey)
 				}
 			}
 		}
@@ -239,7 +241,7 @@ func PrintNoteFields(header string, noteComparisons map[string]map[string]note.N
 	}
 
 	// setup format values
-	for _ , skey := range sortkeys {
+	for _, skey := range sortkeys {
 		keyFields := strings.Split(skey, "@")
 		noteID := keyFields[0]
 		comparisons := noteComparisons[noteID]
@@ -292,7 +294,7 @@ func PrintNoteFields(header string, noteComparisons map[string]map[string]note.N
 
 	// print
 	noteID := ""
-	for _ , skey := range sortkeys {
+	for _, skey := range sortkeys {
 		comment = ""
 		keyFields := strings.Split(skey, "@")
 		key := keyFields[1]
@@ -344,7 +346,7 @@ func PrintNoteFields(header string, noteComparisons map[string]map[string]note.N
 			if printComparison {
 				// verify
 				fmt.Printf(format, "SAPNote, Version", "Parameter", "Expected", "Override", "Actual", "Compliant")
-				for i := 0; i < fmtlen0+fmtlen1+fmtlen2+fmtlen3+fmtlen4+28 ; i++ {
+				for i := 0; i < fmtlen0+fmtlen1+fmtlen2+fmtlen3+fmtlen4+28; i++ {
 					if i == 3+fmtlen0+1 || i == 3+fmtlen0+3+fmtlen1+1 || i == 3+fmtlen0+3+fmtlen1+4+fmtlen2 || i == 3+fmtlen0+3+fmtlen1+4+fmtlen2+2+fmtlen3+1 || i == 3+fmtlen0+3+fmtlen1+4+fmtlen2+2+fmtlen3+3+fmtlen4+1 {
 						fmt.Printf("+")
 					} else {
@@ -355,7 +357,7 @@ func PrintNoteFields(header string, noteComparisons map[string]map[string]note.N
 			} else {
 				// simulate
 				fmt.Printf(format, "Parameter", "Value set", "Value expected", "Override", "Comment")
-				for i := 0; i < fmtlen1+fmtlen2+fmtlen3+fmtlen4+28 ; i++ {
+				for i := 0; i < fmtlen1+fmtlen2+fmtlen3+fmtlen4+28; i++ {
 					if i == 3+fmtlen1+1 || i == 3+fmtlen1+3+fmtlen2+1 || i == 3+fmtlen1+3+fmtlen2+3+fmtlen3+1 || i == 3+fmtlen1+3+fmtlen2+3+fmtlen3+3+fmtlen4+1 {
 						fmt.Printf("+")
 					} else {
@@ -388,12 +390,12 @@ func PrintNoteFields(header string, noteComparisons map[string]map[string]note.N
 	for noteID, reminde := range reminder {
 		if reminde != "" {
 			reminderHead := fmt.Sprintf("Attention for SAP Note %s:\nHints or values not yet handled by saptune. So please read carefully, check and set manually, if needed:\n", noteID)
-			fmt.Printf("%s\n", SetRedText + reminderHead + reminde + ResetTextColor)
+			fmt.Printf("%s\n", SetRedText+reminderHead+reminde+ResetTextColor)
 		}
 	}
 }
 
-// Verify that all system parameters do not deviate from any of the enabled solutions/notes.
+// VerifyAllParameters Verify that all system parameters do not deviate from any of the enabled solutions/notes.
 func VerifyAllParameters() {
 	unsatisfiedNotes, comparisons, err := tuneApp.VerifyAll()
 	if err != nil {
@@ -407,6 +409,7 @@ func VerifyAllParameters() {
 	}
 }
 
+// NoteAction  Note actions like apply, revert, verify asm.
 func NoteAction(actionName, noteID string) {
 	switch actionName {
 	case "apply":
@@ -506,7 +509,7 @@ func NoteAction(actionName, noteID string) {
 			if _, err := os.Stat(fileName); os.IsNotExist(err) {
 				errorExit("Note %s not found in %s or %s.", noteID, NoteTuningSheets, ExtraTuningSheets)
 			} else if err != nil {
-				 errorExit("Failed to read file '%s' - %v", fileName, err)
+				errorExit("Failed to read file '%s' - %v", fileName, err)
 			}
 		} else if err != nil {
 			errorExit("Failed to read file '%s' - %v", fileName, err)
@@ -531,7 +534,7 @@ func NoteAction(actionName, noteID string) {
 			editFileName = ovFileName
 		} else if err == nil {
 			log.Printf("Note override file already exists, using file '%s' as base for editing\n", ovFileName)
-			editFileName =ovFileName
+			editFileName = ovFileName
 		} else {
 			errorExit("Failed to read file '%s' - %v", ovFileName, err)
 		}
@@ -557,6 +560,7 @@ func NoteAction(actionName, noteID string) {
 	}
 }
 
+// SolutionAction  Solution actions like apply, revert, verify asm.
 func SolutionAction(actionName, solName string) {
 	switch actionName {
 	case "apply":

--- a/main.go
+++ b/main.go
@@ -125,7 +125,7 @@ func RevertAction(actionName string) {
 	fmt.Println("Parameters tuned by the notes and solutions have been successfully reverted.")
 }
 
-// Handle daemon actions like start, stop, status asm.
+// DaemonAction handles daemon actions like start, stop, status asm.
 func DaemonAction(actionName string) {
 	switch actionName {
 	case "start":
@@ -192,7 +192,7 @@ func DaemonAction(actionName string) {
 }
 
 // PrintNoteFields Print mismatching fields in the note comparison result.
-func PrintNoteFields(header string, noteComparisons map[string]map[string]note.NoteFieldComparison, printComparison bool) {
+func PrintNoteFields(header string, noteComparisons map[string]map[string]note.FieldComparison, printComparison bool) {
 
 	var fmtlen0, fmtlen1, fmtlen2, fmtlen3, fmtlen4 int
 	// initialise
@@ -466,7 +466,7 @@ func NoteAction(actionName, noteID string) {
 			if err != nil {
 				errorExit("Failed to test the current system against the specified note: %v", err)
 			}
-			noteComp := make(map[string]map[string]note.NoteFieldComparison)
+			noteComp := make(map[string]map[string]note.FieldComparison)
 			noteComp[noteID] = comparisons
 			PrintNoteFields("HEAD", noteComp, true)
 			if !conforming {
@@ -484,7 +484,7 @@ func NoteAction(actionName, noteID string) {
 			errorExit("Failed to test the current system against the specified note: %v", err)
 		} else {
 			fmt.Printf("If you run `saptune note apply %s`, the following changes will be applied to your system:\n", noteID)
-			noteComp := make(map[string]map[string]note.NoteFieldComparison)
+			noteComp := make(map[string]map[string]note.FieldComparison)
 			noteComp[noteID] = comparisons
 			PrintNoteFields("HEAD", noteComp, false)
 		}

--- a/sap/errs.go
+++ b/sap/errs.go
@@ -18,5 +18,5 @@ func PrintErrors(errors []error) error {
 	if hasNil {
 		return nil
 	}
-	return fmt.Errorf("The tuning procedure failed entirely.")
+	return fmt.Errorf("the tuning procedure failed entirely")
 }

--- a/sap/errs_test.go
+++ b/sap/errs_test.go
@@ -15,7 +15,6 @@ func TestPrintErrors(t *testing.T) {
 	if err := PrintErrors([]error{}); err != nil {
 		t.Fatal("should not return failure", err)
 	}
-
 	if err := PrintErrors([]error{errors.New("2"), errors.New("3")}); err == nil {
 		t.Fatal("did not fail")
 	}

--- a/sap/note/compat.go
+++ b/sap/note/compat.go
@@ -318,15 +318,12 @@ func (st SUSENetCPUOptimisation) Apply() error {
 	return err
 }
 
-
-
-
 // Tuning options composed by a third party vendor.
 
 // section [block]
 //type BlockDeviceQueue struct {
-	//BlockDeviceSchedulers param.BlockDeviceSchedulers
-	//BlockDeviceNrRequests param.BlockDeviceNrRequests
+//BlockDeviceSchedulers param.BlockDeviceSchedulers
+//BlockDeviceNrRequests param.BlockDeviceNrRequests
 //}
 
 func CmpSetBlkVal(key, value string) error {
@@ -447,4 +444,3 @@ func (cmptvend CMPTSettings) Apply() error {
 	err = sap.PrintErrors(errs)
 	return err
 }
-

--- a/sap/note/compat.go
+++ b/sap/note/compat.go
@@ -17,6 +17,7 @@ import (
 // No longer active. Only needed for compatibility reasons
 // Revert of notes applied by an older saptune version
 
+// PrepareForSAPEnvironments defines SAP Note 1275776
 // 1275776 - Linux: Preparing SLES for SAP environments
 type PrepareForSAPEnvironments struct {
 	SysconfigPrefix                                         string
@@ -28,17 +29,28 @@ type PrepareForSAPEnvironments struct {
 	KernelSemMsl, KernelSemMns, KernelSemOpm, KernelSemMni  uint64
 }
 
+// Name returns the name of the related SAP Note
 func (prepare PrepareForSAPEnvironments) Name() string {
 	return "Linux: Preparing SLES for SAP environments"
 }
+
+// Initialise initialises the SAP Note structure
+// no longer needed
 func (prepare PrepareForSAPEnvironments) Initialise() (Note, error) {
 	newPrepare := prepare
 	return newPrepare, nil
 }
+
+// Optimise optimises the SAP Note structure
+// no longer needed
 func (prepare PrepareForSAPEnvironments) Optimise() (Note, error) {
 	newPrepare := prepare
 	return newPrepare, nil
 }
+
+// Apply sets the values from the SAP Note structure
+// to the system
+// Only used to revert notes applied by an older saptune version
 func (prepare PrepareForSAPEnvironments) Apply() error {
 	errs := make([]error, 0, 0)
 	// Apply new SHM size
@@ -75,21 +87,33 @@ func (prepare PrepareForSAPEnvironments) Apply() error {
 	return nil
 }
 
+// AfterInstallation defines SAP Note 1984787
 // 1984787 - SUSE LINUX Enterprise Server 12: Installation notes
 type AfterInstallation struct {
 	UuiddSocketStatus bool // UuiddSocketStatus is the status of systemd unit called "uuidd.socket"
 	LogindConfigured  bool // LogindConfigured is true if SAP's logind customisation file is in-place
 }
 
+// Name returns the name of the related SAP Note
 func (inst AfterInstallation) Name() string {
 	return "SUSE LINUX Enterprise Server 12: Installation notes"
 }
+
+// Initialise initialises the SAP Note structure
+// no longer needed
 func (inst AfterInstallation) Initialise() (Note, error) {
 	return AfterInstallation{UuiddSocketStatus: true, LogindConfigured: true}, nil
 }
+
+// Optimise optimises the SAP Note structure
+// no longer needed
 func (inst AfterInstallation) Optimise() (Note, error) {
 	return AfterInstallation{UuiddSocketStatus: true, LogindConfigured: true}, nil
 }
+
+// Apply sets the values from the SAP Note structure
+// to the system
+// Only used to revert notes applied by an older saptune version
 func (inst AfterInstallation) Apply() error {
 	// Set UUID socket status
 	var err error
@@ -113,20 +137,28 @@ func (inst AfterInstallation) Apply() error {
 	return nil
 }
 
+// VmwareGuestIOElevator defines SAP Note 2161991
 // 2161991 - VMware vSphere (guest) configuration guidelines
 type VmwareGuestIOElevator struct {
 	BlockDeviceSchedulers param.BlockDeviceSchedulers
 }
 
+// Name returns the name of the related SAP Note
 func (vmio VmwareGuestIOElevator) Name() string {
 	return "VMware vSphere (guest) configuration guidelines"
 }
+
+// Initialise initialises the SAP Note structure
+// no longer needed
 func (vmio VmwareGuestIOElevator) Initialise() (Note, error) {
 	inspectedParam, err := vmio.BlockDeviceSchedulers.Inspect()
 	return VmwareGuestIOElevator{
 		BlockDeviceSchedulers: inspectedParam.(param.BlockDeviceSchedulers),
 	}, err
 }
+
+// Optimise optimises the SAP Note structure
+// no longer needed
 func (vmio VmwareGuestIOElevator) Optimise() (Note, error) {
 	// SAP recommends noop for Vmware guests
 	optimisedParam, err := vmio.BlockDeviceSchedulers.Optimise("noop")
@@ -134,31 +166,45 @@ func (vmio VmwareGuestIOElevator) Optimise() (Note, error) {
 		BlockDeviceSchedulers: optimisedParam.(param.BlockDeviceSchedulers),
 	}, err
 }
+
+// Apply sets the values from the SAP Note structure
+// to the system
+// Only used to revert notes applied by an older saptune version
 func (vmio VmwareGuestIOElevator) Apply() error {
 	return vmio.BlockDeviceSchedulers.Apply()
 }
 
-/*
-2205917 - SAP HANA DB: Recommended OS settings for SLES 12 / SLES for SAP Applications 12
-Disable kernel memory management features that will introduce additional overhead.
-*/
+// HANARecommendedOSSettings defines SAP Note 2205917
+// 2205917 - SAP HANA DB: Recommended OS settings for SLES 12 / SLES for SAP Applications 12
+// Disable kernel memory management features that will introduce additional overhead.
 type HANARecommendedOSSettings struct {
 	KernelMMTransparentHugepage string
 	KernelMMKsm                 bool
 	KernelNumaBalancing         bool
 }
 
+// Name returns the name of the related SAP Note
 func (hana HANARecommendedOSSettings) Name() string {
 	return "SAP HANA DB: Recommended OS settings for SLES 12 / SLES for SAP Applications 12"
 }
+
+// Initialise initialises the SAP Note structure
+// no longer needed
 func (hana HANARecommendedOSSettings) Initialise() (Note, error) {
 	ret := HANARecommendedOSSettings{}
 	return ret, nil
 }
+
+// Optimise optimises the SAP Note structure
+// no longer needed
 func (hana HANARecommendedOSSettings) Optimise() (Note, error) {
 	ret := HANARecommendedOSSettings{}
 	return ret, nil
 }
+
+// Apply sets the values from the SAP Note structure
+// to the system
+// Only used to revert notes applied by an older saptune version
 func (hana HANARecommendedOSSettings) Apply() error {
 	errs := make([]error, 0, 0)
 	errs = append(errs, system.SetSysString(SysKernelTHPEnabled, hana.KernelMMTransparentHugepage))
@@ -176,10 +222,9 @@ func (hana HANARecommendedOSSettings) Apply() error {
 	return err
 }
 
-/*
-SUSE-GUIDE-01 - SLES 11/12 OS Tuning & Optimization Guide – Part 1
-https://www.suse.com/communities/blog/sles-1112-os-tuning-optimisation-guide-part-1/
-*/
+// SUSESysOptimisation defines SUSE-GUIDE-01
+// SUSE-GUIDE-01 - SLES 11/12 OS Tuning & Optimization Guide – Part 1
+// https://www.suse.com/communities/blog/sles-1112-os-tuning-optimisation-guide-part-1/
 type SUSESysOptimisation struct {
 	SysconfigPrefix string
 
@@ -192,18 +237,29 @@ type SUSESysOptimisation struct {
 	BlockDeviceSchedulers                param.BlockDeviceSchedulers
 }
 
+// Name returns the name of the related SUSE Guide
 func (st SUSESysOptimisation) Name() string {
 	// Do not mention SLES 11 here
 	return "SLES 12 OS Tuning & Optimization Guide – Part 1"
 }
+
+// Initialise initialises the SUSE Guide structure
+// no longer needed
 func (st SUSESysOptimisation) Initialise() (Note, error) {
 	newST := st
 	return newST, nil
 }
+
+// Optimise optimises the SUSE Guide structure
+// no longer needed
 func (st SUSESysOptimisation) Optimise() (Note, error) {
 	newST := st
 	return newST, nil
 }
+
+// Apply sets the values from the SUSE Guide structure
+// to the system
+// Only used to revert notes applied by an older saptune version
 func (st SUSESysOptimisation) Apply() error {
 	errs := make([]error, 0, 0)
 	errs = append(errs, system.SetSysctlUint64(system.SysctlNumberHugepages, st.VMNumberHugePages))
@@ -221,10 +277,9 @@ func (st SUSESysOptimisation) Apply() error {
 	return err
 }
 
-/*
-SUSE-GUIDE-01 - SLES 11/12: Network, CPU Tuning and Optimization – Part 2
-https://www.suse.com/communities/blog/sles-1112-network-cpu-tuning-optimization-part-2/
-*/
+// SUSENetCPUOptimisation defines SUSE-GUIDE-02
+// SUSE-GUIDE-02 - SLES 11/12: Network, CPU Tuning and Optimization – Part 2
+// https://www.suse.com/communities/blog/sles-1112-network-cpu-tuning-optimization-part-2/
 type SUSENetCPUOptimisation struct {
 	SysconfigPrefix string
 
@@ -250,18 +305,29 @@ type SUSENetCPUOptimisation struct {
 	KernelSchedChildRunsFirst                                             uint64
 }
 
+// Name returns the name of the related SUSE Guide
 func (st SUSENetCPUOptimisation) Name() string {
 	// Do not mention SLES 11 here
 	return "SLES 12: Network, CPU Tuning and Optimization – Part 2"
 }
+
+// Initialise initialises the SUSE Guide structure
+// no longer needed
 func (st SUSENetCPUOptimisation) Initialise() (Note, error) {
 	newST := st
 	return newST, nil
 }
+
+// Optimise optimises the SUSE Guide structure
+// no longer needed
 func (st SUSENetCPUOptimisation) Optimise() (Note, error) {
 	newST := st
 	return newST, nil
 }
+
+// Apply sets the values from the SUSE Guide structure
+// to the system
+// Only used to revert notes applied by an older saptune version
 func (st SUSENetCPUOptimisation) Apply() error {
 	// Section "SLES11/12 Network Tuning & Optimization"
 	errs := make([]error, 0, 0)
@@ -326,6 +392,7 @@ func (st SUSENetCPUOptimisation) Apply() error {
 //BlockDeviceNrRequests param.BlockDeviceNrRequests
 //}
 
+// CmpSetBlkVal sets block device values
 func CmpSetBlkVal(key, value string) error {
 	var err error
 
@@ -353,8 +420,8 @@ func CmpSetBlkVal(key, value string) error {
 		for _, entry := range strings.Fields(value) {
 			fields := strings.Split(entry, "@")
 			file := path.Join("block", fields[0], "queue", "nr_requests")
-			tst_err := system.TestSysString(file, fields[1])
-			if tst_err != nil {
+			tstErr := system.TestSysString(file, fields[1])
+			if tstErr != nil {
 				fmt.Printf("Write error on file '%s'.\nCan't set nr_request to '%s', seems to large for the device. Leaving untouched.\n", file, fields[1])
 			} else {
 				NrR, _ := strconv.Atoi(fields[1])
@@ -370,6 +437,8 @@ func CmpSetBlkVal(key, value string) error {
 }
 
 // section [limits]
+
+// CmpSetLimitsVal sets security limits
 func CmpSetLimitsVal(key, value string) error {
 	secLimits, err := system.ParseSecLimitsFile()
 	if err != nil {
@@ -386,7 +455,8 @@ func CmpSetLimitsVal(key, value string) error {
 }
 
 // section [vm]
-// Manipulate /sys/kernel/mm switches.
+
+// CMPTSettings manipulates /sys/kernel/mm switches.
 // Tuning options composed by a third party vendor.
 type CMPTSettings struct {
 	ConfFilePath    string            // Full path to the 3rd party vendor's tuning configuration file
@@ -395,20 +465,28 @@ type CMPTSettings struct {
 	SysctlParams    map[string]string // Sysctl parameter values from the computer system
 }
 
+// Name returns the name of the third party vendor Note
 func (cmptvend CMPTSettings) Name() string {
 	return cmptvend.DescriptiveName
 }
 
+// Initialise initialises the third party vendor Note structure
+// no longer needed
 func (cmptvend CMPTSettings) Initialise() (Note, error) {
 	cmptvend.SysctlParams = make(map[string]string)
 	return cmptvend, nil
 }
 
+// Optimise optimises the third party vendor Note structure
+// no longer needed
 func (cmptvend CMPTSettings) Optimise() (Note, error) {
 	cmptvend.SysctlParams = make(map[string]string)
 	return cmptvend, nil
 }
 
+// Apply sets the values from the third party vendor Note structure
+// to the system
+// Only used to revert notes applied by an older saptune version
 func (cmptvend CMPTSettings) Apply() error {
 	errs := make([]error, 0, 0)
 	// Parse the configuration file

--- a/sap/note/db.go
+++ b/sap/note/db.go
@@ -7,6 +7,7 @@ import (
 	"path"
 )
 
+// LinuxPagingImprovements defines SAP Note 1557506
 // 1557506 - Linux paging improvements
 type LinuxPagingImprovements struct {
 	SysconfigPrefix string // Used by test cases to specify alternative sysconfig location
@@ -16,7 +17,7 @@ type LinuxPagingImprovements struct {
 	UseAlgorithmForHANA         bool
 }
 
-// Name returns the name of the related note
+// Name returns the name of the related SAP Note
 func (paging LinuxPagingImprovements) Name() string {
 	return "Linux paging improvements"
 }

--- a/sap/note/db.go
+++ b/sap/note/db.go
@@ -16,9 +16,12 @@ type LinuxPagingImprovements struct {
 	UseAlgorithmForHANA         bool
 }
 
+// Name returns the name of the related note
 func (paging LinuxPagingImprovements) Name() string {
 	return "Linux paging improvements"
 }
+
+// Initialise reads the parameter values from current system
 func (paging LinuxPagingImprovements) Initialise() (Note, error) {
 	vmPagecach, _ := system.GetSysctlUint64(system.SysctlPagecacheLimitMB)
 	vmIgnoreDirty, _ := system.GetSysctlInt(system.SysctlPagecacheLimitIgnoreDirty)
@@ -29,6 +32,9 @@ func (paging LinuxPagingImprovements) Initialise() (Note, error) {
 		UseAlgorithmForHANA:         true,
 	}, nil
 }
+
+// Optimise gets the expected pagecache values from the configuration
+// or calculates new values
 func (paging LinuxPagingImprovements) Optimise() (Note, error) {
 	newPaging := paging
 	conf, err := txtparser.ParseSysconfigFile(path.Join(newPaging.SysconfigPrefix, "/usr/share/saptune/notes/1557506"), false)
@@ -51,6 +57,8 @@ func (paging LinuxPagingImprovements) Optimise() (Note, error) {
 	newPaging.VMPagecacheLimitIgnoreDirty = conf.GetInt("PAGECACHE_LIMIT_IGNORE_DIRTY", 1)
 	return newPaging, err
 }
+
+// Apply sets the new values in the system
 func (paging LinuxPagingImprovements) Apply() error {
 	errs := make([]error, 0, 0)
 	errs = append(errs, system.SetSysctlUint64(system.SysctlPagecacheLimitMB, paging.VMPagecacheLimitMB))

--- a/sap/note/ini.go
+++ b/sap/note/ini.go
@@ -162,7 +162,11 @@ func (vend INISettings) Initialise() (Note, error) {
 		// do not write parameter values to the saved state file during
 		// a pure 'verify' action
 		if _, ok := vend.ValuesToApply["verify"]; !ok && vend.SysctlParams[param.Key] != "" {
-			CreateParameterStartValues(param.Key, vend.SysctlParams[param.Key])
+			if param.Section == INISectionLimits {
+				SaveLimitsParameter(param.Key, ini.KeyValue["limits"]["LIMIT_DOMAIN"].Value, ini.KeyValue["limits"]["LIMIT_ITEM"].Value, vend.SysctlParams[param.Key], "start", "")
+			} else {
+				CreateParameterStartValues(param.Key, vend.SysctlParams[param.Key])
+			}
 		}
 	}
 	return vend, nil
@@ -226,7 +230,11 @@ func (vend INISettings) Optimise() (Note, error) {
 		// do not write parameter values to the saved state file during
 		// a pure 'verify' action
 		if _, ok := vend.ValuesToApply["verify"]; !ok && vend.SysctlParams[param.Key] != "" {
-			AddParameterNoteValues(param.Key, vend.SysctlParams[param.Key], vend.ID)
+			if param.Section == INISectionLimits {
+				SaveLimitsParameter(param.Key, ini.KeyValue["limits"]["LIMIT_DOMAIN"].Value, ini.KeyValue["limits"]["LIMIT_ITEM"].Value, vend.SysctlParams[param.Key], "add", vend.ID)
+			} else {
+				AddParameterNoteValues(param.Key, vend.SysctlParams[param.Key], vend.ID)
+			}
 		}
 	}
 	return vend, nil
@@ -266,7 +274,12 @@ func (vend INISettings) Apply() error {
 
 		if revertValues && vend.SysctlParams[param.Key] != "" {
 			// revert parameter value
-			pvalue := RevertParameter(param.Key, vend.ID)
+			pvalue := ""
+			if param.Section == INISectionLimits {
+				pvalue = RevertLimitsParameter(param.Key, ini.KeyValue["limits"]["LIMIT_DOMAIN"].Value, ini.KeyValue["limits"]["LIMIT_ITEM"].Value, vend.ID)
+			} else {
+				pvalue = RevertParameter(param.Key, vend.ID)
+			}
 			if pvalue != "" {
 				vend.SysctlParams[param.Key] = pvalue
 			}

--- a/sap/note/ini.go
+++ b/sap/note/ini.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 )
 
+// OverrideTuningSheets defines saptunes override directory
 const OverrideTuningSheets = "/etc/saptune/override/"
 
 var pc = LinuxPagingImprovements{}
@@ -67,7 +68,7 @@ func CalculateOptimumValue(operator txtparser.Operator, currentValue string, exp
 	return strconv.FormatInt(iCurrentValue, 10), nil
 }
 
-// Tuning options composed by a third party vendor.
+// INISettings defines tuning options composed by a third party vendor.
 type INISettings struct {
 	ConfFilePath    string            // Full path to the 3rd party vendor's tuning configuration file
 	ID              string            // ID portion of the tuning configuration
@@ -122,7 +123,7 @@ func (vend INISettings) Initialise() (Note, error) {
 		case INISectionSysctl:
 			vend.SysctlParams[param.Key], _ = system.GetSysctlString(param.Key)
 		case INISectionVM:
-			vend.SysctlParams[param.Key] = GetVmVal(param.Key)
+			vend.SysctlParams[param.Key] = GetVMVal(param.Key)
 		case INISectionBlock:
 			vend.SysctlParams[param.Key], _ = GetBlkVal(param.Key)
 		case INISectionLimits:
@@ -136,7 +137,7 @@ func (vend INISettings) Initialise() (Note, error) {
 		case INISectionMEM:
 			vend.SysctlParams[param.Key] = GetMemVal(param.Key)
 		case INISectionCPU:
-			vend.SysctlParams[param.Key] = GetCpuVal(param.Key)
+			vend.SysctlParams[param.Key] = GetCPUVal(param.Key)
 		case INISectionRpm:
 			vend.SysctlParams[param.Key] = GetRpmVal(param.Key)
 			continue
@@ -191,7 +192,7 @@ func (vend INISettings) Optimise() (Note, error) {
 			//vend.SysctlParams[param.Key] = optimisedValue
 			vend.SysctlParams[param.Key] = OptSysctlVal(param.Operator, param.Key, vend.SysctlParams[param.Key], param.Value)
 		case INISectionVM:
-			vend.SysctlParams[param.Key] = OptVmVal(param.Key, param.Value)
+			vend.SysctlParams[param.Key] = OptVMVal(param.Key, param.Value)
 		case INISectionBlock:
 			vend.SysctlParams[param.Key] = OptBlkVal(param.Key, vend.SysctlParams[param.Key], param.Value)
 		case INISectionLimits:
@@ -205,7 +206,7 @@ func (vend INISettings) Optimise() (Note, error) {
 		case INISectionMEM:
 			vend.SysctlParams[param.Key] = OptMemVal(param.Key, vend.SysctlParams[param.Key], param.Value, ini.KeyValue["mem"]["ShmFileSystemSizeMB"].Value, ini.KeyValue["mem"]["VSZ_TMPFS_PERCENT"].Value)
 		case INISectionCPU:
-			vend.SysctlParams[param.Key] = OptCpuVal(param.Key, vend.SysctlParams[param.Key], param.Value)
+			vend.SysctlParams[param.Key] = OptCPUVal(param.Key, vend.SysctlParams[param.Key], param.Value)
 		case INISectionRpm:
 			vend.SysctlParams[param.Key] = OptRpmVal(param.Key, param.Value)
 			continue
@@ -249,6 +250,7 @@ func (vend INISettings) Apply() error {
 	if err != nil {
 		return err
 	}
+
 	//for key, value := range vend.SysctlParams {
 	for _, param := range ini.AllValues {
 		switch param.Section {
@@ -298,7 +300,7 @@ func (vend INISettings) Apply() error {
 				errs = append(errs, system.SetSysctlString(param.Key, vend.SysctlParams[param.Key]))
 			}
 		case INISectionVM:
-			errs = append(errs, SetVmVal(param.Key, vend.SysctlParams[param.Key]))
+			errs = append(errs, SetVMVal(param.Key, vend.SysctlParams[param.Key]))
 		case INISectionBlock:
 			errs = append(errs, SetBlkVal(param.Key, vend.SysctlParams[param.Key]))
 		case INISectionLimits:
@@ -312,7 +314,7 @@ func (vend INISettings) Apply() error {
 		case INISectionMEM:
 			errs = append(errs, SetMemVal(param.Key, vend.SysctlParams[param.Key]))
 		case INISectionCPU:
-			errs = append(errs, SetCpuVal(param.Key, vend.SysctlParams[param.Key], revertValues, vend.ID))
+			errs = append(errs, SetCPUVal(param.Key, vend.SysctlParams[param.Key], revertValues, vend.ID))
 		case INISectionPagecache:
 			errs = append(errs, SetPagecacheVal(param.Key, &pc))
 		default:

--- a/sap/note/ini_sections.go
+++ b/sap/note/ini_sections.go
@@ -7,14 +7,15 @@ import (
 	"github.com/SUSE/saptune/txtparser"
 	"io/ioutil"
 	"log"
+	"math"
 	"os"
 	"path"
 	"sort"
 	"strconv"
 	"strings"
-	"math"
 )
 
+// section name definition
 const (
 	INISectionSysctl    = "sysctl"
 	INISectionVM        = "vm"
@@ -43,16 +44,17 @@ UserTasksMax=infinity
 `
 )
 
+// GetServiceName returns the systemd service name for supported services
 func GetServiceName(service string) string {
-        switch service {
-        case "UuiddSocket":
-                service = "uuidd.socket"
-        case "Sysstat":
-                service = "sysstat"
-        default:
-                log.Printf("skipping unkown service '%s'", service)
-                service = ""
-        }
+	switch service {
+	case "UuiddSocket":
+		service = "uuidd.socket"
+	case "Sysstat":
+		service = "sysstat"
+	default:
+		log.Printf("skipping unkown service '%s'", service)
+		service = ""
+	}
 	return service
 }
 
@@ -89,12 +91,12 @@ func OptSysctlVal(operator txtparser.Operator, key, actval, cfgval string) strin
 
 		// use exactly the value from the config file. No calculation any more
 		/*
-		optimisedValue, err := CalculateOptimumValue(operator, fieldC, fieldE)
-		//optimisedValue, err := CalculateOptimumValue(param.Operator, vend.SysctlParams[param.Key], param.Value)
-		if err != nil {
-			return ""
-		}
-		allFieldsS = allFieldsS + optimisedValue + "\t"
+			optimisedValue, err := CalculateOptimumValue(operator, fieldC, fieldE)
+			//optimisedValue, err := CalculateOptimumValue(param.Operator, vend.SysctlParams[param.Key], param.Value)
+			if err != nil {
+				return ""
+			}
+			allFieldsS = allFieldsS + optimisedValue + "\t"
 		*/
 		allFieldsS = allFieldsS + fieldE + "\t"
 	}
@@ -337,7 +339,7 @@ func SetVmVal(key, value string) error {
 		err = system.SetSysString(SysKernelTHPEnabled, value)
 	case "KSM":
 		ksmval, _ := strconv.Atoi(value)
-                err = system.SetSysInt(SysKSMRun, ksmval)
+		err = system.SetSysInt(SysKSMRun, ksmval)
 	}
 	return err
 }
@@ -364,8 +366,8 @@ func GetCpuVal(key string) string {
 }
 
 func OptCpuVal(key, actval, cfgval string) string {
-//ANGI TODO - check cfgval is not a single value like 'performance' but
-// cpu0:performance cpu2:powersave
+	//ANGI TODO - check cfgval is not a single value like 'performance' but
+	// cpu0:performance cpu2:powersave
 	sval := strings.ToLower(cfgval)
 	rval := ""
 	val := "0"
@@ -452,11 +454,11 @@ func OptMemVal(key, actval, cfgval, shmsize, tmpfspercent string) string {
 	} else if shmsize == "0" {
 		if tmpfspercent == "0" {
 			// Calculate optimal SHM size (TotalMemSizeMB*75/100) (SAP-Note 941735)
-			size = uint64(system.GetTotalMemSizeMB())*75/100
+			size = uint64(system.GetTotalMemSizeMB()) * 75 / 100
 		} else {
 			// Calculate optimal SHM size (TotalMemSizeMB*VSZ_TMPFS_PERCENT/100)
 			val, _ := strconv.ParseUint(tmpfspercent, 10, 64)
-			size = uint64(system.GetTotalMemSizeMB())*val/100
+			size = uint64(system.GetTotalMemSizeMB()) * val / 100
 		}
 	} else {
 		size, _ = strconv.ParseUint(shmsize, 10, 64)

--- a/sap/note/ini_sections.go
+++ b/sap/note/ini_sections.go
@@ -60,6 +60,9 @@ func GetServiceName(service string) string {
 
 // section handling
 // section [sysctl]
+
+// OptSysctlVal optimises a sysctl parameter value
+// use exactly the value from the config file. No calculation any more
 func OptSysctlVal(operator txtparser.Operator, key, actval, cfgval string) string {
 	if actval == "" {
 		// sysctl parameter not available in system
@@ -105,15 +108,19 @@ func OptSysctlVal(operator txtparser.Operator, key, actval, cfgval string) strin
 }
 
 // section [block]
+
+// BlockDeviceQueue defines block device structures
 type BlockDeviceQueue struct {
 	BlockDeviceSchedulers param.BlockDeviceSchedulers
 	BlockDeviceNrRequests param.BlockDeviceNrRequests
 }
 
+// GetBlkVal initialise the block device structure with the current
+// system settings
 func GetBlkVal(key string) (string, error) {
 	newQueue := make(map[string]string)
 	newReq := make(map[string]int)
-	ret_val := ""
+	retVal := ""
 	switch key {
 	case "IO_SCHEDULER":
 		newIOQ, err := BlockDeviceQueue{}.BlockDeviceSchedulers.Inspect()
@@ -122,7 +129,7 @@ func GetBlkVal(key string) (string, error) {
 		}
 		newQueue = newIOQ.(param.BlockDeviceSchedulers).SchedulerChoice
 		for k, v := range newQueue {
-			ret_val = ret_val + fmt.Sprintf("%s@%s ", k, v)
+			retVal = retVal + fmt.Sprintf("%s@%s ", k, v)
 		}
 	case "NRREQ":
 		newNrR, err := BlockDeviceQueue{}.BlockDeviceNrRequests.Inspect()
@@ -131,19 +138,21 @@ func GetBlkVal(key string) (string, error) {
 		}
 		newReq = newNrR.(param.BlockDeviceNrRequests).NrRequests
 		for k, v := range newReq {
-			ret_val = ret_val + fmt.Sprintf("%s@%s ", k, strconv.Itoa(v))
+			retVal = retVal + fmt.Sprintf("%s@%s ", k, strconv.Itoa(v))
 		}
 	}
-	fields := strings.Fields(ret_val)
+	fields := strings.Fields(retVal)
 	sort.Strings(fields)
-	ret_val = strings.Join(fields, " ")
-	return ret_val, nil
+	retVal = strings.Join(fields, " ")
+	return retVal, nil
 }
 
+// OptBlkVal optimises the block device structure with the settings
+// from the configuration file
 func OptBlkVal(key, actval, cfgval string) string {
 	sval := cfgval
 	val := actval
-	ret_val := ""
+	retVal := ""
 	switch key {
 	case "IO_SCHEDULER":
 		sval = strings.ToLower(cfgval)
@@ -154,15 +163,16 @@ func OptBlkVal(key, actval, cfgval string) string {
 	}
 	for _, entry := range strings.Fields(val) {
 		fields := strings.Split(entry, "@")
-		if ret_val == "" {
-			ret_val = ret_val + fmt.Sprintf("%s@%s", fields[0], sval)
+		if retVal == "" {
+			retVal = retVal + fmt.Sprintf("%s@%s", fields[0], sval)
 		} else {
-			ret_val = ret_val + " " + fmt.Sprintf("%s@%s", fields[0], sval)
+			retVal = retVal + " " + fmt.Sprintf("%s@%s", fields[0], sval)
 		}
 	}
-	return ret_val
+	return retVal
 }
 
+// SetBlkVal applies the settings to the system
 func SetBlkVal(key, value string) error {
 	var err error
 
@@ -201,6 +211,9 @@ func SetBlkVal(key, value string) error {
 }
 
 // section [limits]
+
+// GetLimitsVal initialise the security limit structure with the current
+// system settings
 func GetLimitsVal(key, item, domain string) (string, error) {
 	// Find out current limits
 	limit := ""
@@ -240,6 +253,8 @@ func GetLimitsVal(key, item, domain string) (string, error) {
 	return limit, nil
 }
 
+// OptLimitsVal optimises the security limit structure with the settings
+// from the configuration file or with a calculation
 func OptLimitsVal(key, actval, cfgval, item, domain string) string {
 	limit := cfgval
 	lim := ""
@@ -276,6 +291,7 @@ func OptLimitsVal(key, actval, cfgval, item, domain string) string {
 	return lim
 }
 
+// SetLimitsVal applies the settings to the system
 func SetLimitsVal(key, value, item string) error {
 	if key != "LIMIT_HARD" && key != "LIMIT_SOFT" {
 		return nil
@@ -303,7 +319,10 @@ func SetLimitsVal(key, value, item string) error {
 
 // section [vm]
 // Manipulate /sys/kernel/mm switches.
-func GetVmVal(key string) string {
+
+// GetVMVal initialise the memory management structure with the current
+// system settings
+func GetVMVal(key string) string {
 	var val string
 	switch key {
 	case "THP":
@@ -315,7 +334,9 @@ func GetVmVal(key string) string {
 	return val
 }
 
-func OptVmVal(key, cfgval string) string {
+// OptVMVal optimises the memory management structure with the settings
+// from the configuration file
+func OptVMVal(key, cfgval string) string {
 	val := strings.ToLower(cfgval)
 	switch key {
 	case "THP":
@@ -332,7 +353,8 @@ func OptVmVal(key, cfgval string) string {
 	return val
 }
 
-func SetVmVal(key, value string) error {
+// SetVMVal applies the settings to the system
+func SetVMVal(key, value string) error {
 	var err error
 	switch key {
 	case "THP":
@@ -345,7 +367,10 @@ func SetVmVal(key, value string) error {
 }
 
 // section [cpu]
-func GetCpuVal(key string) string {
+
+// GetCPUVal initialise the cpu performance structure with the current
+// system settings
+func GetCPUVal(key string) string {
 	var val string
 	switch key {
 	case "force_latency":
@@ -365,7 +390,9 @@ func GetCpuVal(key string) string {
 	return strings.TrimSpace(val)
 }
 
-func OptCpuVal(key, actval, cfgval string) string {
+// OptCPUVal optimises the cpu performance structure with the settings
+// from the configuration file
+func OptCPUVal(key, actval, cfgval string) string {
 	//ANGI TODO - check cfgval is not a single value like 'performance' but
 	// cpu0:performance cpu2:powersave
 	sval := strings.ToLower(cfgval)
@@ -405,12 +432,13 @@ func OptCpuVal(key, actval, cfgval string) string {
 	return sval
 }
 
-func SetCpuVal(key, value string, revert bool, noteId string) error {
+// SetCPUVal applies the settings to the system
+func SetCPUVal(key, value string, revert bool, noteID string) error {
 	var err error
 	switch key {
 	case "force_latency":
 		//iVal, _ := strconv.Atoi(value)
-		err = system.SetForceLatency(noteId, value, revert)
+		err = system.SetForceLatency(noteID, value, revert)
 	case "energy_perf_bias":
 		err = system.SetPerfBias(value)
 	case "governor":
@@ -421,6 +449,9 @@ func SetCpuVal(key, value string, revert bool, noteId string) error {
 }
 
 // section [mem]
+
+// GetMemVal initialise the shared memory structure with the current
+// system settings
 func GetMemVal(key string) string {
 	var val string
 	switch key {
@@ -442,6 +473,8 @@ func GetMemVal(key string) string {
 	return val
 }
 
+// OptMemVal optimises the shared memory structure with the settings
+// from the configuration file or with a calculation
 func OptMemVal(key, actval, cfgval, shmsize, tmpfspercent string) string {
 	// shmsize       value of ShmFileSystemSizeMB from config file
 	// tmpfspercent  value of VSZ_TMPFS_PERCENT from config file
@@ -476,6 +509,7 @@ func OptMemVal(key, actval, cfgval, shmsize, tmpfspercent string) string {
 	return ret
 }
 
+// SetMemVal applies the settings to the system
 func SetMemVal(key, value string) error {
 	var err error
 	switch key {
@@ -493,40 +527,51 @@ func SetMemVal(key, value string) error {
 }
 
 // section [rpm]
+
+// GetRpmVal initialise the rpm structure with the current system settings
 func GetRpmVal(key string) string {
 	keyFields := strings.Split(key, ":")
 	instvers := system.GetRpmVers(keyFields[1])
 	return instvers
 }
 
+// OptRpmVal returns the value from the configuration file
 func OptRpmVal(key, cfgval string) string {
 	// nothing to do, only checking for 'verify'
 	return cfgval
 }
 
+// SetRpmVal nothing to do, only checking for 'verify'
 func SetRpmVal(value string) error {
 	// nothing to do, only checking for 'verify'
 	return nil
 }
 
 // section [grub]
+
+// GetGrubVal initialise the grub structure with the current system settings
 func GetGrubVal(key string) string {
 	keyFields := strings.Split(key, ":")
 	val := system.ParseCmdline("/proc/cmdline", keyFields[1])
 	return val
 }
 
+// OptGrubVal returns the value from the configuration file
 func OptGrubVal(key, cfgval string) string {
 	// nothing to do, only checking for 'verify'
 	return cfgval
 }
 
+// SetGrubVal nothing to do, only checking for 'verify'
 func SetGrubVal(value string) error {
 	// nothing to do, only checking for 'verify'
 	return nil
 }
 
 // section [uuidd]
+
+// GetUuiddVal initialise the uuidd socket service structure with the current
+// system settings
 func GetUuiddVal() string {
 	var val string
 	if system.SystemctlIsRunning("uuidd.socket") {
@@ -537,6 +582,8 @@ func GetUuiddVal() string {
 	return val
 }
 
+// OptUuiddVal optimises the uuidd socket service structure with the settings
+// from the configuration file
 func OptUuiddVal(cfgval string) string {
 	sval := strings.ToLower(cfgval)
 	if sval != "start" {
@@ -546,6 +593,7 @@ func OptUuiddVal(cfgval string) string {
 	return sval
 }
 
+// SetUuiddVal applies the settings to the system
 func SetUuiddVal(value string) error {
 	var err error
 	if !system.SystemctlIsRunning("uuidd.socket") {
@@ -555,6 +603,9 @@ func SetUuiddVal(value string) error {
 }
 
 // section [service]
+
+// GetServiceVal initialise the systemd service structure with the current
+// system settings
 func GetServiceVal(key string) string {
 	var val string
 	service := GetServiceName(key)
@@ -569,6 +620,8 @@ func GetServiceVal(key string) string {
 	return val
 }
 
+// OptServiceVal optimises the systemd service structure with the settings
+// from the configuration file
 func OptServiceVal(key, cfgval string) string {
 	sval := strings.ToLower(cfgval)
 	switch key {
@@ -589,6 +642,7 @@ func OptServiceVal(key, cfgval string) string {
 	return sval
 }
 
+// SetServiceVal applies the settings to the system
 func SetServiceVal(key, value string) error {
 	var err error
 	service := GetServiceName(key)
@@ -613,6 +667,9 @@ func SetServiceVal(key, value string) error {
 }
 
 // section [login]
+
+// GetLoginVal initialise the systemd login structure with the current
+// system settings
 func GetLoginVal(key string) (string, error) {
 	var val string
 	switch key {
@@ -628,10 +685,12 @@ func GetLoginVal(key string) (string, error) {
 	return val, nil
 }
 
+// OptLoginVal returns the value from the configuration file
 func OptLoginVal(cfgval string) string {
 	return strings.ToLower(cfgval)
 }
 
+// SetLoginVal applies the settings to the system
 func SetLoginVal(key, value string, revert bool) error {
 	switch key {
 	case "UserTasksMax":
@@ -651,6 +710,9 @@ func SetLoginVal(key, value string, revert bool) error {
 }
 
 // section [pagecache]
+
+// GetPagecacheVal initialise the pagecache structure with the current
+// system settings
 func GetPagecacheVal(key string, cur *LinuxPagingImprovements) string {
 	val := ""
 	currentPagecache, err := LinuxPagingImprovements{SysconfigPrefix: cur.SysconfigPrefix}.Initialise()
@@ -679,6 +741,8 @@ func GetPagecacheVal(key string, cur *LinuxPagingImprovements) string {
 	return val
 }
 
+// OptPagecacheVal optimises the pagecache structure with the settings
+// from the configuration file or with a calculation
 //func OptPagecacheVal(key, cfgval string, cur *LinuxPagingImprovements, keyvalue map[string]map[string]txtparser.INIEntry) string {
 func OptPagecacheVal(key, cfgval string, cur *LinuxPagingImprovements) string {
 	val := strings.ToLower(cfgval)
@@ -710,6 +774,7 @@ func OptPagecacheVal(key, cfgval string, cur *LinuxPagingImprovements) string {
 	return val
 }
 
+// SetPagecacheVal applies the settings to the system
 func SetPagecacheVal(key string, cur *LinuxPagingImprovements) error {
 	var err error
 	if key == "OVERRIDE_PAGECACHE_LIMIT_MB" {

--- a/sap/note/ini_sections_test.go
+++ b/sap/note/ini_sections_test.go
@@ -69,6 +69,7 @@ func TestOptBlkVal(t *testing.T) {
 		t.Fatal(val)
 	}
 }
+
 //SetBlkVal
 
 //GetLimitsVal
@@ -113,6 +114,7 @@ func TestOptLimitsVal(t *testing.T) {
 		t.Fatal(val)
 	}
 }
+
 //SetLimitsVal
 
 func TestGetVmVal(t *testing.T) {
@@ -150,6 +152,7 @@ func TestOptVmVal(t *testing.T) {
 		t.Fatal(val)
 	}
 }
+
 //SetVmVal
 
 func TestGetCpuVal(t *testing.T) {
@@ -181,7 +184,8 @@ func TestOptCpuVal(t *testing.T) {
 	if val != "cpu0:0 cpu1:0 cpu2:0" {
 		t.Fatal(val)
 	}
-/* future feature
+
+	/* future feature
 	val = OptCpuVal("energy_perf_bias", "cpu0:6 cpu1:6 cpu2:6", "cpu0:performance cpu1:normal cpu2:powersave")
 	if val != "cpu0:0 cpu1:6 cpu2:15" {
 		t.Fatal(val)
@@ -190,7 +194,7 @@ func TestOptCpuVal(t *testing.T) {
 	if val != "cpu0:performance cpu1:normal cpu2:powersave" {
 		t.Fatal(val)
 	}
-*/
+	*/
 
 	val = OptCpuVal("governor", "all:powersave", "performance")
 	if val != "all:performance" {
@@ -200,7 +204,7 @@ func TestOptCpuVal(t *testing.T) {
 	if val != "cpu0:performance cpu1:performance cpu2:performance" {
 		t.Fatal(val)
 	}
-/* future feature
+	/* future feature
 	val = OptCpuVal("governor", "cpu0:powersave cpu1:performance cpu2:powersave", "cpu0:performance cpu1:powersave cpu2:performance")
 	if val != "cpu0:performance cpu1:powersave cpu2:performance" {
 		t.Fatal(val)
@@ -209,8 +213,9 @@ func TestOptCpuVal(t *testing.T) {
 	if val != "cpu0:performance cpu1:powersave cpu2:performance" {
 		t.Fatal(val)
 	}
-*/
+	*/
 }
+
 //SetCpuVal
 
 func TestGetMemVal(t *testing.T) {
@@ -238,8 +243,8 @@ func TestOptMemVal(t *testing.T) {
 		t.Fatal(val)
 	}
 
-	size75 := uint64(system.GetTotalMemSizeMB())*75/100
-	size80 := uint64(system.GetTotalMemSizeMB())*80/100
+	size75 := uint64(system.GetTotalMemSizeMB()) * 75 / 100
+	size80 := uint64(system.GetTotalMemSizeMB()) * 80 / 100
 
 	val = OptMemVal("ShmFileSystemSizeMB", "16043", "0", "0", "80")
 	if val != strconv.FormatUint(size80, 10) {
@@ -286,6 +291,7 @@ func TestOptMemVal(t *testing.T) {
 		t.Fatal(val)
 	}
 }
+
 //SetMemVal
 
 func TestGetRpmVal(t *testing.T) {
@@ -355,6 +361,7 @@ func TestOptUuiddVal(t *testing.T) {
 		t.Fatal(val)
 	}
 }
+
 //SetUuiddVal
 
 func TestGetServiceVal(t *testing.T) {
@@ -440,6 +447,7 @@ func TestOptLoginVal(t *testing.T) {
 		t.Fatal(val)
 	}
 }
+
 // SetLoginVal
 
 func TestGetPagecacheVal(t *testing.T) {

--- a/sap/note/ini_sections_test.go
+++ b/sap/note/ini_sections_test.go
@@ -117,106 +117,106 @@ func TestOptLimitsVal(t *testing.T) {
 
 //SetLimitsVal
 
-func TestGetVmVal(t *testing.T) {
+func TestGetVMVal(t *testing.T) {
 	if runtime.GOARCH != "ppc64le" {
-		val := GetVmVal("THP")
+		val := GetVMVal("THP")
 		if val != "always" && val != "madvise" && val != "never" {
 			t.Fatalf("wrong value '%+v' for THP.\n", val)
 		}
 	}
-	val := GetVmVal("KSM")
+	val := GetVMVal("KSM")
 	if val != "1" && val != "0" {
 		t.Fatalf("wrong value '%+v' for KSM.\n", val)
 	}
 }
 
-func TestOptVmVal(t *testing.T) {
-	val := OptVmVal("THP", "always")
+func TestOptVMVal(t *testing.T) {
+	val := OptVMVal("THP", "always")
 	if val != "always" {
 		t.Fatal(val)
 	}
-	val = OptVmVal("THP", "unknown")
+	val = OptVMVal("THP", "unknown")
 	if val != "never" {
 		t.Fatal(val)
 	}
-	val = OptVmVal("KSM", "1")
+	val = OptVMVal("KSM", "1")
 	if val != "1" {
 		t.Fatal(val)
 	}
-	val = OptVmVal("KSM", "2")
+	val = OptVMVal("KSM", "2")
 	if val != "0" {
 		t.Fatal(val)
 	}
-	val = OptVmVal("UNKOWN_PARAMETER", "unknown")
+	val = OptVMVal("UNKOWN_PARAMETER", "unknown")
 	if val != "unknown" {
 		t.Fatal(val)
 	}
 }
 
-//SetVmVal
+//SetVMVal
 
-func TestGetCpuVal(t *testing.T) {
-	val := GetCpuVal("force_latency")
+func TestGetCPUVal(t *testing.T) {
+	val := GetCPUVal("force_latency")
 	if val != "all:none" {
 		t.Logf("force_latency supported: '%s'\n", val)
 	}
-	val = GetCpuVal("energy_perf_bias")
+	val = GetCPUVal("energy_perf_bias")
 	if val != "all:none" {
 		t.Logf("energy_perf_bias supported: '%s'\n", val)
 	}
-	val = GetCpuVal("governor")
+	val = GetCPUVal("governor")
 	if val != "all:none" && val != "" {
 		t.Logf("governor supported: '%s'\n", val)
 	}
 }
 
-func TestOptCpuVal(t *testing.T) {
-	val := OptCpuVal("force_latency", "1000", "70")
+func TestOptCPUVal(t *testing.T) {
+	val := OptCPUVal("force_latency", "1000", "70")
 	if val != "70" {
 		t.Fatal(val)
 	}
 
-	val = OptCpuVal("energy_perf_bias", "all:15", "performance")
+	val = OptCPUVal("energy_perf_bias", "all:15", "performance")
 	if val != "all:0" {
 		t.Fatal(val)
 	}
-	val = OptCpuVal("energy_perf_bias", "cpu0:15 cpu1:6 cpu2:0", "performance")
+	val = OptCPUVal("energy_perf_bias", "cpu0:15 cpu1:6 cpu2:0", "performance")
 	if val != "cpu0:0 cpu1:0 cpu2:0" {
 		t.Fatal(val)
 	}
 
 	/* future feature
-	val = OptCpuVal("energy_perf_bias", "cpu0:6 cpu1:6 cpu2:6", "cpu0:performance cpu1:normal cpu2:powersave")
+	val = OptCPUVal("energy_perf_bias", "cpu0:6 cpu1:6 cpu2:6", "cpu0:performance cpu1:normal cpu2:powersave")
 	if val != "cpu0:0 cpu1:6 cpu2:15" {
 		t.Fatal(val)
 	}
-	val = OptCpuVal("energy_perf_bias", "all:6", "cpu0:performance cpu1:normal cpu2:powersave")
+	val = OptCPUVal("energy_perf_bias", "all:6", "cpu0:performance cpu1:normal cpu2:powersave")
 	if val != "cpu0:performance cpu1:normal cpu2:powersave" {
 		t.Fatal(val)
 	}
 	*/
 
-	val = OptCpuVal("governor", "all:powersave", "performance")
+	val = OptCPUVal("governor", "all:powersave", "performance")
 	if val != "all:performance" {
 		t.Fatal(val)
 	}
-	val = OptCpuVal("governor", "cpu0:powersave cpu1:performance cpu2:powersave", "performance")
+	val = OptCPUVal("governor", "cpu0:powersave cpu1:performance cpu2:powersave", "performance")
 	if val != "cpu0:performance cpu1:performance cpu2:performance" {
 		t.Fatal(val)
 	}
 	/* future feature
-	val = OptCpuVal("governor", "cpu0:powersave cpu1:performance cpu2:powersave", "cpu0:performance cpu1:powersave cpu2:performance")
+	val = OptCPUVal("governor", "cpu0:powersave cpu1:performance cpu2:powersave", "cpu0:performance cpu1:powersave cpu2:performance")
 	if val != "cpu0:performance cpu1:powersave cpu2:performance" {
 		t.Fatal(val)
 	}
-	val = OptCpuVal("energy_perf_bias", "all:powersave", "cpu0:performance cpu1:powersave cpu2:performance")
+	val = OptCPUVal("energy_perf_bias", "all:powersave", "cpu0:performance cpu1:powersave cpu2:performance")
 	if val != "cpu0:performance cpu1:powersave cpu2:performance" {
 		t.Fatal(val)
 	}
 	*/
 }
 
-//SetCpuVal
+//SetCPUVal
 
 func TestGetMemVal(t *testing.T) {
 	val := GetMemVal("VSZ_TMPFS_PERCENT")

--- a/sap/note/ini_test.go
+++ b/sap/note/ini_test.go
@@ -11,6 +11,12 @@ import (
 	"testing"
 )
 
+func cleanUp() {
+	var parameterStateDir = "/var/lib/saptune/parameter"
+	os.RemoveAll(parameterStateDir)
+	defer os.RemoveAll(parameterStateDir)
+}
+
 func TestCalculateOptimumValue(t *testing.T) {
 	if val, err := CalculateOptimumValue(txtparser.OperatorMoreThan, "21", "20"); val != "21" || err != nil {
 		t.Fatal(val, err)
@@ -70,6 +76,7 @@ func TestCalculateOptimumValue(t *testing.T) {
 }
 
 func TestVendorSettings(t *testing.T) {
+	cleanUp()
 	iniPath := path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/ini_test.ini")
 	ini := INISettings{ConfFilePath: iniPath}
 
@@ -122,6 +129,7 @@ func TestVendorSettings(t *testing.T) {
 }
 
 func TestAllSettings(t *testing.T) {
+	cleanUp()
 	testString := []string{"vm.nr_hugepages", "THP", "KSM", "Sysstat"}
 	if runtime.GOARCH == "ppc64le" {
 		testString = []string{"KSM", "Sysstat"}
@@ -249,6 +257,7 @@ func TestAllSettings(t *testing.T) {
 }
 
 func TestPageCacheSettings(t *testing.T) {
+	cleanUp()
 	iniPath := path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/pcTest6/usr/share/saptune/notes/1557506")
 	ini := INISettings{ConfFilePath: iniPath}
 
@@ -279,4 +288,5 @@ func TestPageCacheSettings(t *testing.T) {
 	if optimisedINI.SysctlParams["OVERRIDE_PAGECACHE_LIMIT_MB"] != "641" {
 		t.Fatal(optimisedINI.SysctlParams)
 	}
+	cleanUp()
 }

--- a/sap/note/parameter.go
+++ b/sap/note/parameter.go
@@ -235,10 +235,7 @@ func RevertParameter(param string, noteID string) string {
 	}
 	if len(pEntries.AllNotes) == 1 {
 		// remove parameter state file, if only one entry ('start') is left.
-		remFileName := GetPathToParameter(param)
-		if _, err := os.Stat(remFileName); err == nil {
-			os.Remove(remFileName)
-		}
+		CleanUpParamFile(param)
 	} else {
 		//store changes pEntries
 		err := StoreParameter(param, pEntries, true)
@@ -264,4 +261,12 @@ func RevertLimitsParameter(key, domain, item, id string) string {
 		pvalue = pvalue + pv
 	}
 	return pvalue
+}
+
+// CleanUpParamFile removes the parameter state file
+func CleanUpParamFile(param string) {
+	remFileName := GetPathToParameter(param)
+	if _, err := os.Stat(remFileName); err == nil {
+		os.Remove(remFileName)
+	}
 }

--- a/sap/note/parameter.go
+++ b/sap/note/parameter.go
@@ -13,12 +13,12 @@ import (
 )
 
 type ParameterNoteEntry struct {
-	NoteId   string
-	Value    string
+	NoteId string
+	Value  string
 }
 
 type ParameterNotes struct {
-	AllNotes []ParameterNoteEntry	// list of applied notes, which manipulate the given system parameter
+	AllNotes []ParameterNoteEntry // list of applied notes, which manipulate the given system parameter
 }
 
 // Directory where to store the parameter state files
@@ -27,7 +27,7 @@ const SaptuneParameterStateDir = "/var/lib/saptune/parameter"
 
 // Return path to the serialised parameter state file.
 func GetPathToParameter(param string) string {
-        return path.Join(SaptuneParameterStateDir, param)
+	return path.Join(SaptuneParameterStateDir, param)
 }
 
 // Check, if given noteID is already part of the parameter list of notes
@@ -61,7 +61,7 @@ func ListParams() (ret []string, err error) {
 
 // Create parameter state file and insert the start values.
 func CreateParameterStartValues(param, value string) {
-	pEntries := ParameterNotes {
+	pEntries := ParameterNotes{
 		AllNotes: make([]ParameterNoteEntry, 0, 64),
 	}
 	pEntries = GetSavedParameterNotes(param)
@@ -69,8 +69,8 @@ func CreateParameterStartValues(param, value string) {
 		//log.Printf("Write parameter start value '%s' to file '%s'", value, GetPathToParameter(param))
 		// file does not exist, create start entry
 		pEntry := ParameterNoteEntry{
-			NoteId:   "start",
-			Value:    value,
+			NoteId: "start",
+			Value:  value,
 		}
 		pEntries.AllNotes = append(pEntries.AllNotes, pEntry)
 		err := StoreParameter(param, pEntries, true)
@@ -82,7 +82,7 @@ func CreateParameterStartValues(param, value string) {
 
 // Add note parameter values to the state file.
 func AddParameterNoteValues(param, value, noteID string) {
-	pEntries := ParameterNotes {
+	pEntries := ParameterNotes{
 		AllNotes: make([]ParameterNoteEntry, 0, 64),
 	}
 	pEntries = GetSavedParameterNotes(param)
@@ -90,8 +90,8 @@ func AddParameterNoteValues(param, value, noteID string) {
 		//log.Printf("Write note '%s' parameter value '%s' to file '%s'", noteID, value, GetPathToParameter(param))
 		// file exis
 		pEntry := ParameterNoteEntry{
-			NoteId:   noteID,
-			Value:    value,
+			NoteId: noteID,
+			Value:  value,
 		}
 		pEntries.AllNotes = append(pEntries.AllNotes, pEntry)
 		err := StoreParameter(param, pEntries, true)
@@ -102,8 +102,8 @@ func AddParameterNoteValues(param, value, noteID string) {
 }
 
 // Read content of stored paramter states. Return the content as ParameterNotes
-func GetSavedParameterNotes(param string) (ParameterNotes) {
-	pEntries := ParameterNotes {
+func GetSavedParameterNotes(param string) ParameterNotes {
+	pEntries := ParameterNotes{
 		AllNotes: make([]ParameterNoteEntry, 0, 64),
 	}
 	content, err := ioutil.ReadFile(GetPathToParameter(param))
@@ -116,7 +116,7 @@ func GetSavedParameterNotes(param string) (ParameterNotes) {
 
 // read all saved parameters from the state directory
 // fill structure app.AllParameters
-func GetAllSavedParameters() (map[string]ParameterNotes) {
+func GetAllSavedParameters() map[string]ParameterNotes {
 	params := make(map[string]ParameterNotes)
 	allParams, err := ListParams()
 	if err == nil {
@@ -132,7 +132,7 @@ func GetAllSavedParameters() (map[string]ParameterNotes) {
 }
 
 // Store parameter values to state directory
-// Write a json file with the name of the given parameter containing the 
+// Write a json file with the name of the given parameter containing the
 // applied noteIDs for this parameter and the associated parameter values
 func StoreParameter(param string, obj ParameterNotes, overwriteExisting bool) error {
 	content, err := json.Marshal(obj)
@@ -162,9 +162,9 @@ func PositionInParameterList(noteID string, list []ParameterNoteEntry) int {
 
 // Revert parameter value and remove noteID reference from parameter file
 // return value of parameter, if needed to change, empty string else
-func RevertParameter(param string, noteID string) (string) {
+func RevertParameter(param string, noteID string) string {
 	pvalue := ""
-	pEntries := ParameterNotes {
+	pEntries := ParameterNotes{
 		AllNotes: make([]ParameterNoteEntry, 0, 64),
 	}
 	// read values from the parameter state file

--- a/sap/note/parameter_test.go
+++ b/sap/note/parameter_test.go
@@ -1,0 +1,377 @@
+package note
+
+import (
+	"fmt"
+	"testing"
+)
+
+var paramNote1 = ParameterNoteEntry{
+	NoteID: "start",
+	Value:  "StartValue",
+}
+var paramNote2 = ParameterNoteEntry{
+	NoteID: "entry2",
+	Value:  "AdditionalValue",
+}
+var paramNote3 = ParameterNoteEntry{
+	NoteID: "entry3",
+	Value:  "LastValue",
+}
+
+func TestGetPathToParameter(t *testing.T) {
+	val := GetPathToParameter("FILENAME4TEST")
+	if val != "/var/lib/saptune/parameter/FILENAME4TEST" {
+		t.Fatalf("parameter file name: %v.\n", val)
+	}
+}
+
+func TestGetSavedParameterNotes(t *testing.T) {
+	val := GetSavedParameterNotes("TEST_PARAMETER")
+	if len(val.AllNotes) > 0 {
+		t.Fatalf("parameter file for 'TEST_PARAMETER' exists. content: %+v.\n", val)
+	}
+}
+
+func TestIDInParameterList(t *testing.T) {
+	pNotes := ParameterNotes{
+		AllNotes: make([]ParameterNoteEntry, 0, 8),
+	}
+
+	pNotes.AllNotes = append(pNotes.AllNotes, paramNote1)
+	pNotes.AllNotes = append(pNotes.AllNotes, paramNote2)
+	pNotes.AllNotes = append(pNotes.AllNotes, paramNote3)
+	if !IDInParameterList("entry2", pNotes.AllNotes) {
+		t.Fatalf("'entry2' not part of list '%+v'\n", pNotes)
+	}
+	if IDInParameterList("HUGO", pNotes.AllNotes) {
+		t.Fatalf("'HUGO' is part of list '%+v'\n", pNotes)
+	}
+}
+
+func TestListParams(t *testing.T) {
+	val, tsterr := ListParams()
+	if tsterr == nil && len(val) > 0 {
+		t.Fatalf("there are parameter files stored: '%+v'\n", val)
+	}
+}
+
+func TestCreateParameterStartValues(t *testing.T) {
+	CreateParameterStartValues("TEST_PARAMETER", "TestStartValue")
+	val := GetSavedParameterNotes("TEST_PARAMETER")
+	if len(val.AllNotes) == 0 {
+		t.Fatalf("missing parameter state file 'TEST_PARAMETER': '%+v'\n", val)
+	}
+	if val.AllNotes[0].NoteID != "start" {
+		CleanUpParamFile("TEST_PARAMETER")
+		t.Fatalf("wrong content in state file 'TEST_PARAMETER', 'start' is NOT the first entry, instead it's '%+v'\n", val.AllNotes[0].NoteID)
+	}
+	if val.AllNotes[0].Value != "TestStartValue" {
+		CleanUpParamFile("TEST_PARAMETER")
+		t.Fatalf("wrong start value in state file 'TEST_PARAMETER': '%+v'\n", val.AllNotes[0].Value)
+	}
+	CleanUpParamFile("TEST_PARAMETER")
+
+	// empty start value
+	CreateParameterStartValues("TEST_PARAMETER", "")
+	val = GetSavedParameterNotes("TEST_PARAMETER")
+	if len(val.AllNotes) == 0 {
+		t.Fatalf("missing parameter state file 'TEST_PARAMETER': '%+v'\n", val)
+	}
+	if val.AllNotes[0].NoteID != "start" {
+		CleanUpParamFile("TEST_PARAMETER")
+		t.Fatalf("wrong content in state file 'TEST_PARAMETER', 'start' is NOT the first entry, instead it's '%+v'\n", val.AllNotes[0].NoteID)
+	}
+	if val.AllNotes[0].Value != "" {
+		CleanUpParamFile("TEST_PARAMETER")
+		t.Fatalf("wrong start value in state file 'TEST_PARAMETER': '%+v'\n", val.AllNotes[0].Value)
+	}
+	CleanUpParamFile("TEST_PARAMETER")
+}
+
+func TestAddParameterNoteValues(t *testing.T) {
+	AddParameterNoteValues("TEST_PARAMETER", "TestAddValue", "4711")
+	val := GetSavedParameterNotes("TEST_PARAMETER")
+	if len(val.AllNotes) != 0 {
+		t.Fatalf("parameter state file 'TEST_PARAMETER' exists. content: '%+v'\n", val)
+	}
+
+	CreateParameterStartValues("TEST_PARAMETER", "TestStartValue")
+	AddParameterNoteValues("TEST_PARAMETER", "TestAddValue", "4711")
+	val = GetSavedParameterNotes("TEST_PARAMETER")
+	if len(val.AllNotes) == 0 {
+		t.Fatalf("missing parameter state file 'TEST_PARAMETER': '%+v'\n", val)
+	}
+	if val.AllNotes[0].NoteID != "start" && val.AllNotes[1].NoteID != "4711" {
+		CleanUpParamFile("TEST_PARAMETER")
+		t.Fatalf("wrong content in state file 'TEST_PARAMETER': '%+v'\n", val)
+	}
+	if val.AllNotes[0].Value != "TestStartValue" && val.AllNotes[1].Value != "TestAddValue" {
+		CleanUpParamFile("TEST_PARAMETER")
+		t.Fatalf("wrong content in state file 'TEST_PARAMETER': '%+v'\n", val)
+	}
+	if !IDInParameterList("4711", val.AllNotes) {
+		CleanUpParamFile("TEST_PARAMETER")
+		t.Fatalf("wrong content in state file 'TEST_PARAMETER': '%+v'\n", val)
+	}
+	CleanUpParamFile("TEST_PARAMETER")
+}
+
+func TestSaveLimitsParameter(t *testing.T) {
+	tkey := "TEST_LIMIT_PARAMETER"
+	tdom := "TDOMAIN"
+	titem := "TITEM"
+	sval := "TestLimitStartValue"
+	aval := "TestLimitAddValue"
+
+	paramFile := fmt.Sprintf("%s_%s_%s", tkey, titem, tdom)
+
+	SaveLimitsParameter(tkey, tdom, titem, sval, "start", "")
+	val := GetSavedParameterNotes(tkey)
+	if len(val.AllNotes) != 0 {
+		val = GetSavedParameterNotes(paramFile)
+		if len(val.AllNotes) != 0 {
+			t.Fatalf("parameter state file exists. content: '%+v'\n", val)
+		}
+	}
+
+	SaveLimitsParameter(tkey, tdom, titem, aval, "add", "47114711")
+	val = GetSavedParameterNotes(tkey)
+	if len(val.AllNotes) != 0 {
+		val = GetSavedParameterNotes(paramFile)
+		if len(val.AllNotes) != 0 {
+			t.Fatalf("parameter state file exists. content: '%+v'\n", val)
+		}
+	}
+
+	tkey = "LIMIT_HARD"
+	paramFile = fmt.Sprintf("%s_%s_%s", tkey, titem, tdom)
+
+	SaveLimitsParameter(tkey, tdom, titem, sval, "start", "")
+	val = GetSavedParameterNotes(paramFile)
+	if len(val.AllNotes) != 0 {
+		t.Fatalf("parameter state file exists. content: '%+v'\n", val)
+	}
+
+	sval = "TDOMAIN:TestLimitStartValue"
+	sout := "TDOMAIN:TestLimitStartValue "
+	SaveLimitsParameter(tkey, tdom, titem, sval, "start", "")
+	val = GetSavedParameterNotes(paramFile)
+	if len(val.AllNotes) == 0 {
+		t.Fatalf("missing parameter state file '%s'\n", paramFile)
+	}
+	if val.AllNotes[0].NoteID != "start" {
+		CleanUpParamFile(paramFile)
+		t.Fatalf("wrong content in state file '%s': '%+v'\n", paramFile, val)
+	}
+	if val.AllNotes[0].Value != sout {
+		CleanUpParamFile(paramFile)
+		t.Fatalf("wrong content in state file '%s': '%+v'\n", paramFile, val)
+	}
+
+	aval = "TDOMAIN:TestLimitAddValue"
+	aout := "TDOMAIN:TestLimitAddValue "
+	SaveLimitsParameter(tkey, tdom, titem, aval, "add", "47114711")
+	val = GetSavedParameterNotes(paramFile)
+	if len(val.AllNotes) == 0 {
+		t.Fatalf("missing parameter state file '%+v'\n", paramFile)
+	}
+	if val.AllNotes[0].NoteID != "start" && val.AllNotes[1].NoteID != "47114711" {
+		CleanUpParamFile(paramFile)
+		t.Fatalf("wrong content in state file '%s': '%+v'\n", paramFile, val)
+	}
+	if val.AllNotes[0].Value != sout && val.AllNotes[1].Value != aout {
+		CleanUpParamFile(paramFile)
+		t.Fatalf("wrong content in state file '%s': '%+v'\n", paramFile, val)
+	}
+	if IDInParameterList("4711", val.AllNotes) {
+		CleanUpParamFile(paramFile)
+		t.Fatalf("wrong content in state file '%s': '%+v'\n", paramFile, val)
+	}
+	if !IDInParameterList("47114711", val.AllNotes) {
+		CleanUpParamFile(paramFile)
+		t.Fatalf("wrong content in state file '%s': '%+v'\n", paramFile, val)
+	}
+	CleanUpParamFile(paramFile)
+}
+
+func TestGetAllSavedParameters(t *testing.T) {
+	CreateParameterStartValues("TEST_PARAMETER_1", "TestStartValue1")
+	AddParameterNoteValues("TEST_PARAMETER_1", "TestAddValue1", "4711")
+	CreateParameterStartValues("TEST_PARAMETER_2", "TestStartValue2")
+	AddParameterNoteValues("TEST_PARAMETER_2", "TestAddValue2", "4712")
+	CreateParameterStartValues("TEST_PARAMETER_3", "TestStartValue3")
+	AddParameterNoteValues("TEST_PARAMETER_3", "TestAddValue3", "4713")
+
+	val := GetAllSavedParameters()
+	if val["TEST_PARAMETER_1"].AllNotes[0].NoteID != "start" && val["TEST_PARAMETER_1"].AllNotes[1].NoteID != "4711" {
+		CleanUpParamFile("TEST_PARAMETER_1")
+		CleanUpParamFile("TEST_PARAMETER_2")
+		CleanUpParamFile("TEST_PARAMETER_3")
+		t.Fatalf("wrong content in state file '%s': '%+v'\n", "TEST_PARAMETER_1", val["TEST_PARAMETER_1"].AllNotes)
+	}
+	if val["TEST_PARAMETER_1"].AllNotes[0].Value != "TestStartValue1" && val["TEST_PARAMETER_1"].AllNotes[1].Value != "TestAddValue1" {
+		CleanUpParamFile("TEST_PARAMETER_1")
+		CleanUpParamFile("TEST_PARAMETER_2")
+		CleanUpParamFile("TEST_PARAMETER_3")
+		t.Fatalf("wrong content in state file '%s': '%+v'\n", "TEST_PARAMETER_1", val["TEST_PARAMETER_1"].AllNotes)
+	}
+	if val["TEST_PARAMETER_2"].AllNotes[0].NoteID != "start" && val["TEST_PARAMETER_2"].AllNotes[1].NoteID != "4712" {
+		CleanUpParamFile("TEST_PARAMETER_1")
+		CleanUpParamFile("TEST_PARAMETER_2")
+		CleanUpParamFile("TEST_PARAMETER_3")
+		t.Fatalf("wrong content in state file '%s': '%+v'\n", "TEST_PARAMETER_2", val["TEST_PARAMETER_2"].AllNotes)
+	}
+	if val["TEST_PARAMETER_2"].AllNotes[0].Value != "TestStartValue2" && val["TEST_PARAMETER_2"].AllNotes[1].Value != "TestAddValue2" {
+		CleanUpParamFile("TEST_PARAMETER_1")
+		CleanUpParamFile("TEST_PARAMETER_2")
+		CleanUpParamFile("TEST_PARAMETER_3")
+		t.Fatalf("wrong content in state file '%s': '%+v'\n", "TEST_PARAMETER_2", val["TEST_PARAMETER_2"].AllNotes)
+	}
+	if val["TEST_PARAMETER_3"].AllNotes[0].NoteID != "start" && val["TEST_PARAMETER_3"].AllNotes[1].NoteID != "4713" {
+		CleanUpParamFile("TEST_PARAMETER_1")
+		CleanUpParamFile("TEST_PARAMETER_2")
+		CleanUpParamFile("TEST_PARAMETER_3")
+		t.Fatalf("wrong content in state file '%s': '%+v'\n", "TEST_PARAMETER_3", val["TEST_PARAMETER_3"].AllNotes)
+	}
+	if val["TEST_PARAMETER_3"].AllNotes[0].Value != "TestStartValue3" && val["TEST_PARAMETER_3"].AllNotes[1].Value != "TestAddValue3" {
+		CleanUpParamFile("TEST_PARAMETER_1")
+		CleanUpParamFile("TEST_PARAMETER_2")
+		CleanUpParamFile("TEST_PARAMETER_3")
+		t.Fatalf("wrong content in state file '%s': '%+v'\n", "TEST_PARAMETER_3", val["TEST_PARAMETER_3"].AllNotes)
+	}
+	CleanUpParamFile("TEST_PARAMETER_1")
+	CleanUpParamFile("TEST_PARAMETER_2")
+	CleanUpParamFile("TEST_PARAMETER_3")
+}
+
+func TestStoreParameter(t *testing.T) {
+	paramList := ParameterNotes{
+		AllNotes: make([]ParameterNoteEntry, 0, 64),
+	}
+	param := ParameterNoteEntry{
+		NoteID: "start",
+		Value:  "TestStartValue1",
+	}
+	paramList.AllNotes = append(paramList.AllNotes, param)
+	param = ParameterNoteEntry{
+		NoteID: "4711",
+		Value:  "TestAddValue1",
+	}
+	paramList.AllNotes = append(paramList.AllNotes, param)
+	err := StoreParameter("TEST_PARAMETER_1", paramList, true)
+	if err != nil {
+		CleanUpParamFile("TEST_PARAMETER_1")
+		t.Fatalf("failed to store values for parameter '%s' in file: '%+v'\n", "TEST_PARAMETER_1", paramList)
+	}
+	CleanUpParamFile("TEST_PARAMETER_1")
+}
+
+func TestPositionInParameterList(t *testing.T) {
+	CreateParameterStartValues("TEST_PARAMETER_1", "TestStartValue1")
+	AddParameterNoteValues("TEST_PARAMETER_1", "TestAddValue1", "4711")
+	AddParameterNoteValues("TEST_PARAMETER_1", "TestAddValue2", "4712")
+	AddParameterNoteValues("TEST_PARAMETER_1", "TestAddValue3", "4713")
+	AddParameterNoteValues("TEST_PARAMETER_1", "TestAddValue4", "4714")
+	noteList := GetSavedParameterNotes("TEST_PARAMETER_1")
+	val := PositionInParameterList("4712", noteList.AllNotes)
+	if val != 2 {
+		CleanUpParamFile("TEST_PARAMETER_1")
+		t.Fatalf("wrong position for note '%s': '%v'\n", "4712", val)
+	}
+	val = PositionInParameterList("start", noteList.AllNotes)
+	if val != 0 {
+		CleanUpParamFile("TEST_PARAMETER_1")
+		t.Fatalf("wrong position for note '%s': '%v'\n", "start", val)
+	}
+	val = PositionInParameterList("TEST_NON_EXIST", noteList.AllNotes)
+	if val != 0 {
+		CleanUpParamFile("TEST_PARAMETER_1")
+		t.Fatalf("wrong position for note '%s': '%v'\n", "TEST_NON_EXIST", val)
+	}
+	CleanUpParamFile("TEST_PARAMETER_1")
+}
+
+func TestRevertParameter(t *testing.T) {
+	// test with non existing parameter file
+	val := RevertParameter("TEST_PARAMETER_1", "4712")
+	if val != "" {
+		CleanUpParamFile("TEST_PARAMETER_1")
+		t.Fatalf("wrong parameter '%s' reverted from parameter file '%s'\n", val, "TEST_PARAMETER_1")
+	}
+
+	CreateParameterStartValues("TEST_PARAMETER_1", "TestStartValue1")
+	AddParameterNoteValues("TEST_PARAMETER_1", "TestAddValue1", "4711")
+	AddParameterNoteValues("TEST_PARAMETER_1", "TestAddValue2", "4712")
+	AddParameterNoteValues("TEST_PARAMETER_1", "TestAddValue3", "4713")
+	AddParameterNoteValues("TEST_PARAMETER_1", "TestAddValue4", "4714")
+	val = RevertParameter("TEST_PARAMETER_1", "4712")
+	if val != "TestAddValue4" {
+		CleanUpParamFile("TEST_PARAMETER_1")
+		t.Fatalf("wrong parameter '%s' reverted for note '%s'\n", val, "4712")
+	}
+	val = RevertParameter("TEST_PARAMETER_1", "4714")
+	if val != "TestAddValue3" {
+		CleanUpParamFile("TEST_PARAMETER_1")
+		t.Fatalf("wrong parameter '%s' reverted for note '%s'\n", val, "4714")
+	}
+	val = RevertParameter("TEST_PARAMETER_1", "4711")
+	if val != "TestAddValue3" {
+		CleanUpParamFile("TEST_PARAMETER_1")
+		t.Fatalf("wrong parameter '%s' reverted for note '%s'\n", val, "4711")
+	}
+	val = RevertParameter("TEST_PARAMETER_1", "4713")
+	if val != "TestStartValue1" {
+		CleanUpParamFile("TEST_PARAMETER_1")
+		t.Fatalf("wrong parameter '%s' reverted for note '%s'\n", val, "4713")
+	}
+	CleanUpParamFile("TEST_PARAMETER_1")
+}
+
+func TestRevertLimitsParameter(t *testing.T) {
+	tkey := "LIMIT_HARD"
+	tdom := "TDOMAIN"
+	titem := "TITEM"
+	sval := "TDOMAIN:TestLimitStartValue1"
+	aval1 := "TDOMAIN:TestLimitAddValue1"
+	aval2 := "TDOMAIN:TestLimitAddValue2"
+	aval3 := "TDOMAIN:TestLimitAddValue3"
+	aval4 := "TDOMAIN:TestLimitAddValue4"
+	paramFile := fmt.Sprintf("%s_%s_%s", tkey, titem, tdom)
+
+	CleanUpParamFile(paramFile)
+
+	SaveLimitsParameter(tkey, tdom, titem, sval, "start", "")
+	SaveLimitsParameter(tkey, tdom, titem, aval1, "add", "4711")
+	SaveLimitsParameter(tkey, tdom, titem, aval2, "add", "4712")
+	SaveLimitsParameter(tkey, tdom, titem, aval3, "add", "4713")
+	SaveLimitsParameter(tkey, tdom, titem, aval4, "add", "4714")
+
+	// test with 'wrong' key, return should be an empty string
+	val := RevertLimitsParameter("LIMIT_TEST_KEY", tdom, titem, "4712")
+	if val != "" {
+		CleanUpParamFile(paramFile)
+		t.Fatalf("wrong parameter '%s' reverted for key 'LIMIT_TEST_KEY' and for note '%s'\n", val, "4712")
+	}
+
+	val = RevertLimitsParameter(tkey, tdom, titem, "4712")
+	if val != "TDOMAIN:TestLimitAddValue4 " {
+		CleanUpParamFile(paramFile)
+		t.Fatalf("wrong parameter '%s' reverted for note '%s'\n", val, "4712")
+	}
+	val = RevertLimitsParameter(tkey, tdom, titem, "4714")
+	if val != "TDOMAIN:TestLimitAddValue3 " {
+		CleanUpParamFile(paramFile)
+		t.Fatalf("wrong parameter '%s' reverted for note '%s'\n", val, "4714")
+	}
+	val = RevertLimitsParameter(tkey, tdom, titem, "4711")
+	if val != "TDOMAIN:TestLimitAddValue3 " {
+		CleanUpParamFile(paramFile)
+		t.Fatalf("wrong parameter '%s' reverted for note '%s'\n", val, "4711")
+	}
+	val = RevertLimitsParameter(tkey, tdom, titem, "4713")
+	if val != "TDOMAIN:TestLimitStartValue1 " {
+		CleanUpParamFile(paramFile)
+		t.Fatalf("wrong parameter '%s' reverted for note '%s'\n", val, "4713")
+	}
+	CleanUpParamFile(paramFile)
+}

--- a/sap/param/io.go
+++ b/sap/param/io.go
@@ -10,11 +10,12 @@ import (
 	"strings"
 )
 
-// Change IO elevators on all IO devices
+// BlockDeviceSchedulers changes IO elevators on all IO devices
 type BlockDeviceSchedulers struct {
 	SchedulerChoice map[string]string
 }
 
+// Inspect retrieves the current scheduler from the system
 func (ioe BlockDeviceSchedulers) Inspect() (Parameter, error) {
 	newIOE := BlockDeviceSchedulers{SchedulerChoice: make(map[string]string)}
 	// List /sys/block and inspect the IO elevator of each one
@@ -36,6 +37,8 @@ func (ioe BlockDeviceSchedulers) Inspect() (Parameter, error) {
 	}
 	return newIOE, nil
 }
+
+// Optimise gets the expected scheduler value from the configuration
 func (ioe BlockDeviceSchedulers) Optimise(newElevatorName interface{}) (Parameter, error) {
 	newIOE := BlockDeviceSchedulers{SchedulerChoice: make(map[string]string)}
 	for k := range ioe.SchedulerChoice {
@@ -43,6 +46,8 @@ func (ioe BlockDeviceSchedulers) Optimise(newElevatorName interface{}) (Paramete
 	}
 	return newIOE, nil
 }
+
+// Apply sets the new scheduler value in the system
 func (ioe BlockDeviceSchedulers) Apply() error {
 	errs := make([]error, 0, 0)
 	for name, elevator := range ioe.SchedulerChoice {
@@ -61,6 +66,7 @@ type BlockDeviceNrRequests struct {
 	NrRequests map[string]int
 }
 
+// Inspect retrieves the current nr_requests from the system
 func (ior BlockDeviceNrRequests) Inspect() (Parameter, error) {
 	newIOR := BlockDeviceNrRequests{NrRequests: make(map[string]int)}
 	// List /sys/block and inspect the number of requests of each one
@@ -81,6 +87,8 @@ func (ior BlockDeviceNrRequests) Inspect() (Parameter, error) {
 	}
 	return newIOR, nil
 }
+
+// Optimise gets the expected nr_requests value from the configuration
 func (ior BlockDeviceNrRequests) Optimise(newNrRequestValue interface{}) (Parameter, error) {
 	newIOR := BlockDeviceNrRequests{NrRequests: make(map[string]int)}
 	for k := range ior.NrRequests {
@@ -88,6 +96,8 @@ func (ior BlockDeviceNrRequests) Optimise(newNrRequestValue interface{}) (Parame
 	}
 	return newIOR, nil
 }
+
+// Apply sets the new nr_requests value in the system
 func (ior BlockDeviceNrRequests) Apply() error {
 	errs := make([]error, 0, 0)
 	for name, nrreq := range ior.NrRequests {
@@ -101,6 +111,7 @@ func (ior BlockDeviceNrRequests) Apply() error {
 	return err
 }
 
+// IsValidScheduler checks, if the scheduler value is supported by the system
 func IsValidScheduler(blockdev, scheduler string) bool {
 	val, err := ioutil.ReadFile(path.Join("/sys/block/", blockdev, "/queue/scheduler"))
 	if err == nil && strings.Contains(string(val), scheduler) {
@@ -108,6 +119,8 @@ func IsValidScheduler(blockdev, scheduler string) bool {
 	}
 	return false
 }
+
+// IsValidforNrRequests checks, if the nr_requests value is supported by the system
 func IsValidforNrRequests(blockdev, nrreq string) bool {
 	elev, _ := system.GetSysChoice(path.Join("block", blockdev, "queue", "scheduler"))
 	if elev != "" {

--- a/sap/param/io.go
+++ b/sap/param/io.go
@@ -61,7 +61,7 @@ func (ioe BlockDeviceSchedulers) Apply() error {
 	return err
 }
 
-// Change IO nr_requests on all block devices
+// BlockDeviceNrRequests changes IO nr_requests on all block devices
 type BlockDeviceNrRequests struct {
 	NrRequests map[string]int
 }
@@ -125,7 +125,7 @@ func IsValidforNrRequests(blockdev, nrreq string) bool {
 	elev, _ := system.GetSysChoice(path.Join("block", blockdev, "queue", "scheduler"))
 	if elev != "" {
 		file := path.Join("block", blockdev, "queue", "nr_requests")
-		if tst_err := system.TestSysString(file, nrreq); tst_err == nil {
+		if tstErr := system.TestSysString(file, nrreq); tstErr == nil {
 			return true
 		}
 	}

--- a/sap/param/io_test.go
+++ b/sap/param/io_test.go
@@ -2,6 +2,7 @@ package param
 
 import (
 	"io/ioutil"
+	"path"
 	"testing"
 )
 
@@ -60,22 +61,31 @@ func TestNrRequests(t *testing.T) {
 }
 
 func TestIsValidScheduler(t *testing.T) {
+	scheduler := ""
 	dirCont, err := ioutil.ReadDir("/sys/block")
 	if err != nil {
 		t.Skip("no block files available. Skip test.")
 	}
 	for _, entry := range dirCont {
+		_, err := ioutil.ReadDir(path.Join("/sys/block/", entry.Name(), "mq"))
+		if err != nil {
+			// single queue scheduler (values: noop deadline cfq)
+			scheduler = "cfq"
+		} else {
+			// multi queue scheduler (values: mq-deadline kyber bfq none)
+			scheduler = "none"
+		}
 		if entry.Name() == "sda" {
-			if !IsValidScheduler("sda", "none") {
-				t.Fatal("'none' is not a valid scheduler for 'sda'")
+			if !IsValidScheduler("sda", scheduler) {
+				t.Fatalf("'%s' is not a valid scheduler for 'sda'\n", scheduler)
 			}
 			if IsValidScheduler("sda", "hugo") {
 				t.Fatal("'hugo' is a valid scheduler for 'sda'")
 			}
 		}
 		if entry.Name() == "vda" {
-			if !IsValidScheduler("vda", "none") {
-				t.Fatal("'none' is not a valid scheduler for 'vda'")
+			if !IsValidScheduler("vda", scheduler) {
+				t.Fatalf("'%s' is not a valid scheduler for 'vda'\n", scheduler)
 			}
 			if IsValidScheduler("vda", "hugo") {
 				t.Fatal("'hugo' is a valid scheduler for 'vda'")

--- a/sap/param/io_test.go
+++ b/sap/param/io_test.go
@@ -66,8 +66,8 @@ func TestIsValidScheduler(t *testing.T) {
 	}
 	for _, entry := range dirCont {
 		if entry.Name() == "sda" {
-			if !IsValidScheduler("sda", "cfq") {
-				t.Fatal("'cfq' is not a valid scheduler for 'sda'")
+			if !IsValidScheduler("sda", "none") {
+				t.Fatal("'none' is not a valid scheduler for 'sda'")
 			}
 			if IsValidScheduler("sda", "hugo") {
 				t.Fatal("'hugo' is a valid scheduler for 'sda'")

--- a/sap/param/param.go
+++ b/sap/param/param.go
@@ -1,3 +1,5 @@
+package param
+
 /*
 Parameters are tunable switches on the system that are tuned in very specific
 ways.
@@ -9,14 +11,13 @@ and be able to apply the new value upon request.
 There's only one way to tune a parameter, however a parameter can be referred
 to by one or more SAP notes.
 */
-package param
 
 import (
 	"math"
 )
 
 /*
-A tunable parameter, usually calculated based on user input and/or automatically.
+Parameter is a tunable parameter, usually calculated based on user input and/or automatically.
 Parameter is immutable. Internal state changes can only be made to copies.
 */
 type Parameter interface {

--- a/sap/param/param.go
+++ b/sap/param/param.go
@@ -1,10 +1,13 @@
 /*
-Parameters are tunable switches on the system that are tuned in very specific ways.
+Parameters are tunable switches on the system that are tuned in very specific
+ways.
 
-Each tunable parameter is able to inspect the system to determine the current value, calculate a new value according
-to system environment and/or user input, and be able to apply the new value upon request.
+Each tunable parameter is able to inspect the system to determine the current
+value, calculate a new value according to system environment and/or user input,
+and be able to apply the new value upon request.
 
-There's only one way to tune a parameter, however a parameter can be referred to by one or more SAP notes.
+There's only one way to tune a parameter, however a parameter can be referred
+to by one or more SAP notes.
 */
 package param
 
@@ -22,7 +25,8 @@ type Parameter interface {
 	Apply() error                                            // Apply the parameter value without further calculation.
 }
 
-// Return the maximum among the input values. If there isn't any input value, return 0.
+// MaxI64 returns the maximum among the input values.
+// If there isn't any input value, return 0.
 func MaxI64(values ...int64) int64 {
 	var ret int64
 	for _, value := range values {
@@ -33,7 +37,8 @@ func MaxI64(values ...int64) int64 {
 	return ret
 }
 
-// Return the maximum among the input values. If there isn't any input value, return 0.
+// MaxI returns the maximum among the input values.
+// If there isn't any input value, return 0.
 func MaxI(values ...int) int {
 	var ret int
 	for _, value := range values {
@@ -44,7 +49,8 @@ func MaxI(values ...int) int {
 	return ret
 }
 
-// Return the maximum among the input values. If there isn't any input value, return 0.
+// MaxU64 returns the maximum among the input values.
+// If there isn't any input value, return 0.
 func MaxU64(values ...uint64) uint64 {
 	var ret uint64
 	for _, value := range values {
@@ -55,7 +61,8 @@ func MaxU64(values ...uint64) uint64 {
 	return ret
 }
 
-// Return the minimum among the input values. If there isn't any input value, return 0.
+// MinU64 returns the minimum among the input values.
+// If there isn't any input value, return 0.
 func MinU64(values ...uint64) uint64 {
 	if len(values) == 0 {
 		return 0

--- a/sap/solution/solution.go
+++ b/sap/solution/solution.go
@@ -1,9 +1,10 @@
+package solution
+
 /*
 Solutions are collections of relevant SAP notes, all of which are applicable to specific SAP products.
 
 A system can be tuned for more than one solutions at a time.
 */
-package solution
 
 import (
 	"fmt"
@@ -22,15 +23,22 @@ const (
 	NoteTuningSheets      = "/usr/share/saptune/notes/"
 	ArchX86               = "amd64"      // ArchX86 is the GOARCH value for x86 platform.
 	ArchPPC64LE           = "ppc64le"    // ArchPPC64LE is the GOARCH for 64-bit PowerPC little endian platform.
-	ArchX86_PC            = "amd64_PC"   // ArchX86 is the GOARCH value for x86 platform. _PC indicates PageCache is available
-	ArchPPC64LE_PC        = "ppc64le_PC" // ArchPPC64LE is the GOARCH for 64-bit PowerPC little endian platform. _PC indicates PageCache is available
+	ArchX86PC             = "amd64_PC"   // ArchX86 is the GOARCH value for x86 platform. PC indicates PageCache is available
+	ArchPPC64LEPC         = "ppc64le_PC" // ArchPPC64LE is the GOARCH for 64-bit PowerPC little endian platform. PC indicates PageCache is available
 )
 
-type Solution []string // Solution is identified by set of note numbers.
+// Solution is identified by set of note numbers.
+type Solution []string
 
 // Architecture VS solution ID VS note numbers
 // AllSolutions = map[string]map[string]Solution
+
+// AllSolutions contains a list of all available solutions with their related
+// SAP Notes for all supported architectures
 var AllSolutions = GetSolutionDefintion(SolutionSheet)
+
+// OverrideSolutions contains a list of all available override solutions with
+// their related SAP Notes for all supported architectures
 var OverrideSolutions = GetOverrideSolution(OverrideSolutionSheet, NoteTuningSheets)
 
 // GetSolutionDefintion reads solution definition from file
@@ -82,12 +90,12 @@ func GetSolutionDefintion(fileName string) map[string]map[string]Solution {
 	switch currentArch {
 	case "ArchPPC64LE":
 		if system.IsPagecacheAvailable() {
-			sols[ArchPPC64LE_PC] = sol
+			sols[ArchPPC64LEPC] = sol
 		}
 		sols[ArchPPC64LE] = sol
 	case "ArchX86":
 		if system.IsPagecacheAvailable() {
-			sols[ArchX86_PC] = sol
+			sols[ArchX86PC] = sol
 		}
 		sols[ArchX86] = sol
 	}
@@ -153,12 +161,12 @@ func GetOverrideSolution(fileName, noteFiles string) map[string]map[string]Solut
 	switch currentArch {
 	case "ArchPPC64LE":
 		if system.IsPagecacheAvailable() {
-			sols[ArchPPC64LE_PC] = sol
+			sols[ArchPPC64LEPC] = sol
 		}
 		sols[ArchPPC64LE] = sol
 	case "ArchX86":
 		if system.IsPagecacheAvailable() {
-			sols[ArchX86_PC] = sol
+			sols[ArchX86PC] = sol
 		}
 		sols[ArchX86] = sol
 	}

--- a/sap/solution/solution.go
+++ b/sap/solution/solution.go
@@ -6,23 +6,24 @@ A system can be tuned for more than one solutions at a time.
 package solution
 
 import (
+	"fmt"
 	"github.com/SUSE/saptune/system"
 	"github.com/SUSE/saptune/txtparser"
-	"fmt"
 	"log"
 	"os"
 	"sort"
 	"strings"
 )
 
+// solution constant definitions
 const (
 	SolutionSheet         = "/usr/share/saptune/solutions"
 	OverrideSolutionSheet = "/etc/saptune/override/solutions"
 	NoteTuningSheets      = "/usr/share/saptune/notes/"
-	ArchX86     = "amd64"   // ArchX86 is the GOARCH value for x86 platform.
-	ArchPPC64LE = "ppc64le" // ArchPPC64LE is the GOARCH for 64-bit PowerPC little endian platform.
-	ArchX86_PC     = "amd64_PC"   // ArchX86 is the GOARCH value for x86 platform. _PC indicates PageCache is available
-	ArchPPC64LE_PC = "ppc64le_PC" // ArchPPC64LE is the GOARCH for 64-bit PowerPC little endian platform. _PC indicates PageCache is available
+	ArchX86               = "amd64"      // ArchX86 is the GOARCH value for x86 platform.
+	ArchPPC64LE           = "ppc64le"    // ArchPPC64LE is the GOARCH for 64-bit PowerPC little endian platform.
+	ArchX86_PC            = "amd64_PC"   // ArchX86 is the GOARCH value for x86 platform. _PC indicates PageCache is available
+	ArchPPC64LE_PC        = "ppc64le_PC" // ArchPPC64LE is the GOARCH for 64-bit PowerPC little endian platform. _PC indicates PageCache is available
 )
 
 type Solution []string // Solution is identified by set of note numbers.
@@ -32,12 +33,12 @@ type Solution []string // Solution is identified by set of note numbers.
 var AllSolutions = GetSolutionDefintion(SolutionSheet)
 var OverrideSolutions = GetOverrideSolution(OverrideSolutionSheet, NoteTuningSheets)
 
-// read solution definition from file
+// GetSolutionDefintion reads solution definition from file
 // build same structure for AllSolutions as before
 // can be simplyfied later
-func GetSolutionDefintion(fileName string) (map[string]map[string]Solution) {
+func GetSolutionDefintion(fileName string) map[string]map[string]Solution {
 	sols := make(map[string]map[string]Solution)
-	sol  := make(map[string]Solution)
+	sol := make(map[string]Solution)
 	currentArch := ""
 	arch := ""
 	pcarch := ""
@@ -76,7 +77,7 @@ func GetSolutionDefintion(fileName string) (map[string]map[string]Solution) {
 		if len(OverrideSolutions[arch]) != 0 && len(OverrideSolutions[arch][param.Key]) != 0 {
 			param.Value = strings.Join(OverrideSolutions[arch][param.Key], " ")
 		}
-		sol[param.Key] = strings.Split(param.Value,"\t")
+		sol[param.Key] = strings.Split(param.Value, "\t")
 	}
 	switch currentArch {
 	case "ArchPPC64LE":
@@ -93,12 +94,12 @@ func GetSolutionDefintion(fileName string) (map[string]map[string]Solution) {
 	return sols
 }
 
-// read solution override definition from file
+// GetOverrideSolution reads solution override definition from file
 // build same structure for AllSolutions as before
 // can be simplyfied later
-func GetOverrideSolution(fileName, noteFiles string) (map[string]map[string]Solution) {
+func GetOverrideSolution(fileName, noteFiles string) map[string]map[string]Solution {
 	sols := make(map[string]map[string]Solution)
-	sol  := make(map[string]Solution)
+	sol := make(map[string]Solution)
 	currentArch := ""
 	arch := ""
 	pcarch := ""
@@ -111,7 +112,7 @@ func GetOverrideSolution(fileName, noteFiles string) (map[string]map[string]Solu
 	for _, param := range content.AllValues {
 		//check, if all note files used in the override file are available in /usr/share/saptune/note
 		notesOK := true
-		for _, noteID := range strings.Split(content.KeyValue[param.Section][param.Key].Value,"\t") {
+		for _, noteID := range strings.Split(content.KeyValue[param.Section][param.Key].Value, "\t") {
 			if _, err := os.Stat(fmt.Sprintf("%s%s", noteFiles, noteID)); err != nil {
 				log.Printf("Definition for note '%s' used for solution '%s' in override file '%s' not found in %s", noteID, param.Key, fileName, noteFiles)
 				notesOK = false
@@ -147,7 +148,7 @@ func GetOverrideSolution(fileName, noteFiles string) (map[string]map[string]Solu
 				pcarch = "amd64_PC"
 			}
 		}
-		sol[param.Key] = strings.Split(param.Value,"\t")
+		sol[param.Key] = strings.Split(param.Value, "\t")
 	}
 	switch currentArch {
 	case "ArchPPC64LE":
@@ -164,7 +165,7 @@ func GetOverrideSolution(fileName, noteFiles string) (map[string]map[string]Solu
 	return sols
 }
 
-// Return all solution names, sorted alphabetically.
+// GetSortedSolutionNames returns all solution names, sorted alphabetically.
 func GetSortedSolutionNames(archName string) (ret []string) {
 	ret = make([]string, 0, len(AllSolutions))
 	for id := range AllSolutions[archName] {

--- a/system/cmdline.go
+++ b/system/cmdline.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// Parse /proc/cmdline into key(string) - value(string) pairs.
+// ParseCmdline parse /proc/cmdline into key(string) - value(string) pairs.
 // return value for given boot option or 'NA', if not available
 func ParseCmdline(fileName, option string) string {
 	opt := "NA"

--- a/system/cmdline.go
+++ b/system/cmdline.go
@@ -1,5 +1,6 @@
-// Gather information about kernel cmdline
 package system
+
+// Gather information about kernel cmdline
 
 import (
 	"io/ioutil"

--- a/system/cpu.go
+++ b/system/cpu.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 )
 
+//constant definition
 const (
 	notSupported = "System does not support Intel's performance bias setting"
 	forceLatDir  = "/var/lib/saptune/force_latency"
@@ -27,6 +28,7 @@ var isCpu = regexp.MustCompile(`^cpu\d+$`)
 var isState = regexp.MustCompile(`^state\d+$`)
 var forceLatFile = path.Join(forceLatDir, "/sap_force_latency")
 
+// GetPerfBias retrieve CPU performance configuration from the system
 func GetPerfBias() string {
 	isPBCpu := regexp.MustCompile(`analyzing CPU \d+`)
 	isPBias := regexp.MustCompile(`perf-bias: \d+`)
@@ -70,6 +72,7 @@ func GetPerfBias() string {
 	return strings.TrimSpace(str)
 }
 
+// SetPerfBias set CPU performance configuration to the system using 'cpupower' command
 func SetPerfBias(value string) error {
 	//cmd := exec.Command("cpupower", "-c", "all", "set", "-b", value)
 	cpu := ""
@@ -93,6 +96,7 @@ func SetPerfBias(value string) error {
 	return nil
 }
 
+// SupportsPerfBias check, if the system will support CPU performance settings
 func SupportsPerfBias() bool {
 	cmdName := cpupower_cmd
 	cmdArgs := []string{"info", "-b"}
@@ -109,6 +113,8 @@ func SupportsPerfBias() bool {
 	return true
 }
 
+// GetGovernor retrieve performance configuration regarding to cpu frequency
+// from the system
 func GetGovernor() map[string]string {
 	setAll := true
 	oldgov := "99"
@@ -116,10 +122,10 @@ func GetGovernor() map[string]string {
 	gGov := make(map[string]string)
 
 	dirCont, err := ioutil.ReadDir(cpu_dir)
-        if err != nil {
-                return gGov
-        }
-        for _, entry := range dirCont {
+	if err != nil {
+		return gGov
+	}
+	for _, entry := range dirCont {
 		if isCpu.MatchString(entry.Name()) {
 			gov, _ = GetSysString(path.Join(cpu_dir_sys, entry.Name(), "cpufreq", "scaling_governor"))
 			if gov == "" {
@@ -142,6 +148,8 @@ func GetGovernor() map[string]string {
 	return gGov
 }
 
+// SetGovernor set performance configuration regarding to cpu frequency
+// to the system using 'cpupower' command
 func SetGovernor(value string) error {
 	//cmd := exec.Command("cpupower", "-c", "all", "frequency-set", "-g", value)
 	cpu := ""
@@ -174,6 +182,7 @@ func SetGovernor(value string) error {
 	return nil
 }
 
+// IsValidGovernor check, if the system will support CPU frequency settings
 func IsValidGovernor(cpu, gov string) bool {
 	val, err := ioutil.ReadFile(path.Join(cpu_dir, cpu, "/cpufreq/scaling_available_governors"))
 	if err == nil && strings.Contains(string(val), gov) {
@@ -182,6 +191,7 @@ func IsValidGovernor(cpu, gov string) bool {
 	return false
 }
 
+// GetForceLatency retrieve CPU latency configuration from the system
 func GetForceLatency() string {
 	flval := ""
 	supported := false
@@ -190,10 +200,10 @@ func GetForceLatency() string {
 	// on VMs it's not supported
 
 	dirCont, err := ioutil.ReadDir(cpu_dir)
-        if err != nil {
+	if err != nil {
 		return "all:none"
-        }
-        for _, entry := range dirCont {
+	}
+	for _, entry := range dirCont {
 		// cpu0 ... cpuXY
 		if isCpu.MatchString(entry.Name()) {
 			_, err := ioutil.ReadDir(path.Join(cpu_dir, entry.Name(), "cpuidle"))
@@ -217,9 +227,10 @@ func GetForceLatency() string {
 	} else {
 		flval = string(val)
 	}
-        return flval
+	return flval
 }
 
+// SetForceLatency set CPU latency configuration to the system
 func SetForceLatency(noteId, value string, revert bool) error {
 	oldLat := ""
 	oldLatStates := make(map[string]string)
@@ -240,10 +251,10 @@ func SetForceLatency(noteId, value string, revert bool) error {
 	}
 
 	dirCont, err := ioutil.ReadDir(cpu_dir)
-        if err != nil {
+	if err != nil {
 		return fmt.Errorf("latency settings not supported by the system")
-        }
-        for _, entry := range dirCont {
+	}
+	for _, entry := range dirCont {
 		// cpu0 ... cpuXY
 		if isCpu.MatchString(entry.Name()) {
 			cpudirCont, err := ioutil.ReadDir(path.Join(cpu_dir, entry.Name(), "cpuidle"))
@@ -320,6 +331,7 @@ func SetForceLatency(noteId, value string, revert bool) error {
 	return err
 }
 
+// GetdmaLatency retrieve DMA latency configuration from the system
 func GetdmaLatency() string {
 	latency := make([]byte, 4)
 	dmaLatency, err := os.OpenFile("/dev/cpu_dma_latency", os.O_RDONLY, 0600)

--- a/system/cpu_test.go
+++ b/system/cpu_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 )
 
-
 func TestSupportsPerfBias(t *testing.T) {
 	if !IsUserRoot() {
 		t.Skip("the test requires root access")

--- a/system/daemon.go
+++ b/system/daemon.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 )
 
-// Cal systemctl enable and then systemctl start on thing. Panic on error.
+// SystemctlEnableStart call systemctl enable and then systemctl start on thing.
+// Panic on error.
 func SystemctlEnableStart(thing string) error {
 	if out, err := exec.Command("systemctl", "enable", thing).CombinedOutput(); err != nil {
 		return fmt.Errorf("Failed to call systemctl enable on %s - %v %s", thing, err, string(out))
@@ -18,7 +19,8 @@ func SystemctlEnableStart(thing string) error {
 	return nil
 }
 
-// Cal systemctl disable and then systemctl stop on thing. Panic on error.
+// SystemctlDisableStop call systemctl disable and then systemctl stop on thing.
+// Panic on error.
 func SystemctlDisableStop(thing string) error {
 	if out, err := exec.Command("systemctl", "disable", thing).CombinedOutput(); err != nil {
 		return fmt.Errorf("Failed to call systemctl disable on %s - %v %s", thing, err, string(out))
@@ -29,7 +31,8 @@ func SystemctlDisableStop(thing string) error {
 	return nil
 }
 
-// Return true only if systemctl suggests that the thing is running.
+// SystemctlIsRunning return true only if systemctl suggests that the thing is
+// running.
 func SystemctlIsRunning(thing string) bool {
 	if _, err := exec.Command("systemctl", "is-active", thing).CombinedOutput(); err == nil {
 		return true
@@ -37,16 +40,18 @@ func SystemctlIsRunning(thing string) bool {
 	return false
 }
 
-// Write new profile to tuned, used instead of sometimes unreliable 'tuned-adm' command
+// WriteTunedAdmProfile write new profile to tuned, used instead of sometimes
+// unreliable 'tuned-adm' command
 func WriteTunedAdmProfile(profileName string) error {
 	err := ioutil.WriteFile("/etc/tuned/active_profile", []byte(profileName), 0644)
 	if err != nil {
 		return fmt.Errorf("Failed to write tuned profile '%s' to '%s': %v", profileName, "/etc/tuned/active_profile", err)
-        }
-        return nil
+	}
+	return nil
 }
 
-// Return the currently active tuned profile. Return empty string if it cannot be determined.
+// GetTunedProfile return the currently active tuned profile.
+// Return empty string if it cannot be determined.
 func GetTunedProfile() string {
 	content, err := ioutil.ReadFile("/etc/tuned/active_profile")
 	if err != nil {

--- a/system/fs.go
+++ b/system/fs.go
@@ -13,7 +13,7 @@ import (
 
 var mountOptionSeparator = regexp.MustCompile("[[:space:]]*,[[:space:]]*")
 
-// Represent a mount point entry in /proc/mounts or /etc/fstab
+// MountPoint Represent a mount point entry in /proc/mounts or /etc/fstab
 type MountPoint struct {
 	Device     string
 	MountPoint string
@@ -23,12 +23,13 @@ type MountPoint struct {
 	Fsck       int
 }
 
-// Return true only if two mount points are identical in all attributes.
+// Equals return true only if two mount points are identical in all attributes.
 func (mount1 MountPoint) Equals(mount2 MountPoint) bool {
 	return reflect.DeepEqual(mount1, mount2)
 }
 
-// Return the total size of the file system in MegaBytes. Panic on error.
+// GetFileSystemSizeMB return the total size of the file system in MegaBytes.
+// Panic on error.
 func (mount MountPoint) GetFileSystemSizeMB() uint64 {
 	fs := syscall.Statfs_t{}
 	err := syscall.Statfs(mount.MountPoint, &fs)
@@ -41,7 +42,7 @@ func (mount MountPoint) GetFileSystemSizeMB() uint64 {
 // A list of mount points.
 type MountPoints []MountPoint
 
-// Find a mount point by its path.
+// GetByMountPoint find a mount point by its path.
 func (mounts MountPoints) GetByMountPoint(mountPoint string) (MountPoint, bool) {
 	for _, mount := range mounts {
 		if mount.MountPoint == mountPoint {
@@ -51,7 +52,8 @@ func (mounts MountPoints) GetByMountPoint(mountPoint string) (MountPoint, bool) 
 	return MountPoint{}, false
 }
 
-// Return all mount points defined in the input text. Panic on malformed entry.
+// ParseMounts return all mount points defined in the input text.
+// Panic on malformed entry.
 func ParseMounts(txt string) (mounts MountPoints) {
 	mounts = make([]MountPoint, 0, 0)
 	for _, line := range strings.Split(txt, "\n") {
@@ -81,7 +83,7 @@ func ParseMounts(txt string) (mounts MountPoints) {
 	return
 }
 
-// Return all mount points defined in /etc/fstab. Panic on error.
+// ParseFstab return all mount points defined in /etc/fstab. Panic on error.
 func ParseFstab() MountPoints {
 	fstab, err := ioutil.ReadFile("/etc/fstab")
 	if err != nil {
@@ -90,7 +92,8 @@ func ParseFstab() MountPoints {
 	return ParseMounts(string(fstab))
 }
 
-// Return all mount points appearing in /proc/mounts. Panic on error.
+// ParseProcMounts return all mount points appearing in /proc/mounts.
+// Panic on error.
 func ParseProcMounts() MountPoints {
 	mounts, err := ioutil.ReadFile("/proc/mounts")
 	if err != nil {
@@ -99,7 +102,8 @@ func ParseProcMounts() MountPoints {
 	return ParseMounts(string(mounts))
 }
 
-// Return all mount points appearing in /proc/mounts. Panic on error.
+// ParseMtabMounts return all mount points appearing in /proc/mounts.
+// Panic on error.
 func ParseMtabMounts() MountPoints {
 	mounts, err := ioutil.ReadFile("/etc/mtab")
 	if err != nil {
@@ -108,7 +112,7 @@ func ParseMtabMounts() MountPoints {
 	return ParseMounts(string(mounts))
 }
 
-// Invoke mount command to resize /dev/shm to the specified value.
+// RemountSHM invoke mount command to resize /dev/shm to the specified value.
 func RemountSHM(newSizeMB uint64) error {
 	cmd := exec.Command("mount", "-o", fmt.Sprintf("remount,size=%dM", newSizeMB), "/dev/shm")
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -117,7 +121,7 @@ func RemountSHM(newSizeMB uint64) error {
 	return nil
 }
 
-// List directory content.
+// ListDir list directory content.
 func ListDir(dirPath string) (dirNames, fileNames []string, err error) {
 	entries, err := ioutil.ReadDir(dirPath)
 	if err != nil {

--- a/system/fs.go
+++ b/system/fs.go
@@ -39,7 +39,7 @@ func (mount MountPoint) GetFileSystemSizeMB() uint64 {
 	return uint64(fs.Bsize) * fs.Blocks / 1048576
 }
 
-// A list of mount points.
+// MountPoints contains a list of mount points.
 type MountPoints []MountPoint
 
 // GetByMountPoint find a mount point by its path.

--- a/system/limits.go
+++ b/system/limits.go
@@ -27,10 +27,8 @@ func (limit SecurityLimitInt) String() string {
 	return strconv.Itoa(int(limit))
 }
 
-/*
-ToSecurityLimitInt interprets integer limit number from input string. If the input cannot be parsed successfully, it
-will return a default 0 value.
-*/
+// ToSecurityLimitInt interprets integer limit number from input string.
+// If the input cannot be parsed successfully, it will return a default 0 value.
 func ToSecurityLimitInt(in string) SecurityLimitInt {
 	in = strings.TrimSpace(in)
 	for _, match := range SecurityLimitUnlimitedString {
@@ -49,12 +47,14 @@ type SecLimitsEntry struct {
 	Value              string
 }
 
-// Entries of security/limits.conf file. It is able to convert back to original text in the original entry order.
+// SecLimits Entries of security/limits.conf file. It is able to convert back
+// to original text in the original entry order.
 type SecLimits struct {
 	Entries []*SecLimitsEntry
 }
 
-// Read limits.conf and parse the file content into memory structures.
+// ParseSecLimitsFile read limits.conf and parse the file content into memory
+// structures.
 func ParseSecLimitsFile() (*SecLimits, error) {
 	content, err := ioutil.ReadFile("/etc/security/limits.conf")
 	if err != nil {
@@ -63,7 +63,7 @@ func ParseSecLimitsFile() (*SecLimits, error) {
 	return ParseSecLimits(string(content)), nil
 }
 
-// Read limits.conf text and parse the text into memory structures.
+// ParseSecLimits read limits.conf text and parse the text into memory structures.
 func ParseSecLimits(input string) *SecLimits {
 	limits := &SecLimits{Entries: make([]*SecLimitsEntry, 0, 0)}
 	leadingComments := make([]string, 0, 0)
@@ -107,7 +107,7 @@ func ParseSecLimits(input string) *SecLimits {
 	return limits
 }
 
-// Return string value that belongs to the entry.
+// Get return string value that belongs to the entry.
 func (limits *SecLimits) Get(domain, typeName, item string) (string, bool) {
 	for _, entry := range limits.Entries {
 		if entry.Domain == domain && entry.Type == typeName && entry.Item == item {
@@ -117,10 +117,8 @@ func (limits *SecLimits) Get(domain, typeName, item string) (string, bool) {
 	return "", false
 }
 
-/*
-GetOrUnlimited retrieves an integer limit value and return. If the value is not specified or cannot be parsed correctly,
-the 0 value will be returned.
-*/
+// GetOr0 retrieves an integer limit value and return.
+// If the value is not specified or cannot be parsed correctly, 0 will be returned.
 func (limits *SecLimits) GetOr0(domain, typeName, item string) SecurityLimitInt {
 	val, _ := limits.Get(domain, typeName, item)
 	return ToSecurityLimitInt(val)
@@ -143,7 +141,7 @@ func (limits *SecLimits) Set(domain, typeName, item, value string) {
 	})
 }
 
-// Convert the entries back into text.
+// ToText convert the entries back into text.
 func (limits *SecLimits) ToText() string {
 	var ret bytes.Buffer
 	for _, entry := range limits.Entries {
@@ -159,7 +157,7 @@ func (limits *SecLimits) ToText() string {
 	return ret.String()
 }
 
-// Overwrite /etc/security/limits.conf with the content of this structure.
+// Apply overwrite /etc/security/limits.conf with the content of this structure.
 func (limits *SecLimits) Apply() error {
 	return ioutil.WriteFile("/etc/security/limits.conf", []byte(limits.ToText()), 0644)
 }

--- a/system/limits.go
+++ b/system/limits.go
@@ -1,5 +1,6 @@
-// Implement a parser for /etc/security/limits.conf.
 package system
+
+// Implement a parser for /etc/security/limits.conf.
 
 import (
 	"bytes"
@@ -12,7 +13,8 @@ import (
 
 var consecutiveSpaces = regexp.MustCompile("[[:space:]]+")
 
-type SecurityLimitInt int // SecurityLimitInt is an integer number where -1 represents unlimited value.
+// SecurityLimitInt is an integer number where -1 represents unlimited value.
+type SecurityLimitInt int
 
 // SecurityLimitUnlimitedValue is the constant integer value that represents unrestricted limit.
 const SecurityLimitUnlimitedValue = SecurityLimitInt(-1)
@@ -40,7 +42,7 @@ func ToSecurityLimitInt(in string) SecurityLimitInt {
 	return SecurityLimitInt(i)
 }
 
-// A single entry in security/limits.conf file.
+// SecLimitsEntry is a single entry in security/limits.conf file.
 type SecLimitsEntry struct {
 	LeadingComments    []string // The comment lines leading to the key-value pair, including prefix '#', excluding end-of-line.
 	Domain, Type, Item string

--- a/system/limits.go
+++ b/system/limits.go
@@ -152,7 +152,7 @@ func (limits *SecLimits) ToText() string {
 			ret.WriteRune('\n')
 		}
 		// prevent useless empty lines
-		if entry.Domain != "" && entry.Type != "" && entry.Item != "" {
+		if entry.Domain != "" && entry.Type != "" && entry.Item != "" && entry.Value != "" {
 			ret.WriteString(fmt.Sprintf("%s %s %s %s\n", entry.Domain, entry.Type, entry.Item, entry.Value))
 		}
 	}

--- a/system/mem.go
+++ b/system/mem.go
@@ -1,5 +1,6 @@
-// Gather information about system memory and swap memory.
 package system
+
+// Gather information about system memory and swap memory.
 
 import (
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"strings"
 )
 
+// string definitions for parsing /proc/meminfo output
 const (
 	MemMainTotalKey = "MemTotal"
 	MemSwapTotalKey = "SwapTotal"

--- a/system/mem.go
+++ b/system/mem.go
@@ -14,7 +14,8 @@ const (
 	MemSwapTotalKey = "SwapTotal"
 )
 
-// Parse /proc/meminfo into key(string) - value(int) pairs. Panic on error.
+// ParseMeminfo parse /proc/meminfo into key(string) - value(int) pairs.
+// Panic on error.
 func ParseMeminfo() (infoMap map[string]uint64) {
 	infoMap = make(map[string]uint64)
 	memInfo, err := ioutil.ReadFile("/proc/meminfo")
@@ -38,22 +39,25 @@ func ParseMeminfo() (infoMap map[string]uint64) {
 	return
 }
 
-// Return size of system main memory, excluding swap. Panic on error.
+// GetMainMemSizeMB return size of system main memory, excluding swap.
+// Panic on error.
 func GetMainMemSizeMB() uint64 {
 	return ParseMeminfo()[MemMainTotalKey] / 1024
 }
 
-// Return size of system main memory plus swap. Panic on error.
+// GetTotalMemSizeMB return size of system main memory plus swap.
+// Panic on error.
 func GetTotalMemSizeMB() uint64 {
 	return (ParseMeminfo()[MemMainTotalKey] + ParseMeminfo()[MemSwapTotalKey]) / 1024
 }
 
-// Return size of system main memory plus swap, in pages. Panic on error.
+// GetTotalMemSizePages return size of system main memory plus swap, in pages.
+// Panic on error.
 func GetTotalMemSizePages() uint64 {
 	return (ParseMeminfo()[MemMainTotalKey] + ParseMeminfo()[MemSwapTotalKey]) / uint64(os.Getpagesize())
 }
 
-// Return kernel semaphore limits. Panic on error.
+// GetSemaphoreLimits return kernel semaphore limits. Panic on error.
 func GetSemaphoreLimits() (msl, mns, opm, mni uint64) {
 	field, err := GetSysctlString("kernel.sem")
 	if err != nil {

--- a/system/rpm.go
+++ b/system/rpm.go
@@ -11,6 +11,7 @@ import (
 
 var alphanumPattern = regexp.MustCompile("([a-zA-Z]+)|([0-9]+)|(~)")
 
+// GetRpmVers return the version of an installed RPM
 func GetRpmVers(rpm string) string {
 	// rpm -q --qf '%{VERSION}-%{RELEASE}\n' glibc
 	notInstalled := fmt.Sprintf("package %s is not installed", rpm)
@@ -32,7 +33,6 @@ func GetRpmVers(rpm string) string {
 	return rpmVers
 }
 
-
 /* compare rpm versions
 func CmpRpmVers, func CheckRpmVers
 build on base of information from http://rpm.org/user_doc/dependencies.html
@@ -40,12 +40,16 @@ and https://github.com/rpm-software-management/rpm/blob/master/lib/rpmvercmp.c
 Equal == 0, GreaterThan > 0, LessThan < 0
 vers1 is '228-150.22.1', vers2 is '228-142.1'
 */
+
+// CmpRpmVers compare versions of 2 RPMs (installed version, expected version)
+// Return true, if installed package version is equal or higher than expected
+// Return false, if installed package version is less than expected
 func CmpRpmVers(vers1, vers2 string) bool {
 	if vers1 == "" {
 		// package not installed
 		return false
 	}
-	if vers1  == vers2 {
+	if vers1 == vers2 {
 		// rpm version and release are equal
 		return true
 	}
@@ -72,6 +76,8 @@ func CmpRpmVers(vers1, vers2 string) bool {
 	}
 }
 
+// CheckRpmVers compare versions of 2 RPMs (installed version, expected version)
+// Return 0 (Equal), 1 (GreaterThan) or -1 (LessThan)
 func CheckRpmVers(vers1, vers2 string) int {
 	// per definition numbers are greater than alphas
 	if vers1 == vers2 {

--- a/system/rpm.go
+++ b/system/rpm.go
@@ -1,5 +1,6 @@
-// wrapper to rpm command
 package system
+
+// wrapper to rpm command
 
 import (
 	"fmt"
@@ -70,10 +71,9 @@ func CmpRpmVers(vers1, vers2 string) bool {
 	if ret < 0 {
 		// installed package release is less than expected
 		return false
-	} else {
-		// installed package release is equal or higher than expected
-		return true
 	}
+	// installed package release is equal or higher than expected
+	return true
 }
 
 // CheckRpmVers compare versions of 2 RPMs (installed version, expected version)

--- a/system/sys.go
+++ b/system/sys.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-// Read a /sys/ key and return the string value.
+// GetSysString read a /sys/ key and return the string value.
 func GetSysString(parameter string) (string, error) {
 	val, err := ioutil.ReadFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)))
 	if err != nil {
@@ -18,7 +18,8 @@ func GetSysString(parameter string) (string, error) {
 	return strings.TrimSpace(string(val)), nil
 }
 
-// Read a /sys/ key that comes with current value and alternative choices, return the current choice or empty string.
+// GetSysChoice read a /sys/ key that comes with current value and alternative
+// choices, return the current choice or empty string.
 func GetSysChoice(parameter string) (string, error) {
 	val, err := ioutil.ReadFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)))
 	if err != nil {
@@ -34,7 +35,7 @@ func GetSysChoice(parameter string) (string, error) {
 	return "", nil
 }
 
-// Read an integer /sys/ key.
+// GetSysInt read an integer /sys/ key.
 func GetSysInt(parameter string) (int, error) {
 	value, err := GetSysString(parameter)
 	if err != nil {
@@ -43,7 +44,7 @@ func GetSysInt(parameter string) (int, error) {
 	return strconv.Atoi(value)
 }
 
-// Write a string /sys/ value.
+// SetSysString write a string /sys/ value.
 func SetSysString(parameter, value string) error {
 	if err := ioutil.WriteFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644); err != nil {
 		return fmt.Errorf("failed to set sys key '%s' to string '%s': %v", parameter, value, err)
@@ -51,12 +52,12 @@ func SetSysString(parameter, value string) error {
 	return nil
 }
 
-// Write an integer /sys/ value.
+// SetSysInt write an integer /sys/ value.
 func SetSysInt(parameter string, value int) error {
 	return SetSysString(parameter, strconv.Itoa(value))
 }
 
-// Test writing a string /sys/ value.
+// TestSysString Test writing a string /sys/ value.
 func TestSysString(parameter, value string) error {
 	save, err := GetSysString(parameter)
 	if err != nil {

--- a/system/sys.go
+++ b/system/sys.go
@@ -1,5 +1,6 @@
-// Manipulate /sys/ switches.
 package system
+
+// Manipulate /sys/ switches.
 
 import (
 	"fmt"

--- a/system/sysctl.go
+++ b/system/sysctl.go
@@ -1,5 +1,6 @@
-// Manipulate sysctl switches.
 package system
+
+// Manipulate sysctl switches.
 
 import (
 	"fmt"

--- a/system/sysctl.go
+++ b/system/sysctl.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 )
 
+// mapping of system parameter names to configuration names
 const (
 	SysctlPagecacheLimitMB          = "vm.pagecache_limit_mb"
 	SysctlPagecacheLimitIgnoreDirty = "vm.pagecache_limit_ignore_dirty"
@@ -63,7 +64,7 @@ const (
 	SysctlRunChildFirst             = "kernel.sched_child_runs_first"
 )
 
-// Read a sysctl key and return the string value.
+// GetSysctlString read a sysctl key and return the string value.
 func GetSysctlString(parameter string) (string, error) {
 	val, err := ioutil.ReadFile(path.Join("/proc/sys", strings.Replace(parameter, ".", "/", -1)))
 	if err != nil {
@@ -72,7 +73,7 @@ func GetSysctlString(parameter string) (string, error) {
 	return strings.TrimSpace(string(val)), nil
 }
 
-// Read an integer sysctl key.
+// GetSysctlInt read an integer sysctl key.
 func GetSysctlInt(parameter string) (int, error) {
 	value, err := GetSysctlString(parameter)
 	if err != nil {
@@ -81,7 +82,7 @@ func GetSysctlInt(parameter string) (int, error) {
 	return strconv.Atoi(value)
 }
 
-// Read an uint64 sysctl key.
+// GetSysctlUint64 read an uint64 sysctl key.
 func GetSysctlUint64(parameter string) (uint64, error) {
 	value, err := GetSysctlString(parameter)
 	if err != nil {
@@ -90,7 +91,7 @@ func GetSysctlUint64(parameter string) (uint64, error) {
 	return strconv.ParseUint(value, 10, 64)
 }
 
-// Write a string sysctl value.
+// SetSysctlString write a string sysctl value.
 func SetSysctlString(parameter, value string) error {
 	err := ioutil.WriteFile(path.Join("/proc/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644)
 	if os.IsNotExist(err) {
@@ -101,19 +102,19 @@ func SetSysctlString(parameter, value string) error {
 	return nil
 }
 
-// Write an integer sysctl value.
+// SetSysctlInt write an integer sysctl value.
 func SetSysctlInt(parameter string, value int) error {
 	err := SetSysctlString(parameter, strconv.Itoa(value))
 	return err
 }
 
-// Write an integer sysctl value.
+// SetSysctlUint64 write an integer sysctl value.
 func SetSysctlUint64(parameter string, value uint64) error {
 	err := SetSysctlString(parameter, strconv.FormatUint(value, 10))
 	return err
 }
 
-// Write an integer sysctl value into the specified field pf the key.
+// SetSysctlUint64Field write an integer sysctl value into the specified field pf the key.
 func SetSysctlUint64Field(param string, field int, value uint64) error {
 	fields, err := GetSysctlString(param)
 	if err != nil {
@@ -129,10 +130,11 @@ func SetSysctlUint64Field(param string, field int, value uint64) error {
 	return err
 }
 
+// IsPagecacheAvailable check, if system supports pagecache limit
 func IsPagecacheAvailable() bool {
-        _, err := ioutil.ReadFile(path.Join("/proc/sys", strings.Replace(SysctlPagecacheLimitMB, ".", "/", -1)))
-        if err == nil {
-                return true
-        }
-        return false
+	_, err := ioutil.ReadFile(path.Join("/proc/sys", strings.Replace(SysctlPagecacheLimitMB, ".", "/", -1)))
+	if err == nil {
+		return true
+	}
+	return false
 }

--- a/system/system.go
+++ b/system/system.go
@@ -6,12 +6,12 @@ import (
 	"regexp"
 )
 
-// Return true only if the current user is root.
+// IsUserRoot return true only if the current user is root.
 func IsUserRoot() bool {
 	return os.Getuid() == 0
 }
 
-// Returns true, if the cmd is available.
+// CmdIsAvailable returns true, if the cmd is available.
 func CmdIsAvailable(cmdName string) bool {
 	if _, err := os.Stat(cmdName); os.IsNotExist(err) {
 		return false
@@ -19,6 +19,7 @@ func CmdIsAvailable(cmdName string) bool {
 	return true
 }
 
+// GetOsVers returns the OS version
 func GetOsVers() string {
 	// VERSION="12", VERSION="15"
 	// VERSION="12-SP1", VERSION="12-SP2", VERSION="12-SP3"
@@ -34,6 +35,7 @@ func GetOsVers() string {
 	return matches[1]
 }
 
+// GetOsName returns the OS name
 func GetOsName() string {
 	// NAME="SLES"
 	var re = regexp.MustCompile(`NAME="([\w\s]+)"`)

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 )
 
-
 func TestIsUserRoot(t *testing.T) {
 	if !IsUserRoot() {
 		t.Log("the test requires root access")

--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 )
 
+// Operator definitions
 const (
 	OperatorLessThan      = "<"
 	OperatorLessThanEqual = "<="
@@ -18,11 +19,13 @@ const (
 	OperatorEqual         = "="
 )
 
-type Operator string // The comparison or assignment operator used in an INI file entry
+// Operator is the comparison or assignment operator used in an INI file entry
+type Operator string
 
-var RegexKeyOperatorValue = regexp.MustCompile(`([\w.+_-]+)\s*([<=>]+)\s*["']*(.*?)["']*$`) // Break up a line into key, operator, value.
+// RegexKeyOperatorValue breaks up a line into key, operator, value.
+var RegexKeyOperatorValue = regexp.MustCompile(`([\w.+_-]+)\s*([<=>]+)\s*["']*(.*?)["']*$`)
 
-// A single key-value pair in INI file.
+// INIEntry contains a single key-value pair in INI file.
 type INIEntry struct {
 	Section  string
 	Key      string
@@ -30,7 +33,7 @@ type INIEntry struct {
 	Value    string
 }
 
-// All key-value pairs of an INI file.
+// INIFile contains all key-value pairs of an INI file.
 type INIFile struct {
 	AllValues []INIEntry
 	KeyValue  map[string]map[string]INIEntry

--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -1,8 +1,8 @@
 package txtparser
 
 import (
-	"github.com/SUSE/saptune/system"
 	"fmt"
+	"github.com/SUSE/saptune/system"
 	"io/ioutil"
 	"os"
 	"path"
@@ -36,6 +36,7 @@ type INIFile struct {
 	KeyValue  map[string]map[string]INIEntry
 }
 
+// GetINIFileDescriptiveName return the descriptive name of the Note
 func GetINIFileDescriptiveName(fileName string) string {
 	var re = regexp.MustCompile(`# SAP-NOTE=.*VERSION=(\d*)\s*DATE=(.*)\s*NAME="([^"]*)"`)
 	rval := ""
@@ -50,6 +51,7 @@ func GetINIFileDescriptiveName(fileName string) string {
 	return rval
 }
 
+// GetINIFileCategory return the category the Note belongs to
 func GetINIFileCategory(fileName string) string {
 	var re = regexp.MustCompile(`# SAP-NOTE=.*CATEGORY=(\w*)\s*VERSION=.*"`)
 	rval := ""
@@ -64,6 +66,8 @@ func GetINIFileCategory(fileName string) string {
 	return rval
 }
 
+// GetINIFileVersion return the version of the Note used to setup the Note
+// configuration file
 func GetINIFileVersion(fileName string) string {
 	var re = regexp.MustCompile(`# SAP-NOTE=.*VERSION=(\d*)\s*DATE=.*"`)
 	rval := ""
@@ -78,6 +82,7 @@ func GetINIFileVersion(fileName string) string {
 	return rval
 }
 
+// ParseINIFile read the content of the configuration file
 func ParseINIFile(fileName string, autoCreate bool) (*INIFile, error) {
 	content, err := ioutil.ReadFile(fileName)
 	if os.IsNotExist(err) && autoCreate {
@@ -96,6 +101,7 @@ func ParseINIFile(fileName string, autoCreate bool) (*INIFile, error) {
 	return ParseINI(string(content)), nil
 }
 
+// ParseINI parse the content of the configuration file
 func ParseINI(input string) *INIFile {
 	ret := &INIFile{
 		AllValues: make([]INIEntry, 0, 64),
@@ -138,7 +144,7 @@ func ParseINI(input string) *INIFile {
 		if currentSection == "rpm" {
 			fields := strings.Fields(line)
 			if fields[1] == "all" || fields[1] == system.GetOsVers() {
-				kov = []string {"rpm", "rpm:" + fields[0], fields[1], fields[2]}
+				kov = []string{"rpm", "rpm:" + fields[0], fields[1], fields[2]}
 			} else {
 				kov = nil
 			}

--- a/txtparser/sysconfig.go
+++ b/txtparser/sysconfig.go
@@ -27,7 +27,8 @@ type Sysconfig struct {
 	KeyValue  map[string]*SysconfigEntry
 }
 
-// Read sysconfig file and parse the file content into memory structures.
+// ParseSysconfigFile read sysconfig file and parse the file content into
+// memory structures.
 func ParseSysconfigFile(fileName string, autoCreate bool) (*Sysconfig, error) {
 	content, err := ioutil.ReadFile(fileName)
 	if os.IsNotExist(err) && autoCreate {
@@ -46,7 +47,7 @@ func ParseSysconfigFile(fileName string, autoCreate bool) (*Sysconfig, error) {
 	return ParseSysconfig(string(content))
 }
 
-// Read sysconfig text and parse the text into memory structures.
+// ParseSysconfig read sysconfig text and parse the text into memory structures.
 func ParseSysconfig(input string) (*Sysconfig, error) {
 	conf := &Sysconfig{
 		AllValues: make([]*SysconfigEntry, 0, 0),
@@ -96,7 +97,8 @@ func (conf *Sysconfig) Set(key string, value interface{}) {
 	conf.KeyValue[key] = kv
 }
 
-// Give a space-separated integer array value to a key. If the key does not yet exist, it is created.
+// SetIntArray give a space-separated integer array value to a key.
+// If the key does not yet exist, it is created.
 func (conf *Sysconfig) SetIntArray(key string, values []int) {
 	strs := make([]string, len(values))
 	for i, val := range values {
@@ -105,12 +107,14 @@ func (conf *Sysconfig) SetIntArray(key string, values []int) {
 	conf.Set(key, strings.Join(strs, " "))
 }
 
-// Give a space-separated string array value to a key. If the key does not yet exist, it is created.
+// SetStrArray give a space-separated string array value to a key.
+// If the key does not yet exist, it is created.
 func (conf *Sysconfig) SetStrArray(key string, values []string) {
 	conf.Set(key, strings.Join(values, " "))
 }
 
-// Return integer value that belongs to the key, or the default value if the key does not exist or value is not an integer.
+// GetInt return integer value that belongs to the key, or the default value
+// if the key does not exist or value is not an integer.
 func (conf *Sysconfig) GetInt(key string, defaultValue int) int {
 	entry, exists := conf.KeyValue[key]
 	if !exists {
@@ -123,7 +127,8 @@ func (conf *Sysconfig) GetInt(key string, defaultValue int) int {
 	return intValue
 }
 
-// Return uint64 value that belongs to the key, or the default value if the key does not exist or value is not an integer.
+// GetUint64 return uint64 value that belongs to the key, or the default value
+// if the key does not exist or value is not an integer.
 func (conf *Sysconfig) GetUint64(key string, defaultValue uint64) uint64 {
 	entry, exists := conf.KeyValue[key]
 	if !exists {
@@ -136,7 +141,8 @@ func (conf *Sysconfig) GetUint64(key string, defaultValue uint64) uint64 {
 	return intValue
 }
 
-// Return string value that belongs to the key, or the default value if the key does not exist.
+// GetString return string value that belongs to the key, or the default value
+// if the key does not exist.
 func (conf *Sysconfig) GetString(key, defaultValue string) string {
 	entry, exists := conf.KeyValue[key]
 	if !exists || strings.TrimSpace(entry.Value) == "" {
@@ -145,7 +151,8 @@ func (conf *Sysconfig) GetString(key, defaultValue string) string {
 	return strings.TrimSpace(entry.Value)
 }
 
-// Assume the key carries a space-separated array value, return the value array.
+// GetStringArray assume the key carries a space-separated array value,
+// return the value array.
 func (conf *Sysconfig) GetStringArray(key string, defaultValue []string) (ret []string) {
 	entry, exists := conf.KeyValue[key]
 	if !exists {
@@ -161,7 +168,8 @@ func (conf *Sysconfig) GetStringArray(key string, defaultValue []string) (ret []
 	return
 }
 
-// Assume the key carries a space-separated array of integers, return the array. Discard malformed integers.
+// GetIntArray assume the key carries a space-separated array of integers,
+// return the array. Discard malformed integers.
 func (conf *Sysconfig) GetIntArray(key string, defaultValue []int) (ret []int) {
 	entry, exists := conf.KeyValue[key]
 	if !exists {
@@ -178,7 +186,8 @@ func (conf *Sysconfig) GetIntArray(key string, defaultValue []int) (ret []int) {
 	return
 }
 
-// Return bool value that belongs to the key, or the default value if key does not exist.
+// GetBool return bool value that belongs to the key, or the default value
+// if key does not exist.
 // True values are "yes" or "true".
 func (conf *Sysconfig) GetBool(key string, defaultValue bool) bool {
 	defaultValStr := "no"
@@ -189,7 +198,8 @@ func (conf *Sysconfig) GetBool(key string, defaultValue bool) bool {
 	return (value == "yes" || value == "true")
 }
 
-// Convert key-value pairs back into text. Values are always surrounded by double-quotes.
+// ToText convert key-value pairs back into text.
+// Values are always surrounded by double-quotes.
 func (conf *Sysconfig) ToText() string {
 	var ret bytes.Buffer
 	for _, kv := range conf.AllValues {

--- a/txtparser/sysconfig.go
+++ b/txtparser/sysconfig.go
@@ -1,5 +1,6 @@
-// Implement a universal parser for /etc/sysconfig files.
 package txtparser
+
+// Implement a universal parser for /etc/sysconfig files.
 
 import (
 	"bytes"
@@ -14,14 +15,15 @@ import (
 
 var consecutiveSpaces = regexp.MustCompile("[[:space:]]+")
 
-// A single key-value pair in sysconfig file.
+// SysconfigEntry contains a single key-value pair in sysconfig file.
 type SysconfigEntry struct {
 	LeadingComments []string // The comment lines leading to the key-value pair, including prefix '#', excluding end-of-line.
 	Key             string   // The key.
 	Value           string   // The value, excluding '=' character and double-quotes. Values will always come in double-quotes when converted to text.
 }
 
-// Key-value pairs of a sysconfig file. It is able to convert back to original text in the original key order.
+// Sysconfig contains key-value pairs of a sysconfig file.
+// It is able to convert back to original text in the original key order.
 type Sysconfig struct {
 	AllValues []*SysconfigEntry // All key-value pairs in the orignal order.
 	KeyValue  map[string]*SysconfigEntry


### PR DESCRIPTION
adapt the parameter oriented save state file handling (store and revert) to the special needs of the security limits parameter (bsc#1124485)
add unit tests for parameter handling and support for test coverage using codeclimate on branch 'master' of repository SUSE/saptune
format changes to satisfy gofmt and golint 

At the moment the codeclimate badges will show a wrong context (non available coverage of 'master' branch instead of 'saptune_improvement'). But the codeclimate settings will work correctly after we have merged the branch 'saptune_improvements' to 'master' as codeclimate only supports one branch per repository and I had imported the 'master' branch of SUSE/saptune to codeclimate.
