### PR TITLE
change of block device handling - scheduler and nr_req setting

### DIFF
--- a/sap/note/ini_sections_test.go
+++ b/sap/note/ini_sections_test.go
@@ -1,6 +1,7 @@
 package note
 
 import (
+	"github.com/SUSE/saptune/sap/param"
 	"github.com/SUSE/saptune/system"
 	"github.com/SUSE/saptune/txtparser"
 	"os"
@@ -49,28 +50,29 @@ func TestOptSysctlVal(t *testing.T) {
 
 //GetBlkVal
 func TestOptBlkVal(t *testing.T) {
-	val := OptBlkVal("IO_SCHEDULER", "sda@cfq", "noop")
-	if val != "sda@noop" {
+	tblck := param.BlockDeviceQueue{param.BlockDeviceSchedulers{SchedulerChoice: make(map[string]string)}, param.BlockDeviceNrRequests{NrRequests: make(map[string]int)}}
+	val := OptBlkVal("IO_SCHEDULER_sda", "noop", &tblck)
+	if val != "noop" {
 		t.Fatal(val)
 	}
-	val = OptBlkVal("IO_SCHEDULER", "sda@cfq", "NoOP")
-	if val != "sda@noop" {
+	val = OptBlkVal("IO_SCHEDULER_sdb", "NoOP", &tblck)
+	if val != "noop" {
 		t.Fatal(val)
 	}
-	val = OptBlkVal("IO_SCHEDULER", "sda@cfq sdb@cfq sdc@none", "noop")
-	if val != "sda@noop sdb@noop sdc@noop" {
+	val = OptBlkVal("IO_SCHEDULER_sdc", "cfq", &tblck)
+	if val != "cfq" {
 		t.Fatal(val)
 	}
-	val = OptBlkVal("NRREQ", "sda@128", "512")
-	if val != "sda@512" {
+	val = OptBlkVal("NRREQ_sda", "512", &tblck)
+	if val != "512" {
 		t.Fatal(val)
 	}
-	val = OptBlkVal("NRREQ", "sda@128", "0")
-	if val != "sda@1024" {
+	val = OptBlkVal("NRREQ_sdb", "0", &tblck)
+	if val != "1024" {
 		t.Fatal(val)
 	}
-	val = OptBlkVal("NRREQ", "sda@128 sdb@512 sdc@1024", "512")
-	if val != "sda@512 sdb@512 sdc@512" {
+	val = OptBlkVal("NRREQ_sdc", "128", &tblck)
+	if val != "128" {
 		t.Fatal(val)
 	}
 }

--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -174,6 +174,18 @@ func ParseINI(input string) *INIFile {
 				currentEntriesArray = append(currentEntriesArray, entry)
 				currentEntriesMap[entry.Key] = entry
 			}
+		} else if currentSection == "block" {
+			_, sysDevs := system.ListDir("/sys/block", "the available block devices of the system")
+			for _, bdev := range sysDevs {
+				entry := INIEntry{
+					Section:  currentSection,
+					Key:      fmt.Sprintf("%s_%s", kov[1], bdev),
+					Operator: Operator(kov[2]),
+					Value:    kov[3],
+				}
+				currentEntriesArray = append(currentEntriesArray, entry)
+				currentEntriesMap[entry.Key] = entry
+			}
 		} else {
 			// handle tunables with more than one value
 			value := strings.Replace(kov[3], " ", "\t", -1)


### PR DESCRIPTION
change the handling of the block device configuration to have a better representation and display on big systems with many devices. Mainly important for the 'verify' and 'simulate' action