### PR TITLE
change UserTasksMax handling and improve logging 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"reflect"
 	"sort"
+	"strings"
 )
 
 // define saptunes main configuration file and variables
@@ -352,6 +353,9 @@ func (app *App) RevertAll(permanent bool) error {
 	otherNotes, err := app.State.List()
 	if err == nil {
 		for _, otherNoteID := range otherNotes {
+			if strings.HasSuffix(otherNoteID, "_n2c") {
+				continue
+			}
 			if err := app.RevertNote(otherNoteID, permanent); err != nil {
 				allErrs = append(allErrs, err)
 			}

--- a/app/app.go
+++ b/app/app.go
@@ -7,7 +7,6 @@ import (
 	"github.com/SUSE/saptune/system"
 	"github.com/SUSE/saptune/txtparser"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"reflect"
@@ -263,7 +262,7 @@ func (app *App) RevertNote(noteID string, permanent bool) error {
 		}
 		i = PositionInNoteApplyOrder(app.NoteApplyOrder, noteID)
 		if i < 0 {
-			log.Printf("noteID '%s' not found in configuration 'NoteApplyOrder'", noteID)
+			system.WarningLog("noteID '%s' not found in configuration 'NoteApplyOrder'", noteID)
 		} else if i < len(app.NoteApplyOrder) && app.NoteApplyOrder[i] == noteID {
 			// remove noteID from the configuration 'NoteApplyOrder'
 			app.NoteApplyOrder = append(app.NoteApplyOrder[0:i], app.NoteApplyOrder[i+1:]...)

--- a/app/state.go
+++ b/app/state.go
@@ -3,8 +3,8 @@ package app
 import (
 	"encoding/json"
 	"github.com/SUSE/saptune/sap/note"
+	"github.com/SUSE/saptune/system"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"strings"
@@ -100,7 +100,7 @@ func (state *State) CheckForOldRevertData() (oldUpdFiles []string, check bool) {
 					// note and the 'n2c' file from the
 					// update path v1 to v2
 					oldUpdFiles = append(oldUpdFiles, fileName)
-					log.Printf("found old saved state file for Note '%s'.", fileName)
+					system.WarningLog("found old saved state file for Note '%s'.", fileName)
 					check = true
 				} else {
 					oldUpdFiles = append(oldUpdFiles, entry)

--- a/ospackage/profile/tuned.conf
+++ b/ospackage/profile/tuned.conf
@@ -11,7 +11,7 @@
 # Comprehensive system optimisation profile for various SAP solutions.
 # The parameters are set based on throughput-performance profile.
 # Certain parameters from throughput-performance are removed to let saptune take over.
-# Author: Howard Guo <hguo@suse.com>
+# Author: Howard Guo <hguo@suse.com>, Angela Briel <abriel@suse.com>
 [main]
 summary=Comprehensive system optimisation with saptune
 

--- a/ospackage/usr/share/bash-completion/completions/saptune.completion
+++ b/ospackage/usr/share/bash-completion/completions/saptune.completion
@@ -6,6 +6,8 @@
 #   saptune solution [ list | verify ]
 #   saptune solution [ apply | simulate | verify | revert ] SolutionName
 #   saptune revert all
+#   saptune version
+#   saptune --version
 
 _saptune() {
     local cur prev opts base pattern
@@ -16,7 +18,7 @@ _saptune() {
     
     case ${COMP_CWORD} in 
 
-        1)  opts="daemon solution note revert"
+        1)  opts="daemon solution note revert version --version"
             ;;
         
         2)  case "${prev}" in

--- a/ospackage/usr/share/saptune/notes/1984787
+++ b/ospackage/usr/share/saptune/notes/1984787
@@ -5,6 +5,17 @@
 [version]
 # SAP-NOTE=1984787 CATEGORY=LINUX VERSION=32 DATE=26.06.2018 NAME="SUSE LINUX Enterprise Server 12: Installation notes"
 
+[login]
+# /etc/systemd/logind.conf.d/saptune-UserTasksMax.conf UserTasksMax setting
+# This file configures a parameter of the systemd login manager
+# It sets the maximum number of OS tasks each user may run concurrently
+# The behaviour of the systemd login manager was changed starting SLES12SP2
+# to prevent fork bomb attacks.
+# The value for UserTasksMax will be set to 'infinity'
+# With this setting your system is vulnerable to fork bomb attacks
+#
+UserTasksMax=infinity
+
 [service]
 # start the related services
 UuiddSocket=start
@@ -69,7 +80,3 @@ vm.dirty_background_bytes=314572800
 [reminder]
 # systemd drop-in configuration file: for SLES12GA and SLES12SP1 handled by saptune package installation
 # installation of uuid daemon: handled by saptune package installation
-
-# /etc/systemd/logind.conf.d/sap.conf UserTasksMax setting
-# UserTasksMax=infinity
-# - done during post install of package installation

--- a/ospackage/usr/share/saptune/notes/2205917
+++ b/ospackage/usr/share/saptune/notes/2205917
@@ -5,6 +5,17 @@
 [version]
 # SAP-NOTE=2205917 CATEGORY=HANA VERSION=42 DATE=02.03.2018 NAME="SAP HANA DB: Recommended OS settings for SLES 12 / SLES for SAP Applications 12"
 
+[login]
+# /etc/systemd/logind.conf.d/saptune-UserTasksMax.conf UserTasksMax setting
+# This file configures a parameter of the systemd login manager
+# It sets the maximum number of OS tasks each user may run concurrently
+# The behaviour of the systemd login manager was changed starting SLES12SP2
+# to prevent fork bomb attacks.
+# The value for UserTasksMax will be set to 'infinity'
+# With this setting your system is vulnerable to fork bomb attacks
+#
+UserTasksMax=infinity
+
 [vm]
 # Disable transparent hugepages (THP, applies to Intel-based systems only)
 # changes /sys/kernel/mm/transparent_hugepage/enabled
@@ -110,7 +121,3 @@ transparent_hugepage=never
 
 [reminder]
 # IBM EnergyScale for POWER8 Processor-Based Systems (applies to IBM Power systems only) - not supported by saptune!
-
-# /etc/systemd/logind.conf.d/sap.conf UserTasksMax setting
-# UserTasksMax=infinity
-# - done during post install of package installation

--- a/ospackage/usr/share/saptune/notes/2578899
+++ b/ospackage/usr/share/saptune/notes/2578899
@@ -5,6 +5,17 @@
 [version]
 # SAP-NOTE=2578899 CATEGORY=LINUX VERSION=11 DATE=03.01.2019 NAME="SUSE LINUX Enterprise Server 15: Installation notes"
 
+[login]
+# /etc/systemd/logind.conf.d/saptune-UserTasksMax.conf UserTasksMax setting
+# This file configures a parameter of the systemd login manager
+# It sets the maximum number of OS tasks each user may run concurrently
+# The behaviour of the systemd login manager was changed starting SLES12SP2
+# to prevent fork bomb attacks.
+# The value for UserTasksMax will be set to 'infinity'
+# With this setting your system is vulnerable to fork bomb attacks
+#
+UserTasksMax=infinity
+
 [service]
 # start the related services
 UuiddSocket=start
@@ -60,8 +71,3 @@ vm.dirty_bytes=629145600
 # vm.dirty_background_bytes should be set to 314572800 (see TID_7010287)
 #
 vm.dirty_background_bytes=314572800
-
-[reminder]
-# /etc/systemd/logind.conf.d/sap.conf UserTasksMax setting
-# UserTasksMax=infinity
-# - done during post install of package installation

--- a/ospackage/usr/share/saptune/scripts/upd_helper
+++ b/ospackage/usr/share/saptune/scripts/upd_helper
@@ -9,6 +9,17 @@
 # only called in postinstallation, if it is a package update
 # NOT called, if it is an initial package installation
 
+# upd_helper v1tov2pi
+# upd_helper v1tov2pt
+# upd_helper sle12to15pt
+
+if [ "$1" == "" ]; then
+    echo "ERROR: missing argument"
+    exit 1
+else
+    upd_opt="$1"
+fi
+
 SAPTUNE_SYSCONFIG=/etc/sysconfig/saptune
 CUSTOM_TUNED_CONF=/etc/tuned/saptune/tuned.conf
 
@@ -19,34 +30,6 @@ PARAMETERSTATEDIR=/var/lib/saptune/parameter
 NOTEDIR=/usr/share/saptune/notes
 NOTES2CHANGE_12to15="1984787,2578899 2205917,2684254"
 NOTES2DELETE_15="1557506"
-
-# upd_helper v1tov2pi
-# upd_helper v1tov2pt
-# upd_helper sle12to15pt
-
-if [ "$1" -eq "" ]; then
-    echo "ERROR: missing argument"
-    exit 1
-fi
-case "$1" in
-v1tov2pi)
-    # called from the postinstall script of saptune, if installation was an
-    # update from saptune version 1 to version 2
-    set_sysconfig_version
-    create_tuned_conf
-    ;;
-v1tov2pt)
-    # called from the posttrans script of saptune, if installation was an
-    # update from saptune version 1 to version 2
-    get_back_extra_ASE_BOBJ
-    ;;
-sle12to15pt)
-    # called from the posttrans script of saptune, if installation was an
-    # update from saptune version 2 to version 2
-    change_note_names
-    delete_notes
-    ;;
-esac
 
 set_sysconfig_version() {
     # add or change SAPTUNE_VERSION string in /etc/sysconfig/saptune to "1"
@@ -210,3 +193,23 @@ delete_notes() {
         fi
     done
 }
+
+case "$upd_opt" in
+v1tov2pi)
+    # called from the postinstall script of saptune, if installation was an
+    # update from saptune version 1 to version 2
+    set_sysconfig_version
+    create_tuned_conf
+    ;;
+v1tov2pt)
+    # called from the posttrans script of saptune, if installation was an
+    # update from saptune version 1 to version 2
+    get_back_extra_ASE_BOBJ
+    ;;
+sle12to15pt)
+    # called from the posttrans script of saptune, if installation was an
+    # update from saptune version 2 to version 2
+    change_note_names
+    delete_notes
+    ;;
+esac

--- a/ospackage/usr/share/saptune/scripts/upd_helper
+++ b/ospackage/usr/share/saptune/scripts/upd_helper
@@ -70,7 +70,7 @@ create_tuned_conf() {
 	sed -i '/^\[main\]/i\
 #\
 # for compatibility support of saptune version 1 the tuned config script\
-# /usr/lib/tuned/saptune/tuned.conf is copied to $CUSTOM_TUNED_CONF\
+# /usr/lib/tuned/saptune/tuned.conf is copied to /etc/tuned/saptune/tuned.conf\
 # during the saptune package update from version 1 to version 2\
 #\
 ' $CUSTOM_TUNED_CONF

--- a/ospackage/usr/share/saptune/scripts/upd_helper
+++ b/ospackage/usr/share/saptune/scripts/upd_helper
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1004
 
 # saptune update helper script
 # upd_helper is called by post script of saptune package installation to
@@ -9,6 +10,7 @@
 # NOT called, if it is an initial package installation
 
 SAPTUNE_SYSCONFIG=/etc/sysconfig/saptune
+CUSTOM_TUNED_CONF=/etc/tuned/saptune/tuned.conf
 
 OVERRIDEDIR=/etc/saptune/override
 SAVEDSTATEDIR=/var/lib/saptune/saved_state
@@ -18,109 +20,193 @@ NOTEDIR=/usr/share/saptune/notes
 NOTES2CHANGE_12to15="1984787,2578899 2205917,2684254"
 NOTES2DELETE_15="1557506"
 
-OIFS=$IFS
-for notepair in $NOTES2CHANGE_12to15; do
-    IFS=","
-    # shellcheck disable=SC2086
-    set -- $notepair
-    oldNote=$1
-    newNote=$2
-    IFS=$OIFS
-    if [ ! -f ${NOTEDIR}/"${oldNote}" ] && [ -f ${NOTEDIR}/"${newNote}" ]; then
-        # the old note definition name is NOT available, but the new one
-        # so update from SLE12 to SLE15
-        # change config
+# upd_helper v1tov2pi
+# upd_helper v1tov2pt
+# upd_helper sle12to15pt
 
-        # 1. change variable TUNE_FOR_NOTES and NOTE_APPLY_ORDER in /etc/sysconfig/saptune
-        # " ${oldNote} " or " ${oldNote}\"" or "\"${oldNote}\""
-        # srch_pat="[ \"]${oldNote}[ \"]"
-        srch_pat1="[ ]${oldNote}[ ]"
-        new_pat1=" ${newNote} "
-        if grep "$srch_pat1" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
-            echo "### changing old, SLE12 specific Note name '$oldNote' to the new, SLE15 Note name '$newNote'"
-            sed -i "s/$srch_pat1/$new_pat1/g" $SAPTUNE_SYSCONFIG
-        fi
-        srch_pat2=" ${oldNote}\""
-        new_pat2=" ${newNote}\""
-        if grep "$srch_pat2" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
-            echo "### changing old, SLE12 specific Note name '$oldNote' to the new, SLE15 Note name '$newNote'"
-            sed -i "s/$srch_pat2/$new_pat2/g" $SAPTUNE_SYSCONFIG
-        fi
-        srch_pat3="\"${oldNote}\""
-        new_pat3="\"${newNote}\""
-        if grep "$srch_pat3" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
-            echo "### changing old, SLE12 specific Note name '$oldNote' to the new, SLE15 Note name '$newNote'"
-            sed -i "s/$srch_pat3/$new_pat3/g" $SAPTUNE_SYSCONFIG
-        fi
+if [ "$1" -eq "" ]; then
+    echo "ERROR: missing argument"
+    exit 1
+fi
+case "$1" in
+v1tov2pi)
+    # called from the postinstall script of saptune, if installation was an
+    # update from saptune version 1 to version 2
+    set_sysconfig_version
+    create_tuned_conf
+    ;;
+v1tov2pt)
+    # called from the posttrans script of saptune, if installation was an
+    # update from saptune version 1 to version 2
+    get_back_extra_ASE_BOBJ
+    ;;
+sle12to15pt)
+    # called from the posttrans script of saptune, if installation was an
+    # update from saptune version 2 to version 2
+    change_note_names
+    delete_notes
+    ;;
+esac
 
-        # 2. check existence of override file and change name
-        if [ -f ${OVERRIDEDIR}/"$oldNote" ]; then
-            echo "### mv old override filename '${OVERRIDEDIR}/$oldNote' to new filename '${OVERRIDEDIR}/$newNote'"
-            echo "WARNING: the header information in section [version] will NOT be adapted. So it will show the old SAP Note name and the related information"
-            mv ${OVERRIDEDIR}/"$oldNote" ${OVERRIDEDIR}/"$newNote"
-        fi
+set_sysconfig_version() {
+    # add or change SAPTUNE_VERSION string in /etc/sysconfig/saptune to "1"
+    if (grep "SAPTUNE_VERSION[[:space:]]*=" $SAPTUNE_SYSCONFIG >/dev/null 2>&1); then
+        sed -i 's/SAPTUNE_VERSION="2"/SAPTUNE_VERSION="1"/' $SAPTUNE_SYSCONFIG
+    else
+        echo "missing SAPTUNE_VERSION string in /etc/sysconfig/saptune. Appending ..."
+        echo -e "## Type:    string\n## Default: \"2\"\n#\n# Version of saptune\nSAPTUNE_VERSION=\"1\"\n" >> $SAPTUNE_SYSCONFIG
+    fi
+}
 
-        # 3. check existence of saved_state file and change name
-        if [ -f ${SAVEDSTATEDIR}/"$oldNote" ]; then
-            echo "### mv old saved state file to the new name"
-            mv ${SAVEDSTATEDIR}/"$oldNote" ${SAVEDSTATEDIR}/"$newNote"
-        fi
+create_tuned_conf() {
+    # add 'old' cpu section to tuned.conf for compatibility reasons
+    # if a custom tuned.conf file exists, do nothing.
+    if [ ! -f $CUSTOM_TUNED_CONF ]; then
+        echo "create custom file '$CUSTOM_TUNED_CONF' for compatibility support of saptune version 1"
+        echo "see man saptune(8) and saptune-migrate(7) for more information"
+        mkdir -p /etc/tuned/saptune
+        cp /usr/lib/tuned/saptune/tuned.conf $CUSTOM_TUNED_CONF
+	# add description
+	sed -i '/^\[main\]/i\
+#\
+# for compatibility support of saptune version 1 the tuned config script\
+# /usr/lib/tuned/saptune/tuned.conf is copied to $CUSTOM_TUNED_CONF\
+# during the saptune package update from version 1 to version 2\
+#\
+' $CUSTOM_TUNED_CONF
+        # add cpu section
+        sed -i '/^\[script\]/i\
+[cpu]\
+#cpu section added by saptune package installation during package update from version1 to version2\
+#stv1tov2#\
+governor=performance\
+energy_perf_bias=performance\
+min_perf_pct=100\
+force_latency = 70\
+' $CUSTOM_TUNED_CONF
+        # use absolute pathname for script
+        sed -i 's%script.sh%/usr/lib/tuned/saptune/script.sh%' $CUSTOM_TUNED_CONF
+    fi
+}
 
-        # 4. check, if old note name is available in any parameter saved state file
-        srch_pat="\"${oldNote}\""
-        new_pat="\"${newNote}\""
-        if grep "$srch_pat" "${PARAMETERSTATEDIR}"/* >/dev/null 2>&1; then
-            echo "### changing the parameter saved state files"
-        fi
-        for pfile in "${PARAMETERSTATEDIR}"/*; do
-            if grep "$srch_pat" "$pfile" >/dev/null 2>&1; then
-                sed -i "s/$srch_pat/$new_pat/g" "$pfile"
+get_back_extra_ASE_BOBJ() {
+    # check for extra files needed for the v1tov2 migration
+    # get back custom note definition files for BOBJ and/or ASE
+    # needed for migration, if customer had applied these notes
+    if [ -f /etc/saptune/extra/SAP_BOBJ_n2c.conf ]; then
+        mv /etc/saptune/extra/SAP_BOBJ_n2c.conf /etc/saptune/extra/SAP_BOBJ-SAP_Business_OBJects.conf || :
+    fi
+    if [ -f /etc/saptune/extra/SAP_ASE_n2c.conf ]; then
+        mv /etc/saptune/extra/SAP_ASE_n2c.conf /etc/saptune/extra/SAP_ASE-SAP_Adaptive_Server_Enterprise.conf || :
+    fi
+}
+
+change_note_names() {
+    OIFS=$IFS
+    for notepair in $NOTES2CHANGE_12to15; do
+        IFS=","
+        # shellcheck disable=SC2086
+        set -- $notepair
+        oldNote=$1
+        newNote=$2
+        IFS=$OIFS
+        if [ ! -f ${NOTEDIR}/"${oldNote}" ] && [ -f ${NOTEDIR}/"${newNote}" ]; then
+            # the old note definition name is NOT available, but the new one
+            # so update from SLE12 to SLE15
+            # change config
+
+            # 1. change variable TUNE_FOR_NOTES and NOTE_APPLY_ORDER in /etc/sysconfig/saptune
+            # " ${oldNote} " or " ${oldNote}\"" or "\"${oldNote}\""
+            # srch_pat="[ \"]${oldNote}[ \"]"
+            srch_pat1="[ ]${oldNote}[ ]"
+            new_pat1=" ${newNote} "
+            if grep "$srch_pat1" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
+                echo "### changing old, SLE12 specific Note name '$oldNote' to the new, SLE15 Note name '$newNote'"
+                sed -i "s/$srch_pat1/$new_pat1/g" $SAPTUNE_SYSCONFIG
             fi
-        done
-    #else
-        # if both note files are available - not possible, rpm should cover
-        # if both note files NOT available - not possible, rpm should cover
-        # if oldNote is available, but newNote not
-        #    still on SLE12, no update from 12 to 15, so nothing to do
-    fi
-done
+            srch_pat2=" ${oldNote}\""
+            new_pat2=" ${newNote}\""
+            if grep "$srch_pat2" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
+                echo "### changing old, SLE12 specific Note name '$oldNote' to the new, SLE15 Note name '$newNote'"
+                sed -i "s/$srch_pat2/$new_pat2/g" $SAPTUNE_SYSCONFIG
+            fi
+            srch_pat3="\"${oldNote}\""
+            new_pat3="\"${newNote}\""
+            if grep "$srch_pat3" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
+                echo "### changing old, SLE12 specific Note name '$oldNote' to the new, SLE15 Note name '$newNote'"
+                sed -i "s/$srch_pat3/$new_pat3/g" $SAPTUNE_SYSCONFIG
+            fi
 
-for delnote in $NOTES2DELETE_15; do
-    if [ ! -f ${NOTEDIR}/"${delnote}" ]; then
-        # 1. delete Note from variable TUNE_FOR_NOTES and NOTE_APPLY_ORDER in /etc/sysconfig/saptune
-        # " ${delnote} " or " ${delnote}\"" or "\"${delnote}\""
-        # srch_pat="[ \"]${delnote}[ \"]"
-        srch_pat1="[ ]${delnote}[ ]"
-        del_pat1=" "
-        if grep "$srch_pat1" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
-            echo "### removing old, SLE12 specific Note name '$delnote' from $SAPTUNE_SYSCONFIG"
-            sed -i "s/$srch_pat1/$del_pat1/g" $SAPTUNE_SYSCONFIG
-        fi
-        srch_pat2=" ${delnote}\""
-        del_pat2="\""
-        if grep "$srch_pat2" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
-            echo "### removing old, SLE12 specific Note name '$delnote' from $SAPTUNE_SYSCONFIG"
-            sed -i "s/$srch_pat2/$del_pat2/g" $SAPTUNE_SYSCONFIG
-        fi
-        srch_pat3="\"${delnote}\""
-        del_pat3="\"\""
-        if grep "$srch_pat3" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
-            echo "### removing old, SLE12 specific Note name '$delnote' from $SAPTUNE_SYSCONFIG"
-            sed -i "s/$srch_pat3/$del_pat3/g" $SAPTUNE_SYSCONFIG
-        fi
+            # 2. check existence of override file and change name
+            if [ -f ${OVERRIDEDIR}/"$oldNote" ]; then
+                echo "### mv old override filename '${OVERRIDEDIR}/$oldNote' to new filename '${OVERRIDEDIR}/$newNote'"
+                echo "WARNING: the header information in section [version] will NOT be adapted. So it will show the old SAP Note name and the related information"
+                mv ${OVERRIDEDIR}/"$oldNote" ${OVERRIDEDIR}/"$newNote"
+            fi
 
-        # 2. check existence of override file and print a WARNING
-        if [ -f ${OVERRIDEDIR}/"$delnote" ]; then
-            echo "WARNING: override file '${OVERRIDEDIR}/$delnote' exists, but Note definition is no longer supported."
-            echo "Please check and remove superfluous file"
-        fi
+            # 3. check existence of saved_state file and change name
+            if [ -f ${SAVEDSTATEDIR}/"$oldNote" ]; then
+                echo "### mv old saved state file to the new name"
+                mv ${SAVEDSTATEDIR}/"$oldNote" ${SAVEDSTATEDIR}/"$newNote"
+            fi
 
-        # 3. check existence of saved_state file and remove file
-        # normally shouldn't be available
-        if [ -f ${SAVEDSTATEDIR}/"$oldNote" ]; then
-            echo "WARNING: old saved state file '${SAVEDSTATEDIR}/$delnote' found, removing superfluous file."
-            rm ${SAVEDSTATEDIR}/"$delnote"
+            # 4. check, if old note name is available in any parameter saved state file
+            srch_pat="\"${oldNote}\""
+            new_pat="\"${newNote}\""
+            if grep "$srch_pat" "${PARAMETERSTATEDIR}"/* >/dev/null 2>&1; then
+                echo "### changing the parameter saved state files"
+            fi
+            for pfile in "${PARAMETERSTATEDIR}"/*; do
+                if grep "$srch_pat" "$pfile" >/dev/null 2>&1; then
+                    sed -i "s/$srch_pat/$new_pat/g" "$pfile"
+                fi
+            done
+        #else
+            # if both note files are available - not possible, rpm should cover
+            # if both note files NOT available - not possible, rpm should cover
+            # if oldNote is available, but newNote not
+            #    still on SLE12, no update from 12 to 15, so nothing to do
         fi
-    fi
-done
+    done
+}
 
+delete_notes() {
+    for delnote in $NOTES2DELETE_15; do
+        if [ ! -f ${NOTEDIR}/"${delnote}" ]; then
+            # 1. delete Note from variable TUNE_FOR_NOTES and NOTE_APPLY_ORDER in /etc/sysconfig/saptune
+            # " ${delnote} " or " ${delnote}\"" or "\"${delnote}\""
+            # srch_pat="[ \"]${delnote}[ \"]"
+            srch_pat1="[ ]${delnote}[ ]"
+            del_pat1=" "
+            if grep "$srch_pat1" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
+                echo "### removing old, SLE12 specific Note name '$delnote' from $SAPTUNE_SYSCONFIG"
+                sed -i "s/$srch_pat1/$del_pat1/g" $SAPTUNE_SYSCONFIG
+            fi
+            srch_pat2=" ${delnote}\""
+            del_pat2="\""
+            if grep "$srch_pat2" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
+                echo "### removing old, SLE12 specific Note name '$delnote' from $SAPTUNE_SYSCONFIG"
+                sed -i "s/$srch_pat2/$del_pat2/g" $SAPTUNE_SYSCONFIG
+            fi
+            srch_pat3="\"${delnote}\""
+            del_pat3="\"\""
+            if grep "$srch_pat3" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
+                echo "### removing old, SLE12 specific Note name '$delnote' from $SAPTUNE_SYSCONFIG"
+                sed -i "s/$srch_pat3/$del_pat3/g" $SAPTUNE_SYSCONFIG
+            fi
+
+            # 2. check existence of override file and print a WARNING
+            if [ -f ${OVERRIDEDIR}/"$delnote" ]; then
+                echo "WARNING: override file '${OVERRIDEDIR}/$delnote' exists, but Note definition is no longer supported."
+                echo "Please check and remove superfluous file"
+            fi
+
+            # 3. check existence of saved_state file and remove file
+            # normally shouldn't be available
+            if [ -f ${SAVEDSTATEDIR}/"$oldNote" ]; then
+                echo "WARNING: old saved state file '${SAVEDSTATEDIR}/$delnote' found, removing superfluous file."
+                rm ${SAVEDSTATEDIR}/"$delnote"
+            fi
+        fi
+    done
+}

--- a/sap/errs.go
+++ b/sap/errs.go
@@ -2,6 +2,7 @@ package sap
 
 import (
 	"fmt"
+	//"github.com/SUSE/saptune/system"
 	"log"
 )
 
@@ -13,6 +14,8 @@ func PrintErrors(errors []error) error {
 			hasNil = true
 		} else {
 			log.Printf("%v", err)
+			//txt := fmt.Sprintf("%v", err)
+			//system.ErrorLog(txt)
 		}
 	}
 	if hasNil {

--- a/sap/note/ini.go
+++ b/sap/note/ini.go
@@ -1,11 +1,9 @@
 package note
 
 import (
-	"fmt"
 	"github.com/SUSE/saptune/sap"
 	"github.com/SUSE/saptune/system"
 	"github.com/SUSE/saptune/txtparser"
-	"log"
 	"path"
 	"strconv"
 	"strings"
@@ -28,7 +26,8 @@ func CalculateOptimumValue(operator txtparser.Operator, currentValue string, exp
 	var iCurrentValue int64
 	iExpectedValue, err := strconv.ParseInt(expectedValue, 10, 64)
 	if err != nil {
-		return "", fmt.Errorf("Expected value \"%s\" should be but is not an integer", expectedValue)
+		system.ErrorLog("Expected value \"%s\" should be but is not an integer", expectedValue)
+		return "", err
 	}
 	if currentValue == "" {
 		switch operator {
@@ -44,7 +43,8 @@ func CalculateOptimumValue(operator txtparser.Operator, currentValue string, exp
 	} else {
 		iCurrentValue, err = strconv.ParseInt(currentValue, 10, 64)
 		if err != nil {
-			return "", fmt.Errorf("Current value \"%s\" should be but is not an integer", currentValue)
+			system.ErrorLog("Current value \"%s\" should be but is not an integer", currentValue)
+			return "", err
 		}
 		switch operator {
 		case txtparser.OperatorLessThan:
@@ -156,7 +156,7 @@ func (vend INISettings) Initialise() (Note, error) {
 			}
 			vend.SysctlParams[param.Key] = GetPagecacheVal(param.Key, &pc)
 		default:
-			log.Printf("3rdPartyTuningOption %s: skip unknown section %s", vend.ConfFilePath, param.Section)
+			system.WarningLog("3rdPartyTuningOption %s: skip unknown section %s", vend.ConfFilePath, param.Section)
 			continue
 		}
 		// do not write parameter values to the saved state file during
@@ -224,7 +224,7 @@ func (vend INISettings) Optimise() (Note, error) {
 			//vend.SysctlParams[param.Key] = OptPagecacheVal(param.Key, param.Value, &pc, ini.KeyValue)
 			vend.SysctlParams[param.Key] = OptPagecacheVal(param.Key, param.Value, &pc)
 		default:
-			log.Printf("3rdPartyTuningOption %s: skip unknown section %s", vend.ConfFilePath, param.Section)
+			system.WarningLog("3rdPartyTuningOption %s: skip unknown section %s", vend.ConfFilePath, param.Section)
 			continue
 		}
 		// do not write parameter values to the saved state file during
@@ -331,7 +331,7 @@ func (vend INISettings) Apply() error {
 		case INISectionPagecache:
 			errs = append(errs, SetPagecacheVal(param.Key, &pc))
 		default:
-			log.Printf("3rdPartyTuningOption %s: skip unknown section %s", vend.ConfFilePath, param.Section)
+			system.WarningLog("3rdPartyTuningOption %s: skip unknown section %s", vend.ConfFilePath, param.Section)
 			continue
 		}
 	}

--- a/sap/note/ini_sections.go
+++ b/sap/note/ini_sections.go
@@ -6,7 +6,6 @@ import (
 	"github.com/SUSE/saptune/system"
 	"github.com/SUSE/saptune/txtparser"
 	"io/ioutil"
-	"log"
 	"math"
 	"os"
 	"path"
@@ -49,7 +48,7 @@ func GetServiceName(service string) string {
 	case "Sysstat":
 		service = "sysstat"
 	default:
-		log.Printf("skipping unkown service '%s'", service)
+		system.WarningLog("skipping unkown service '%s'", service)
 		service = ""
 	}
 	return service
@@ -70,7 +69,7 @@ func OptSysctlVal(operator txtparser.Operator, key, actval, cfgval string) strin
 	allFieldsS := ""
 
 	if len(allFieldsC) != len(allFieldsE) && (operator == txtparser.OperatorEqual || len(allFieldsE) > 1) {
-		log.Printf("wrong number of fields given in the config file for parameter '%s'\n", key)
+		system.WarningLog("wrong number of fields given in the config file for parameter '%s'\n", key)
 		return ""
 	}
 
@@ -338,12 +337,12 @@ func OptVMVal(key, cfgval string) string {
 	switch key {
 	case "THP":
 		if val != "always" && val != "madvise" && val != "never" {
-			log.Print("wrong selection for THP. Now set to 'never' to disable transarent huge pages")
+			system.WarningLog("wrong selection for THP. Now set to 'never' to disable transarent huge pages")
 			val = "never"
 		}
 	case "KSM":
 		if val != "1" && val != "0" {
-			log.Print("wrong selection for KSM. Now set to default value '0'")
+			system.WarningLog("wrong selection for KSM. Now set to default value '0'")
 			val = "0"
 		}
 	}
@@ -408,7 +407,7 @@ func OptCPUVal(key, actval, cfgval string) string {
 		case "powersave":
 			val = "15"
 		default:
-			log.Print("wrong selection for energy_perf_bias. Now set to 'performance'")
+			system.WarningLog("wrong selection for energy_perf_bias. Now set to 'performance'")
 			val = "0"
 		}
 		//ANGI TODO - if actval 'all:6', but cfgval 'cpu0:performance cpu1:normal cpu2:powersave'
@@ -463,7 +462,7 @@ func GetMemVal(key string) string {
 				val = strconv.FormatFloat(percent, 'f', -1, 64)
 			}
 		} else {
-			log.Print("GetMemVal: failed to find /dev/shm mount point")
+			system.WarningLog("GetMemVal: failed to find /dev/shm mount point")
 			val = "-1"
 		}
 	}
@@ -479,7 +478,7 @@ func OptMemVal(key, actval, cfgval, shmsize, tmpfspercent string) string {
 	var ret string
 
 	if actval == "-1" {
-		log.Print("OptMemVal: /dev/shm is not a valid mount point, will not calculate its optimal size.")
+		system.WarningLog("OptMemVal: /dev/shm is not a valid mount point, will not calculate its optimal size.")
 		size = 0
 	} else if shmsize == "0" {
 		if tmpfspercent == "0" {
@@ -517,7 +516,7 @@ func SetMemVal(key, value string) error {
 				return err
 			}
 		} else {
-			log.Print("SetMemVal: /dev/shm is not a valid mount point, will not adjust its size.")
+			system.WarningLog("SetMemVal: /dev/shm is not a valid mount point, will not adjust its size.")
 		}
 	}
 	return err
@@ -584,7 +583,7 @@ func GetUuiddVal() string {
 func OptUuiddVal(cfgval string) string {
 	sval := strings.ToLower(cfgval)
 	if sval != "start" {
-		log.Print("wrong selection for UuiddSocket. Now set to 'start' to start the uuid daemon")
+		system.WarningLog("wrong selection for UuiddSocket. Now set to 'start' to start the uuid daemon")
 		sval = "start"
 	}
 	return sval
@@ -624,16 +623,16 @@ func OptServiceVal(key, cfgval string) string {
 	switch key {
 	case "UuiddSocket":
 		if sval != "start" {
-			log.Printf("wrong selection for '%s'. Now set to 'start' to start the service\n", key)
+			system.WarningLog("wrong selection for '%s'. Now set to 'start' to start the service\n", key)
 			sval = "start"
 		}
 	case "Sysstat":
 		if sval != "start" && sval != "stop" {
-			log.Printf("wrong selection for '%s'. Now set to 'start' to start the service\n", key)
+			system.WarningLog("wrong selection for '%s'. Now set to 'start' to start the service\n", key)
 			sval = "start"
 		}
 	default:
-		log.Printf("skipping unkown service '%s'", key)
+		system.WarningLog("skipping unkown service '%s'", key)
 		return ""
 	}
 	return sval
@@ -722,7 +721,7 @@ func SetLoginVal(key, value string, revert bool) error {
 				return err
 			}
 			if value == "infinity" {
-				log.Print("Be aware: system-wide UserTasksMax is now set to infinity according to SAP recommendations.\n" +
+				system.WarningLog("Be aware: system-wide UserTasksMax is now set to infinity according to SAP recommendations.\n" +
 					"This opens up entire system to fork-bomb style attacks.")
 			}
 			// set per user
@@ -778,12 +777,12 @@ func OptPagecacheVal(key, cfgval string, cur *LinuxPagingImprovements) string {
 	switch key {
 	case "ENABLE_PAGECACHE_LIMIT":
 		if val != "yes" && val != "no" {
-			log.Print("wrong selection for ENABLE_PAGECACHE_LIMIT. Now set to default 'no'")
+			system.WarningLog("wrong selection for ENABLE_PAGECACHE_LIMIT. Now set to default 'no'")
 			val = "no"
 		}
 	case "PAGECACHE_LIMIT_IGNORE_DIRTY":
 		if val != "2" && val != "1" && val != "0" {
-			log.Print("wrong selection for PAGECACHE_LIMIT_IGNORE_DIRTY. Now set to default '1'")
+			system.WarningLog("wrong selection for PAGECACHE_LIMIT_IGNORE_DIRTY. Now set to default '1'")
 			val = "1"
 		}
 		cur.VMPagecacheLimitIgnoreDirty, _ = strconv.Atoi(val)

--- a/sap/note/ini_sections_test.go
+++ b/sap/note/ini_sections_test.go
@@ -420,13 +420,13 @@ func TestGetLoginVal(t *testing.T) {
 	}
 
 	val, err = GetLoginVal("UserTasksMax")
-	if _, errno := os.Stat("/etc/systemd/logind.conf.d/sap.conf"); errno != nil {
+	if _, errno := os.Stat("/etc/systemd/logind.conf.d/saptune-UserTasksMax.conf"); errno != nil {
 		if !os.IsNotExist(errno) {
 			if val != "" || err == nil {
 				t.Fatal(val)
 			}
 		} else {
-			if val != "" || err != nil {
+			if val != "NA" || err != nil {
 				t.Fatal(val)
 			}
 		}

--- a/sap/note/note.go
+++ b/sap/note/note.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"github.com/SUSE/saptune/system"
 	"github.com/SUSE/saptune/txtparser"
-	"log"
 	"os"
 	"path"
 	"reflect"
@@ -56,7 +55,7 @@ func GetTuningOptions(saptuneTuningDir, thirdPartyTuningDir string) TuningOption
 	_, files, err := system.ListDir(saptuneTuningDir)
 	if err != nil {
 		// Not a fatal error
-		log.Printf("GetTuningOptions: failed to read saptune tuning definitions - %v", err)
+		system.WarningLog("GetTuningOptions: failed to read saptune tuning definitions - %v", err)
 	}
 	for _, fileName := range files {
 		ret[fileName] = INISettings{
@@ -70,14 +69,14 @@ func GetTuningOptions(saptuneTuningDir, thirdPartyTuningDir string) TuningOption
 	_, files, err = system.ListDir(thirdPartyTuningDir)
 	if err != nil {
 		// Not a fatal error
-		log.Printf("GetTuningOptions: failed to read 3rd party tuning definitions - %v", err)
+		system.WarningLog("GetTuningOptions: failed to read 3rd party tuning definitions - %v", err)
 	}
 	for _, fileName := range files {
 		// ignore left over files (BOBJ and ASE definition files) from
 		// the migration of saptune version 1 to saptune version 2
 		if fileName == "SAP_BOBJ-SAP_Business_OBJects.conf" || fileName == "SAP_ASE-SAP_Adaptive_Server_Enterprise.conf" {
-			log.Printf("GetTuningOptions: skip old note definition \"%s\" from saptune version 1.", fileName)
-			log.Println("For more information refer to the man page saptune-migrate(7)")
+			system.WarningLog("GetTuningOptions: skip old note definition \"%s\" from saptune version 1.", fileName)
+			system.WarningLog("For more information refer to the man page saptune-migrate(7)")
 			continue
 		}
 		id := ""
@@ -87,12 +86,12 @@ func GetTuningOptions(saptuneTuningDir, thirdPartyTuningDir string) TuningOption
 			// no header found in the vendor file
 			// fall back to the old style vendor file names
 			// support of old style vendor file names for compatibility reasons
-			log.Printf("GetTuningOptions: no header information found in file \"%s\"", fileName)
-			log.Println("falling back to old style vendor file names")
+			system.WarningLog("GetTuningOptions: no header information found in file \"%s\"", fileName)
+			system.WarningLog("falling back to old style vendor file names")
 			// By convention, the portion before dash makes up the ID.
 			idName := strings.SplitN(fileName, "-", 2)
 			if len(idName) != 2 {
-				log.Printf("GetTuningOptions: skip bad file name \"%s\"", fileName)
+				system.WarningLog("GetTuningOptions: skip bad file name \"%s\"", fileName)
 				continue
 			}
 			id = idName[0]
@@ -105,7 +104,7 @@ func GetTuningOptions(saptuneTuningDir, thirdPartyTuningDir string) TuningOption
 		}
 		// Do not allow vendor to override built-in
 		if _, exists := ret[id]; exists {
-			log.Printf("GetTuningOptions: vendor's \"%s\" will not override built-in tuning implementation", fileName)
+			system.WarningLog("GetTuningOptions: vendor's \"%s\" will not override built-in tuning implementation", fileName)
 			continue
 		}
 		ret[id] = INISettings{
@@ -142,11 +141,13 @@ type FieldComparison struct {
 func CompareJSValue(v1, v2 interface{}) (v1JS, v2JS string, match bool) {
 	v1JSBytes, err := json.Marshal(v1)
 	if err != nil {
-		log.Panicf("CompareJSValue: failed to serialise \"%+v\" - %v", v1, err)
+		system.ErrorLog("CompareJSValue: failed to serialise \"%+v\" - %v", v1, err)
+		panic(err)
 	}
 	v2JSBytes, err := json.Marshal(v2)
 	if err != nil {
-		log.Panicf("CompareJSValue: failed to serialise \"%+v\" - %v", v2, err)
+		system.ErrorLog("CompareJSValue: failed to serialise \"%+v\" - %v", v2, err)
+		panic(err)
 	}
 	v1JS, err = strconv.Unquote(string(v1JSBytes))
 	if err != nil {

--- a/sap/note/parameter.go
+++ b/sap/note/parameter.go
@@ -3,8 +3,8 @@ package note
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/SUSE/saptune/system"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"strings"
@@ -72,7 +72,7 @@ func CreateParameterStartValues(param, value string) {
 	}
 	pEntries = GetSavedParameterNotes(param)
 	if len(pEntries.AllNotes) == 0 {
-		//log.Printf("Write parameter start value '%s' to file '%s'", value, GetPathToParameter(param))
+		//system.InfoLog("Write parameter start value '%s' to file '%s'", value, GetPathToParameter(param))
 		// file does not exist, create start entry
 		pEntry := ParameterNoteEntry{
 			NoteID: "start",
@@ -81,7 +81,7 @@ func CreateParameterStartValues(param, value string) {
 		pEntries.AllNotes = append(pEntries.AllNotes, pEntry)
 		err := StoreParameter(param, pEntries, true)
 		if err != nil {
-			log.Printf("Failed to store start values for parameter file '%s' for parameter '%s'", GetPathToParameter(param), param)
+			system.WarningLog("Failed to store start values for parameter file '%s' for parameter '%s'", GetPathToParameter(param), param)
 		}
 	}
 }
@@ -93,7 +93,7 @@ func AddParameterNoteValues(param, value, noteID string) {
 	}
 	pEntries = GetSavedParameterNotes(param)
 	if len(pEntries.AllNotes) != 0 && !IDInParameterList(noteID, pEntries.AllNotes) {
-		//log.Printf("Write note '%s' parameter value '%s' to file '%s'", noteID, value, GetPathToParameter(param))
+		//system.InfoLog("Write note '%s' parameter value '%s' to file '%s'", noteID, value, GetPathToParameter(param))
 		// file exis
 		pEntry := ParameterNoteEntry{
 			NoteID: noteID,
@@ -102,7 +102,7 @@ func AddParameterNoteValues(param, value, noteID string) {
 		pEntries.AllNotes = append(pEntries.AllNotes, pEntry)
 		err := StoreParameter(param, pEntries, true)
 		if err != nil {
-			log.Printf("Failed to store note '%s' values for parameter file '%s' for parameter '%s'", noteID, GetPathToParameter(param), param)
+			system.WarningLog("Failed to store note '%s' values for parameter file '%s' for parameter '%s'", noteID, GetPathToParameter(param), param)
 		}
 	}
 }
@@ -240,7 +240,7 @@ func RevertParameter(param string, noteID string) string {
 		//store changes pEntries
 		err := StoreParameter(param, pEntries, true)
 		if err != nil {
-			fmt.Println("Problems during storing new parameter values")
+			system.WarningLog("Problems during storing new parameter values")
 		}
 	}
 	return pvalue

--- a/sap/note/parameter.go
+++ b/sap/note/parameter.go
@@ -270,3 +270,14 @@ func CleanUpParamFile(param string) {
 		os.Remove(remFileName)
 	}
 }
+
+// IsLastNoteOfParameter returns true, if there is no parameter state file
+// or false, which means that another note changing the parameter is still
+// applied
+func IsLastNoteOfParameter(param string) bool {
+	chkFileName := GetPathToParameter(param)
+	if _, err := os.Stat(chkFileName); os.IsNotExist(err) {
+		return true
+	}
+	return false
+}

--- a/sap/param/io.go
+++ b/sap/param/io.go
@@ -4,7 +4,6 @@ import (
 	"github.com/SUSE/saptune/sap"
 	"github.com/SUSE/saptune/system"
 	"io/ioutil"
-	"log"
 	"path"
 	"strconv"
 	"strings"
@@ -52,7 +51,7 @@ func (ioe BlockDeviceSchedulers) Apply() error {
 	errs := make([]error, 0, 0)
 	for name, elevator := range ioe.SchedulerChoice {
 		if !IsValidScheduler(name, elevator) {
-			log.Printf("'%s' is not a valid scheduler for device '%s', skipping.", elevator, name)
+			system.WarningLog("'%s' is not a valid scheduler for device '%s', skipping.", elevator, name)
 			continue
 		}
 		errs = append(errs, system.SetSysString(path.Join("block", name, "queue", "scheduler"), elevator))
@@ -102,7 +101,7 @@ func (ior BlockDeviceNrRequests) Apply() error {
 	errs := make([]error, 0, 0)
 	for name, nrreq := range ior.NrRequests {
 		if !IsValidforNrRequests(name, strconv.Itoa(nrreq)) {
-			log.Printf("skipping device '%s', not valid for setting 'number of requests' to '%v'", name, nrreq)
+			system.WarningLog("skipping device '%s', not valid for setting 'number of requests' to '%v'", name, nrreq)
 			continue
 		}
 		errs = append(errs, system.SetSysInt(path.Join("block", name, "queue", "nr_requests"), nrreq))

--- a/sap/solution/solution.go
+++ b/sap/solution/solution.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"github.com/SUSE/saptune/system"
 	"github.com/SUSE/saptune/txtparser"
-	"log"
 	"os"
 	"sort"
 	"strings"
@@ -52,7 +51,7 @@ func GetSolutionDefintion(fileName string) map[string]map[string]Solution {
 	pcarch := ""
 	content, err := txtparser.ParseINIFile(fileName, false)
 	if err != nil {
-		log.Printf("Failed to read solution definition from file '%s'", fileName)
+		system.ErrorLog("Failed to read solution definition from file '%s'", fileName)
 		return sols
 	}
 
@@ -122,7 +121,7 @@ func GetOverrideSolution(fileName, noteFiles string) map[string]map[string]Solut
 		notesOK := true
 		for _, noteID := range strings.Split(content.KeyValue[param.Section][param.Key].Value, "\t") {
 			if _, err := os.Stat(fmt.Sprintf("%s%s", noteFiles, noteID)); err != nil {
-				log.Printf("Definition for note '%s' used for solution '%s' in override file '%s' not found in %s", noteID, param.Key, fileName, noteFiles)
+				system.WarningLog("Definition for note '%s' used for solution '%s' in override file '%s' not found in %s", noteID, param.Key, fileName, noteFiles)
 				notesOK = false
 			}
 		}

--- a/system/cmdline.go
+++ b/system/cmdline.go
@@ -4,7 +4,6 @@ package system
 
 import (
 	"io/ioutil"
-	"log"
 	"strings"
 )
 
@@ -14,7 +13,7 @@ func ParseCmdline(fileName, option string) string {
 	opt := "NA"
 	cmdLine, err := ioutil.ReadFile(fileName)
 	if err != nil {
-		log.Printf("ParseCmdline: failed to read  %s: %v", fileName, err)
+		WarningLog("ParseCmdline: failed to read  %s: %v", fileName, err)
 		return opt
 	}
 	for _, param := range strings.Fields(string(cmdLine)) {

--- a/system/daemon.go
+++ b/system/daemon.go
@@ -25,6 +25,14 @@ func SystemctlDisable(thing string) error {
 	return nil
 }
 
+// SystemctlRestart call systemctl restart on thing.
+func SystemctlRestart(thing string) error {
+	if out, err := exec.Command("systemctl", "restart", thing).CombinedOutput(); err != nil {
+		return fmt.Errorf("Failed to call systemctl restart on %s - %v %s", thing, err, string(out))
+	}
+	return nil
+}
+
 // SystemctlStart call systemctl start on thing.
 func SystemctlStart(thing string) error {
 	if out, err := exec.Command("systemctl", "start", thing).CombinedOutput(); err != nil {

--- a/system/daemon.go
+++ b/system/daemon.go
@@ -1,9 +1,7 @@
 package system
 
 import (
-	"fmt"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -12,7 +10,8 @@ import (
 // SystemctlEnable call systemctl enable on thing.
 func SystemctlEnable(thing string) error {
 	if out, err := exec.Command("systemctl", "enable", thing).CombinedOutput(); err != nil {
-		return fmt.Errorf("Failed to call systemctl enable on %s - %v %s", thing, err, string(out))
+		ErrorLog("Failed to call systemctl enable on %s - %v %s", thing, err, string(out))
+		return err
 	}
 	return nil
 }
@@ -20,7 +19,8 @@ func SystemctlEnable(thing string) error {
 // SystemctlDisable call systemctl disable on thing.
 func SystemctlDisable(thing string) error {
 	if out, err := exec.Command("systemctl", "disable", thing).CombinedOutput(); err != nil {
-		return fmt.Errorf("Failed to call systemctl disable on %s - %v %s", thing, err, string(out))
+		ErrorLog("Failed to call systemctl disable on %s - %v %s", thing, err, string(out))
+		return err
 	}
 	return nil
 }
@@ -28,7 +28,8 @@ func SystemctlDisable(thing string) error {
 // SystemctlRestart call systemctl restart on thing.
 func SystemctlRestart(thing string) error {
 	if out, err := exec.Command("systemctl", "restart", thing).CombinedOutput(); err != nil {
-		return fmt.Errorf("Failed to call systemctl restart on %s - %v %s", thing, err, string(out))
+		ErrorLog("Failed to call systemctl restart on %s - %v %s", thing, err, string(out))
+		return err
 	}
 	return nil
 }
@@ -36,7 +37,8 @@ func SystemctlRestart(thing string) error {
 // SystemctlStart call systemctl start on thing.
 func SystemctlStart(thing string) error {
 	if out, err := exec.Command("systemctl", "start", thing).CombinedOutput(); err != nil {
-		return fmt.Errorf("Failed to call systemctl start on %s - %v %s", thing, err, string(out))
+		ErrorLog("Failed to call systemctl start on %s - %v %s", thing, err, string(out))
+		return err
 	}
 	return nil
 }
@@ -44,7 +46,8 @@ func SystemctlStart(thing string) error {
 // SystemctlStop call systemctl stop on thing.
 func SystemctlStop(thing string) error {
 	if out, err := exec.Command("systemctl", "stop", thing).CombinedOutput(); err != nil {
-		return fmt.Errorf("Failed to call systemctl stop on %s - %v %s", thing, err, string(out))
+		ErrorLog("Failed to call systemctl stop on %s - %v %s", thing, err, string(out))
+		return err
 	}
 	return nil
 }
@@ -86,7 +89,8 @@ func SystemctlIsRunning(thing string) bool {
 func WriteTunedAdmProfile(profileName string) error {
 	err := ioutil.WriteFile("/etc/tuned/active_profile", []byte(profileName), 0644)
 	if err != nil {
-		return fmt.Errorf("Failed to write tuned profile '%s' to '%s': %v", profileName, "/etc/tuned/active_profile", err)
+		ErrorLog("Failed to write tuned profile '%s' to '%s': %v", profileName, "/etc/tuned/active_profile", err)
+		return err
 	}
 	return nil
 }
@@ -106,7 +110,8 @@ func GetTunedProfile() string {
 // TunedAdmOff calls tuned-adm to switch off the active profile.
 func TunedAdmOff() error {
 	if out, err := exec.Command("tuned-adm", "off").CombinedOutput(); err != nil {
-		return fmt.Errorf("Failed to call tuned-adm to switch off the active profile - %v %s", err, string(out))
+		ErrorLog("Failed to call tuned-adm to switch off the active profile - %v %s", err, string(out))
+		return err
 	}
 	return nil
 }
@@ -116,7 +121,8 @@ func TunedAdmOff() error {
 // changed the behaviour/handling of the file /etc/tuned/active_profile
 func TunedAdmProfile(profileName string) error {
 	if out, err := exec.Command("tuned-adm", "profile", profileName).CombinedOutput(); err != nil {
-		return fmt.Errorf("Failed to call tuned-adm to active profile %s - %v %s", profileName, err, string(out))
+		ErrorLog("Failed to call tuned-adm to active profile %s - %v %s", profileName, err, string(out))
+		return err
 	}
 	return nil
 }
@@ -126,7 +132,7 @@ func TunedAdmProfile(profileName string) error {
 func GetTunedAdmProfile() string {
 	out, err := exec.Command("tuned-adm", "active").CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to call tuned-adm to get the active profile - %v %s", err, string(out))
+		ErrorLog("Failed to call tuned-adm to get the active profile - %v %s", err, string(out))
 		return ""
 	}
 	re := regexp.MustCompile(`Current active profile: ([\w-]+)`)

--- a/system/limits.go
+++ b/system/limits.go
@@ -60,7 +60,8 @@ type SecLimits struct {
 func ParseSecLimitsFile() (*SecLimits, error) {
 	content, err := ioutil.ReadFile("/etc/security/limits.conf")
 	if err != nil {
-		return nil, fmt.Errorf("failed to open limits.conf: %v", err)
+		ErrorLog("failed to open limits.conf: %v", err)
+		return nil, err
 	}
 	return ParseSecLimits(string(content)), nil
 }

--- a/system/logging.go
+++ b/system/logging.go
@@ -1,0 +1,82 @@
+package system
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+var infoLogger *log.Logger    // Info logger
+var debugLogger *log.Logger   // Debug logger
+var errorLogger *log.Logger   // Error logger
+var warningLogger *log.Logger // Warning logger
+
+// calledFrom returns the name and the line number of the calling source file
+func calledFrom() string {
+	ret := ""
+	_, file, no, ok := runtime.Caller(2)
+	if ok {
+		_, relfile := filepath.Split(file)
+		ret = fmt.Sprintf("%s:%d: ", relfile, no)
+	}
+	return ret
+}
+
+// DebugLog sents text to the DebugLogWriter
+func DebugLog(txt string, stuff ...interface{}) {
+	if debugLogger != nil {
+		debugLogger.Printf(calledFrom()+txt+"\n", stuff...)
+	}
+}
+
+// InfoLog sents text to the InfoLogWriter
+func InfoLog(txt string, stuff ...interface{}) {
+	if infoLogger != nil {
+		infoLogger.Printf(calledFrom()+txt+"\n", stuff...)
+	}
+}
+
+// WarningLog sents text to the WarningLogWriter
+func WarningLog(txt string, stuff ...interface{}) {
+	if warningLogger != nil {
+		warningLogger.Printf(calledFrom()+txt+"\n", stuff...)
+	}
+}
+
+// ErrorLog sents text to the ErrorLogWriter
+func ErrorLog(txt string, stuff ...interface{}) {
+	if errorLogger != nil {
+		errorLogger.Printf(calledFrom()+txt+"\n", stuff...)
+	}
+}
+
+// LogInit initialise the different log writer saptune will use
+func LogInit() {
+	var saptuneLog io.Writer
+	//define log format
+	logTimeFormat := time.Now().Format("2006-01-02 15:04:05.000 ")
+
+	//create log file with desired read/write permissions
+	saptuneLog, err := os.OpenFile("/var/log/tuned/tuned.log", os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
+	if err != nil {
+		panic(err.Error())
+	}
+	//saptuneWriter := io.MultiWriter(os.Stderr, saptuneLog)
+	//log.SetOutput(saptuneWriter)
+
+	debugLogWriter := io.MultiWriter(os.Stderr, saptuneLog)
+	infoLogWriter := io.MultiWriter(os.Stdout, saptuneLog)
+	warningLogWriter := io.MultiWriter(os.Stderr, saptuneLog)
+	errorLogWriter := io.MultiWriter(os.Stderr, saptuneLog)
+
+	debugLogger = log.New(debugLogWriter, logTimeFormat+"DEBUG    saptune.", 0)
+	infoLogger = log.New(infoLogWriter, logTimeFormat+"INFO     saptune.", 0)
+	warningLogger = log.New(warningLogWriter, logTimeFormat+"WARNING  saptune.", 0)
+	errorLogger = log.New(errorLogWriter, logTimeFormat+"ERROR    saptune.", 0)
+	//errorLogger = log.New(errorLogWriter, logTimeFormat+"ERROR    saptune.", log.Lshortfile)
+	//log.SetFlags(0)
+}

--- a/system/login.go
+++ b/system/login.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"fmt"
-	"log"
 	"os/exec"
 	"strings"
 )
@@ -13,12 +12,12 @@ func GetCurrentLogins() []string {
 	cmdName := "/usr/bin/loginctl"
 	cmdArgs := []string{"--no-pager", "--no-legend", "--no-ask-password", "list-users"}
 	if !CmdIsAvailable(cmdName) {
-		log.Printf("command '%s' not found", cmdName)
+		WarningLog("command '%s' not found", cmdName)
 		return uID
 	}
 	cmdOut, err := exec.Command(cmdName, cmdArgs...).CombinedOutput()
 	if err != nil {
-		log.Printf("failed to invoke external command '%s %v': %v, output: %s", cmdName, cmdArgs, err, string(cmdOut))
+		WarningLog("failed to invoke external command '%s %v': %v, output: %s", cmdName, cmdArgs, err, string(cmdOut))
 		return uID
 	}
 	for _, logins := range strings.Split(string(cmdOut), "\n") {
@@ -40,12 +39,12 @@ func GetTasksMax(userID string) string {
 	cmdArgs := []string{"show", "-p", "TasksMax", uSlice}
 
 	if !CmdIsAvailable(cmdName) {
-		log.Printf("command '%s' not found", cmdName)
+		WarningLog("command '%s' not found", cmdName)
 		return ""
 	}
 	cmdOut, err := exec.Command(cmdName, cmdArgs...).CombinedOutput()
 	if err != nil {
-		log.Printf("failed to invoke external command '%s %v': %v, output: %s", cmdName, cmdArgs, err, string(cmdOut))
+		WarningLog("failed to invoke external command '%s %v': %v, output: %s", cmdName, cmdArgs, err, string(cmdOut))
 		return ""
 	}
 	tasksMax := strings.Split(strings.TrimSpace(string(cmdOut)), "=")

--- a/system/login.go
+++ b/system/login.go
@@ -1,0 +1,71 @@
+package system
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+// GetCurrentLogins returns the user ids of the currently logged in users
+func GetCurrentLogins() []string {
+	uID := []string{}
+	cmdName := "/usr/bin/loginctl"
+	cmdArgs := []string{"--no-pager", "--no-legend", "--no-ask-password", "list-users"}
+	if !CmdIsAvailable(cmdName) {
+		log.Printf("command '%s' not found", cmdName)
+		return uID
+	}
+	cmdOut, err := exec.Command(cmdName, cmdArgs...).CombinedOutput()
+	if err != nil {
+		log.Printf("failed to invoke external command '%s %v': %v, output: %s", cmdName, cmdArgs, err, string(cmdOut))
+		return uID
+	}
+	for _, logins := range strings.Split(string(cmdOut), "\n") {
+		if logins == "" {
+			continue
+		}
+		user := strings.Split(strings.TrimSpace(logins), " ")
+		uID = append(uID, user[0])
+	}
+	return uID
+}
+
+// GetTasksMax returns the current limit of TasksMax for a given user id
+// which is the value for UserTasksMax
+func GetTasksMax(userID string) string {
+	//systemctl show -p TasksMax user-<uid>.slice
+	uSlice := "user-" + userID + ".slice"
+	cmdName := "/usr/bin/systemctl"
+	cmdArgs := []string{"show", "-p", "TasksMax", uSlice}
+
+	if !CmdIsAvailable(cmdName) {
+		log.Printf("command '%s' not found", cmdName)
+		return ""
+	}
+	cmdOut, err := exec.Command(cmdName, cmdArgs...).CombinedOutput()
+	if err != nil {
+		log.Printf("failed to invoke external command '%s %v': %v, output: %s", cmdName, cmdArgs, err, string(cmdOut))
+		return ""
+	}
+	tasksMax := strings.Split(strings.TrimSpace(string(cmdOut)), "=")
+	if len(tasksMax) == 0 {
+		return ""
+	}
+	return tasksMax[1]
+}
+
+// SetTasksMax sets the limit of TasksMax for a given user id to 'limit'
+func SetTasksMax(userID, limit string) error {
+	//systemctl  --runtime set-property user-<uid>.slice TasksMax=infinity
+	uSlice := "user-" + userID + ".slice"
+	tmLimit := "TasksMax=" + limit
+	cmdName := "/usr/bin/systemctl"
+	cmdArgs := []string{"--runtime", "set-property", uSlice, tmLimit}
+
+	if !CmdIsAvailable(cmdName) {
+		return fmt.Errorf("command '%s' not found", cmdName)
+	}
+	_, err := exec.Command(cmdName, cmdArgs...).CombinedOutput()
+	return err
+}

--- a/system/rpm.go
+++ b/system/rpm.go
@@ -23,7 +23,7 @@ func GetRpmVers(rpm string) string {
 	cmdOut, err := exec.Command(cmdName, cmdArgs...).CombinedOutput()
 	if err != nil {
 		if len(string(cmdOut)) == 0 || strings.TrimSpace(string(cmdOut)) != notInstalled {
-			fmt.Printf("There was an error running external command 'rpm -q --qf '%%{VERSION}-%%{RELEASE}' %s': %v, output: %s", rpm, err, cmdOut)
+			WarningLog("There was an error running external command 'rpm -q --qf '%%{VERSION}-%%{RELEASE}' %s': %v, output: %s", rpm, err, cmdOut)
 		}
 		return ""
 	}

--- a/system/sys.go
+++ b/system/sys.go
@@ -3,7 +3,6 @@ package system
 // Manipulate /sys/ switches.
 
 import (
-	"fmt"
 	"io/ioutil"
 	"path"
 	"strconv"
@@ -14,7 +13,8 @@ import (
 func GetSysString(parameter string) (string, error) {
 	val, err := ioutil.ReadFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)))
 	if err != nil {
-		return "", fmt.Errorf("failed to read sys string key '%s': %v", parameter, err)
+		WarningLog("failed to read sys string key '%s': %v", parameter, err)
+		return "", err
 	}
 	return strings.TrimSpace(string(val)), nil
 }
@@ -24,7 +24,8 @@ func GetSysString(parameter string) (string, error) {
 func GetSysChoice(parameter string) (string, error) {
 	val, err := ioutil.ReadFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)))
 	if err != nil {
-		return "", fmt.Errorf("failed to read sys key of choices '%s': %v", parameter, err)
+		WarningLog("failed to read sys key of choices '%s': %v", parameter, err)
+		return "", err
 	}
 	// Split up the choices
 	allChoices := consecutiveSpaces.Split(string(val), -1)
@@ -40,7 +41,8 @@ func GetSysChoice(parameter string) (string, error) {
 func GetSysInt(parameter string) (int, error) {
 	value, err := GetSysString(parameter)
 	if err != nil {
-		return 0, fmt.Errorf("failed to read integer sys key '%s': %v", parameter, err)
+		WarningLog("failed to read integer sys key '%s': %v", parameter, err)
+		return 0, err
 	}
 	return strconv.Atoi(value)
 }
@@ -48,7 +50,8 @@ func GetSysInt(parameter string) (int, error) {
 // SetSysString write a string /sys/ value.
 func SetSysString(parameter, value string) error {
 	if err := ioutil.WriteFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644); err != nil {
-		return fmt.Errorf("failed to set sys key '%s' to string '%s': %v", parameter, value, err)
+		WarningLog("failed to set sys key '%s' to string '%s': %v", parameter, value, err)
+		return err
 	}
 	return nil
 }
@@ -62,7 +65,8 @@ func SetSysInt(parameter string, value int) error {
 func TestSysString(parameter, value string) error {
 	save, err := GetSysString(parameter)
 	if err != nil {
-		return fmt.Errorf("failed to get sys key '%s': %v", parameter, err)
+		WarningLog("failed to get sys key '%s': %v", parameter, err)
+		return err
 	}
 	if err = ioutil.WriteFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644); err == nil {
 		// set key back to previous value, because this was only a test

--- a/system/sysctl.go
+++ b/system/sysctl.go
@@ -5,7 +5,6 @@ package system
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"strconv"
@@ -69,7 +68,8 @@ const (
 func GetSysctlString(parameter string) (string, error) {
 	val, err := ioutil.ReadFile(path.Join("/proc/sys", strings.Replace(parameter, ".", "/", -1)))
 	if err != nil {
-		return "", fmt.Errorf("Failed to read sysctl key '%s': %v", parameter, err)
+		WarningLog("Failed to read sysctl key '%s': %v", parameter, err)
+		return "", err
 	}
 	return strings.TrimSpace(string(val)), nil
 }
@@ -96,9 +96,10 @@ func GetSysctlUint64(parameter string) (uint64, error) {
 func SetSysctlString(parameter, value string) error {
 	err := ioutil.WriteFile(path.Join("/proc/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644)
 	if os.IsNotExist(err) {
-		log.Printf("sysctl key '%s' is not supported by os, skipping.", parameter)
+		WarningLog("sysctl key '%s' is not supported by os, skipping.", parameter)
 	} else if err != nil {
-		return fmt.Errorf("Failed to write sysctl key '%s': %v", parameter, err)
+		WarningLog("Failed to write sysctl key '%s': %v", parameter, err)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
set/remove value for UserTasksMax during apply/revert of the related Notes and NO longer during postinstall of package installation (bsc#1124489)

using different LogWriters for INFO, WARNING, ERROR and DEBUG
and add the expected format (<date> <timestamp> <prio:8> saptune.<saptune_routine>:<line_no> <message>) to the log messages
Now the discussion can start, which logging information is expected/desired and which severity should be used

additional some minor changes are done:
- move more update stuff from postinstall/posttrans script of the saptune package to the upd_helper script to simplify the package scripts
- ignore saved state files with suffix '_n2c' during RevertAll action as they are only migration helper files and no active saved state files
- add option 'version' and '--version' to bash-completion