### PR TITLE
add some small enhancements to please our beta testers

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -56,11 +56,18 @@ func InitialiseApp(sysconfigPrefix, stateDirPrefix string, allNotes map[string]n
 	return
 }
 
+// PrintNoteApplyOrder prints out the order of the currently applied notes
+func (app *App) PrintNoteApplyOrder() {
+	if len(app.NoteApplyOrder) != 0 {
+		fmt.Printf("\ncurrent order of applied notes is: %s\n\n", strings.Join(app.NoteApplyOrder, " "))
+	}
+}
+
 // PositionInNoteApplyOrder returns the position of the note within the slice.
 // for a given noteID get the position in the slice NoteApplyOrder
 // do not sort the slice
-func PositionInNoteApplyOrder(list []string, noteID string) int {
-	for cnt, note := range list {
+func (app *App) PositionInNoteApplyOrder(noteID string) int {
+	for cnt, note := range app.NoteApplyOrder {
 		if note == noteID {
 			return cnt
 		}
@@ -134,7 +141,7 @@ func (app *App) TuneNote(noteID string) error {
 		sort.Strings(app.TuneForNotes)
 	}
 	// to prevent double noteIDs in the apply order list
-	i := PositionInNoteApplyOrder(app.NoteApplyOrder, noteID)
+	i := app.PositionInNoteApplyOrder(noteID)
 	if i < 0 { // noteID not yet available
 		app.NoteApplyOrder = append(app.NoteApplyOrder, noteID)
 	}
@@ -191,6 +198,7 @@ func (app *App) TuneNote(noteID string) error {
 	if len(valApplyList) != 0 {
 		optimised = optimised.(note.INISettings).SetValuesToApply(valApplyList)
 	}
+
 	if conforming {
 		// Do not apply the Note, if the system already complies with
 		// the requirements.
@@ -259,7 +267,7 @@ func (app *App) RevertNote(noteID string, permanent bool) error {
 		if i < len(app.TuneForNotes) && app.TuneForNotes[i] == noteID {
 			app.TuneForNotes = append(app.TuneForNotes[0:i], app.TuneForNotes[i+1:]...)
 		}
-		i = PositionInNoteApplyOrder(app.NoteApplyOrder, noteID)
+		i = app.PositionInNoteApplyOrder(noteID)
 		if i < 0 {
 			system.WarningLog("noteID '%s' not found in configuration 'NoteApplyOrder'", noteID)
 		} else if i < len(app.NoteApplyOrder) && app.NoteApplyOrder[i] == noteID {

--- a/main.go
+++ b/main.go
@@ -575,12 +575,10 @@ func NoteAction(actionName, noteID string) {
 		editFileName := ""
 		fileName := fmt.Sprintf("%s%s", NoteTuningSheets, noteID)
 		if _, err := os.Stat(fileName); os.IsNotExist(err) {
-			_, files, err := system.ListDir(ExtraTuningSheets)
-			if err == nil {
-				for _, f := range files {
-					if strings.HasPrefix(f, noteID) {
-						fileName = fmt.Sprintf("%s%s", ExtraTuningSheets, f)
-					}
+			_, files := system.ListDir(ExtraTuningSheets, "")
+			for _, f := range files {
+				if strings.HasPrefix(f, noteID) {
+					fileName = fmt.Sprintf("%s%s", ExtraTuningSheets, f)
 				}
 			}
 			if _, err := os.Stat(fileName); os.IsNotExist(err) {

--- a/main.go
+++ b/main.go
@@ -465,6 +465,7 @@ func VerifyAllParameters() {
 		errorExit("Failed to inspect the current system: %v", err)
 	}
 	PrintNoteFields("NONE", comparisons, true)
+	tuneApp.PrintNoteApplyOrder()
 	if len(unsatisfiedNotes) == 0 {
 		fmt.Println("The running system is currently well-tuned according to all of the enabled notes.")
 	} else {
@@ -515,7 +516,7 @@ func NoteAction(actionName, noteID string) {
 				format = " O" + format
 			}
 			if i := sort.SearchStrings(solutionNoteIDs, noteID); i < len(solutionNoteIDs) && solutionNoteIDs[i] == noteID {
-				j := app.PositionInNoteApplyOrder(tuneApp.NoteApplyOrder, noteID)
+				j := tuneApp.PositionInNoteApplyOrder(noteID)
 				if j < 0 { // noteID was reverted manually
 					format = " " + setGreenText + "-" + format + resetTextColor
 				} else {
@@ -526,8 +527,9 @@ func NoteAction(actionName, noteID string) {
 			}
 			fmt.Printf(format, noteID, noteObj.Name())
 		}
+		tuneApp.PrintNoteApplyOrder()
 		if !system.SystemctlIsRunning(TunedService) || system.GetTunedProfile() != TunedProfileName {
-			fmt.Println("\nRemember: if you wish to automatically activate the solution's tuning options after a reboot," +
+			fmt.Println("Remember: if you wish to automatically activate the solution's tuning options after a reboot," +
 				"you must instruct saptune to configure \"tuned\" daemon by running:" +
 				"\n    saptune daemon start")
 		}
@@ -543,6 +545,7 @@ func NoteAction(actionName, noteID string) {
 			noteComp := make(map[string]map[string]note.FieldComparison)
 			noteComp[noteID] = comparisons
 			PrintNoteFields("HEAD", noteComp, true)
+			tuneApp.PrintNoteApplyOrder()
 			if !conforming {
 				errorExit("The parameters listed above have deviated from the specified note.\n")
 			} else {

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -165,15 +165,18 @@ The command '\fBcpupower -c all frequency-set -g <value>\fR' or '\fBcpupower -c 
 .SH "[service]"
 The section "[service]" is dealing with starting and stopping services controlled by systemd.
 .br
-This section can contain the following options:
+The syntax for the entries are:
 .TP
-.BI UuiddSocket= STRING
-This option starts the uuidd.socket service. Only '\fBstart\fR' is a valid value, because the uuidd.socket service is essential for a working SAP environment.
-.TP
-.BI Sysstat= STRING
-This option handels the sysstat service. Valid values are '\fBstart\fR' or '\fBstop\fR'.
+.BI <servicename>=<start|stop>
+Valid services are those listed by the command '\fIsystemctl list-unit-files\fR'.
 .br
-Please be in mind: A running sysstat service can effect the system performance. But if there are real performance trouble with the SAP system, SAP service normally orders the sysstat reports collected in /var/log/sa.
+Valid values are '\fBstart\fR' or '\fBstop\fR'.
+.TP
+.BI Exceptions\ and\ Warnings:
+.TP
+For the service \fBuuidd.socket\fR only '\fBstart\fR' is a valid value, because the uuidd.socket service is essential for a working SAP environment.
+.TP
+Concerning \fBsysstat.service\fR please be in mind: A running sysstat service can effect the system performance. But if there are real performance trouble with the SAP system, SAP service normally orders the sysstat reports collected in /var/log/sa.
 .br
 See sar(1), sa2(8), sa1(8) for more information
 .SH "[reminder]"

--- a/ospackage/man/saptune_v2.8
+++ b/ospackage/man/saptune_v2.8
@@ -26,7 +26,7 @@ saptune \- Comprehensive system optimisation management for SAP solutions (Versi
 [ list | verify ]
 
 \fBsaptune note\fP
-[ apply | simulate | verify | customise | revert ]  NoteID
+[ apply | simulate | verify | customise | create | revert ]  NoteID
 
 \fBsaptune solution\fP
 [ list | verify ]
@@ -135,6 +135,11 @@ If a Note definition contains a '\fB[reminder]\fR' section, this section will be
 .B customise
 This allows to customize the values of the saptune Note definitions. The Note definition file will be copied from \fI/usr/share/saptune/notes\fR or \fI/etc/saptune/extra\fR to the override location at \fI/etc/saptune/override\fR, if the file does not exist already. After that an editor will be launched to allow changing the Note definitions.
 The editor is defined by the \fBEDITOR\fR environment variable. If not set editor defaults to /usr/bin/vim.
+.TP
+.B create
+This allows to create own Note definition files in \fI/etc/saptune/extra\fR. The Note definition file will be created from a template file into the location \fI/etc/saptune/extra\fR, if the file does not exist already. After that an editor will be launched to allow changing the Note definitions.
+The editor is defined by the \fBEDITOR\fR environment variable. If not set editor defaults to /usr/bin/vim.
+You need to choose an unique NoteID for this operation. Use '\fIsaptune note list\fR' to find the already used NoteIDs.
 .TP
 .B revert
 Revert optimisation settings carried out by the Note, and the Note will no longer be activated automatically upon system boot.

--- a/ospackage/usr/share/saptune/NoteTemplate.conf
+++ b/ospackage/usr/share/saptune/NoteTemplate.conf
@@ -1,0 +1,24 @@
+# This is a template for a saptune note definition file.
+#
+# You can add here your own configuration. See saptune-note(5) for details.
+# The version section is mandatory, it *must* exist.
+#
+# change all _TEXT_TO_CHANGE_ with your values
+# and add all the needed sections and parameter/value pairs
+
+[version]
+# _TEXT_TO_CHANGE_-NOTE=_TEXT_TO_CHANGE_ CATEGORY=_TEXT_TO_CHANGE_ VERSION=0 DATE=_TEXT_TO_CHANGE_ NAME=" _TEXT_TO_CHANGE_ "
+
+# supported sections
+#[block]
+#[cpu]
+#[grub]
+#[limits]
+#[login]
+#[mem]
+#[pagecache]
+#[reminder]
+#[rpm]
+#[service]
+#[sysctl]
+#[vm]

--- a/ospackage/usr/share/saptune/notes/1984787
+++ b/ospackage/usr/share/saptune/notes/1984787
@@ -18,8 +18,8 @@ UserTasksMax=infinity
 
 [service]
 # start the related services
-UuiddSocket=start
-Sysstat=start
+uuidd.socket=start
+sysstat.service=start
 
 [block]
 # The default I/O scheduler for SLES is CFQ. It offers satisfactory performance

--- a/ospackage/usr/share/saptune/notes/2578899
+++ b/ospackage/usr/share/saptune/notes/2578899
@@ -18,8 +18,8 @@ UserTasksMax=infinity
 
 [service]
 # start the related services
-UuiddSocket=start
-Sysstat=start
+uuidd.socket=start
+sysstat.service=start
 
 [block]
 # The default I/O scheduler for SLES is CFQ. It offers satisfactory performance

--- a/sap/note/ini.go
+++ b/sap/note/ini.go
@@ -143,8 +143,6 @@ func (vend INISettings) Initialise() (Note, error) {
 			vend.SysctlParams[param.Key], _ = GetBlkVal(param.Key)
 		case INISectionLimits:
 			vend.SysctlParams[param.Key], _ = GetLimitsVal(param.Value)
-		case INISectionUuidd:
-			vend.SysctlParams[param.Key] = GetUuiddVal()
 		case INISectionService:
 			vend.SysctlParams[param.Key] = GetServiceVal(param.Key)
 		case INISectionLogin:
@@ -225,8 +223,6 @@ func (vend INISettings) Optimise() (Note, error) {
 			vend.SysctlParams[param.Key] = OptBlkVal(param.Key, vend.SysctlParams[param.Key], param.Value)
 		case INISectionLimits:
 			vend.SysctlParams[param.Key] = OptLimitsVal(vend.SysctlParams[param.Key], param.Value)
-		case INISectionUuidd:
-			vend.SysctlParams[param.Key] = OptUuiddVal(param.Value)
 		case INISectionService:
 			vend.SysctlParams[param.Key] = OptServiceVal(param.Key, param.Value)
 		case INISectionLogin:
@@ -351,8 +347,6 @@ func (vend INISettings) Apply() error {
 			errs = append(errs, SetBlkVal(param.Key, vend.SysctlParams[param.Key]))
 		case INISectionLimits:
 			errs = append(errs, SetLimitsVal(param.Key, pvendID, vend.SysctlParams[param.Key], revertValues))
-		case INISectionUuidd:
-			errs = append(errs, SetUuiddVal(vend.SysctlParams[param.Key]))
 		case INISectionService:
 			errs = append(errs, SetServiceVal(param.Key, vend.SysctlParams[param.Key]))
 		case INISectionLogin:

--- a/sap/note/ini_sections.go
+++ b/sap/note/ini_sections.go
@@ -538,7 +538,9 @@ func GetServiceVal(key string) string {
 func OptServiceVal(key, cfgval string) string {
 	sval := strings.ToLower(cfgval)
 	service := system.GetServiceName(key)
-
+	if service == "" {
+		return "NA"
+	}
 	if service == "uuidd.socket" && sval != "start" {
 		// for uuidd.socket we only support 'start' (bsc#1100107)
 		system.WarningLog("wrong selection '%s' for '%s'. Now set to 'start' to start the service\n", sval, service)

--- a/sap/note/ini_sections_test.go
+++ b/sap/note/ini_sections_test.go
@@ -13,15 +13,19 @@ import (
 var PCTestBaseConf = path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/ospackage/usr/share/saptune/note/1557506")
 
 func TestGetServiceName(t *testing.T) {
-	val := GetServiceName("UuiddSocket")
+	val := system.GetServiceName("uuidd.socket")
 	if val != "uuidd.socket" {
 		t.Fatal(val)
 	}
-	val = GetServiceName("Sysstat")
-	if val != "sysstat" {
+	val = system.GetServiceName("sysstat")
+	if val != "sysstat.service" {
 		t.Fatal(val)
 	}
-	val = GetServiceName("UnkownService")
+	val = system.GetServiceName("sysstat.service")
+	if val != "sysstat.service" {
+		t.Fatal(val)
+	}
+	val = system.GetServiceName("UnkownService")
 	if val != "" {
 		t.Fatal(val)
 	}
@@ -310,36 +314,12 @@ func TestSetGrubVal(t *testing.T) {
 	}
 }
 
-func TestGetUuiddVal(t *testing.T) {
-	val := GetUuiddVal()
-	if val != "start" && val != "stop" {
-		t.Fatal(val)
-	}
-}
-
-func TestOptUuiddVal(t *testing.T) {
-	val := OptUuiddVal("start")
-	if val != "start" {
-		t.Fatal(val)
-	}
-	val = OptUuiddVal("stop")
-	if val != "start" {
-		t.Fatal(val)
-	}
-	val = OptUuiddVal("unknown")
-	if val != "start" {
-		t.Fatal(val)
-	}
-}
-
-//SetUuiddVal
-
 func TestGetServiceVal(t *testing.T) {
 	val := GetServiceVal("UnkownService")
-	if val != "" {
+	if val != "NA" {
 		t.Fatal(val)
 	}
-	val = GetServiceVal("UuiddSocket")
+	val = GetServiceVal("uuidd.socket")
 	if val != "start" && val != "stop" && val != "" {
 		t.Fatal(val)
 	}
@@ -347,30 +327,30 @@ func TestGetServiceVal(t *testing.T) {
 
 func TestOptServiceVal(t *testing.T) {
 	val := OptServiceVal("UnkownService", "start")
-	if val != "" {
-		t.Fatal(val)
-	}
-	val = OptServiceVal("UuiddSocket", "start")
 	if val != "start" {
 		t.Fatal(val)
 	}
-	val = OptServiceVal("UuiddSocket", "stop")
+	val = OptServiceVal("uuidd.socket", "start")
 	if val != "start" {
 		t.Fatal(val)
 	}
-	val = OptServiceVal("UuiddSocket", "unknown")
+	val = OptServiceVal("uuidd.socket", "stop")
 	if val != "start" {
 		t.Fatal(val)
 	}
-	val = OptServiceVal("Sysstat", "start")
+	val = OptServiceVal("uuidd.socket", "unknown")
 	if val != "start" {
 		t.Fatal(val)
 	}
-	val = OptServiceVal("Sysstat", "stop")
+	val = OptServiceVal("sysstat", "start")
+	if val != "start" {
+		t.Fatal(val)
+	}
+	val = OptServiceVal("sysstat.service", "stop")
 	if val != "stop" {
 		t.Fatal(val)
 	}
-	val = OptServiceVal("Sysstat", "unknown")
+	val = OptServiceVal("sysstat", "unknown")
 	if val != "start" {
 		t.Fatal(val)
 	}

--- a/sap/note/ini_sections_test.go
+++ b/sap/note/ini_sections_test.go
@@ -14,15 +14,15 @@ var PCTestBaseConf = path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptun
 
 func TestGetServiceName(t *testing.T) {
 	val := system.GetServiceName("uuidd.socket")
-	if val != "uuidd.socket" {
+	if val != "uuidd.socket" && val != "" {
 		t.Fatal(val)
 	}
 	val = system.GetServiceName("sysstat")
-	if val != "sysstat.service" {
+	if val != "sysstat.service" && val != "" {
 		t.Fatal(val)
 	}
 	val = system.GetServiceName("sysstat.service")
-	if val != "sysstat.service" {
+	if val != "sysstat.service" && val != "" {
 		t.Fatal(val)
 	}
 	val = system.GetServiceName("UnkownService")
@@ -320,38 +320,38 @@ func TestGetServiceVal(t *testing.T) {
 		t.Fatal(val)
 	}
 	val = GetServiceVal("uuidd.socket")
-	if val != "start" && val != "stop" && val != "" {
+	if val != "start" && val != "stop" && val != "NA" {
 		t.Fatal(val)
 	}
 }
 
 func TestOptServiceVal(t *testing.T) {
 	val := OptServiceVal("UnkownService", "start")
-	if val != "start" {
+	if val != "NA" {
 		t.Fatal(val)
 	}
 	val = OptServiceVal("uuidd.socket", "start")
-	if val != "start" {
+	if val != "start" && val != "NA" {
 		t.Fatal(val)
 	}
 	val = OptServiceVal("uuidd.socket", "stop")
-	if val != "start" {
+	if val != "start" && val != "NA" {
 		t.Fatal(val)
 	}
 	val = OptServiceVal("uuidd.socket", "unknown")
-	if val != "start" {
+	if val != "start" && val != "NA" {
 		t.Fatal(val)
 	}
 	val = OptServiceVal("sysstat", "start")
-	if val != "start" {
+	if val != "start" && val != "NA" {
 		t.Fatal(val)
 	}
 	val = OptServiceVal("sysstat.service", "stop")
-	if val != "stop" {
+	if val != "stop" && val != "NA" {
 		t.Fatal(val)
 	}
 	val = OptServiceVal("sysstat", "unknown")
-	if val != "start" {
+	if val != "start" && val != "NA" {
 		t.Fatal(val)
 	}
 }

--- a/sap/note/ini_test.go
+++ b/sap/note/ini_test.go
@@ -2,8 +2,8 @@ package note
 
 import (
 	"fmt"
-	"github.com/SUSE/saptune/txtparser"
 	"github.com/SUSE/saptune/system"
+	"github.com/SUSE/saptune/txtparser"
 	"os"
 	"path"
 	"runtime"

--- a/sap/note/ini_test.go
+++ b/sap/note/ini_test.go
@@ -131,9 +131,9 @@ func TestVendorSettings(t *testing.T) {
 
 func TestAllSettings(t *testing.T) {
 	cleanUp()
-	testString := []string{"vm.nr_hugepages", "THP", "KSM", "Sysstat"}
+	testString := []string{"vm.nr_hugepages", "THP", "KSM", "sysstat"}
 	if runtime.GOARCH == "ppc64le" {
-		testString = []string{"KSM", "Sysstat"}
+		testString = []string{"KSM", "sysstat"}
 	}
 	iniPath := path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/ini_all_test.ini")
 	ini := INISettings{ConfFilePath: iniPath}
@@ -219,13 +219,13 @@ func TestAllSettings(t *testing.T) {
 	if optimisedINI.SysctlParams["VSZ_TMPFS_PERCENT"] != "60" {
 		t.Fatal(optimisedINI.SysctlParams)
 	}
-	if optimisedINI.SysctlParams["Sysstat"] != "stop" {
+	if optimisedINI.SysctlParams["sysstat"] != "stop" {
 		t.Fatal(optimisedINI.SysctlParams)
 	}
-	if optimisedINI.SysctlParams["UuiddSocket"] != "start" {
+	if optimisedINI.SysctlParams["uuidd.socket"] != "start" {
 		t.Fatal(optimisedINI.SysctlParams)
 	}
-	if optimisedINI.SysctlParams["UnkownService"] != "" {
+	if optimisedINI.SysctlParams["UnkownService"] != "stop" {
 		t.Fatal(optimisedINI.SysctlParams)
 	}
 	if optimisedINI.SysctlParams["grub:transparent_hugepage"] != "never" {

--- a/sap/note/ini_test.go
+++ b/sap/note/ini_test.go
@@ -219,13 +219,13 @@ func TestAllSettings(t *testing.T) {
 	if optimisedINI.SysctlParams["VSZ_TMPFS_PERCENT"] != "60" {
 		t.Fatal(optimisedINI.SysctlParams)
 	}
-	if optimisedINI.SysctlParams["sysstat"] != "stop" {
+	if optimisedINI.SysctlParams["sysstat"] != "stop" && optimisedINI.SysctlParams["sysstat"] != "NA" {
 		t.Fatal(optimisedINI.SysctlParams)
 	}
-	if optimisedINI.SysctlParams["uuidd.socket"] != "start" {
+	if optimisedINI.SysctlParams["uuidd.socket"] != "start" && optimisedINI.SysctlParams["uuidd.socket"] != "NA" {
 		t.Fatal(optimisedINI.SysctlParams)
 	}
-	if optimisedINI.SysctlParams["UnkownService"] != "stop" {
+	if optimisedINI.SysctlParams["UnkownService"] != "NA" {
 		t.Fatal(optimisedINI.SysctlParams)
 	}
 	if optimisedINI.SysctlParams["grub:transparent_hugepage"] != "never" {

--- a/sap/note/note.go
+++ b/sap/note/note.go
@@ -52,11 +52,7 @@ func Note2Convert(noteID string) string {
 func GetTuningOptions(saptuneTuningDir, thirdPartyTuningDir string) TuningOptions {
 	ret := TuningOptions{}
 	// Collect those defined by saptune
-	_, files, err := system.ListDir(saptuneTuningDir)
-	if err != nil {
-		// Not a fatal error
-		system.WarningLog("GetTuningOptions: failed to read saptune tuning definitions - %v", err)
-	}
+	_, files := system.ListDir(saptuneTuningDir, "saptune tuning definitions")
 	for _, fileName := range files {
 		ret[fileName] = INISettings{
 			ConfFilePath:    path.Join(saptuneTuningDir, fileName),
@@ -66,11 +62,7 @@ func GetTuningOptions(saptuneTuningDir, thirdPartyTuningDir string) TuningOption
 	}
 
 	// Collect those defined by 3rd party
-	_, files, err = system.ListDir(thirdPartyTuningDir)
-	if err != nil {
-		// Not a fatal error
-		system.WarningLog("GetTuningOptions: failed to read 3rd party tuning definitions - %v", err)
-	}
+	_, files = system.ListDir(thirdPartyTuningDir, "3rd party tuning definitions")
 	for _, fileName := range files {
 		// ignore left over files (BOBJ and ASE definition files) from
 		// the migration of saptune version 1 to saptune version 2

--- a/sap/note/note.go
+++ b/sap/note/note.go
@@ -79,6 +79,12 @@ func GetTuningOptions(saptuneTuningDir, thirdPartyTuningDir string) TuningOption
 			system.WarningLog("For more information refer to the man page saptune-migrate(7)")
 			continue
 		}
+		if !strings.HasSuffix(fileName, ".conf") {
+			// skip filenames without .conf suffix
+			system.WarningLog("skip file \"%s\", wrong filename syntax, missing '.conf' suffix", fileName)
+			continue
+		}
+
 		id := ""
 		// get the description of the note from the header inside the file
 		name := txtparser.GetINIFileDescriptiveName(path.Join(thirdPartyTuningDir, fileName))

--- a/system/fs.go
+++ b/system/fs.go
@@ -122,10 +122,11 @@ func RemountSHM(newSizeMB uint64) error {
 }
 
 // ListDir list directory content.
-func ListDir(dirPath string) (dirNames, fileNames []string, err error) {
+func ListDir(dirPath, logMsg string) (dirNames, fileNames []string) {
 	entries, err := ioutil.ReadDir(dirPath)
-	if err != nil {
-		return
+	if err != nil && logMsg != "" {
+		// Not a fatal error
+		WarningLog("failed to read %s - %v", logMsg, err)
 	}
 	dirNames = make([]string, 0, 0)
 	fileNames = make([]string, 0, 0)

--- a/system/fs_test.go
+++ b/system/fs_test.go
@@ -221,10 +221,7 @@ func TestListDir(t *testing.T) {
 	} else if err := file.Close(); err != nil {
 		t.Fatal(err)
 	}
-	dirs, files, err := ListDir(tmpDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dirs, files := ListDir(tmpDir, "")
 	if !reflect.DeepEqual(dirs, []string{"aDir"}) {
 		t.Fatal(dirs)
 	}

--- a/testdata/ini_all_test.ini
+++ b/testdata/ini_all_test.ini
@@ -30,15 +30,12 @@ VSZ_TMPFS_PERCENT=60
 glibc all 2.22-51.6
 
 [service]
-Sysstat=stop
-UuiddSocket=start
+sysstat=stop
+uuidd.socket=start
 UnkownService=stop
 
 [sysctl]
 vm.nr_hugepages=128
-
-[uuidd]
-UuiddSocket=start
 
 [vm]
 THP=always


### PR DESCRIPTION
print current applied note order at the end of 'saptune note list' and 'saptune note verify'
section [service] now supports all services and not only uuidd.sockets and sysstat
remove uuidd.socket specific section [uuidd] as it's no longer needed
add new action 'create' to support the customer/vendor while creating a vendor or customer specific file in /etc/saptune/extra