### PR TITLE
change handling of force latency

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -128,6 +128,7 @@ and then please double check your input and /etc/sysconfig/saptune`, name)
 // If the note is not yet covered by one of the enabled solutions,
 // the note number will be added into the list of additional notes.
 func (app *App) TuneNote(noteID string) error {
+	forceApply := false
 	aNote, err := app.GetNoteByID(noteID)
 	if err != nil {
 		return err
@@ -177,6 +178,8 @@ func (app *App) TuneNote(noteID string) error {
 					addkey = "vm.dirty_background_bytes"
 				case "vm.dirty_ratio":
 					addkey = "vm.dirty_bytes"
+				case "force_latency":
+					forceApply = true
 				}
 				if addkey != "" {
 					//currentState.(note.INISettings).SysctlParams[addkey], _ = system.GetSysctlString(addkey)
@@ -199,7 +202,7 @@ func (app *App) TuneNote(noteID string) error {
 		optimised = optimised.(note.INISettings).SetValuesToApply(valApplyList)
 	}
 
-	if conforming {
+	if conforming && !forceApply {
 		// Do not apply the Note, if the system already complies with
 		// the requirements.
 		return nil

--- a/app/app.go
+++ b/app/app.go
@@ -359,9 +359,6 @@ func (app *App) RevertAll(permanent bool) error {
 	otherNotes, err := app.State.List()
 	if err == nil {
 		for _, otherNoteID := range otherNotes {
-			if strings.HasSuffix(otherNoteID, "_n2c") {
-				continue
-			}
 			if err := app.RevertNote(otherNoteID, permanent); err != nil {
 				allErrs = append(allErrs, err)
 			}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -122,14 +122,14 @@ func TestReadConfig(t *testing.T) {
 	// Read the default config should not yield anything
 	tuneApp := InitialiseApp(OSPackageInGOPATH, "", AllTestNotes, AllTestSolutions)
 	if len(tuneApp.TuneForSolutions) != 0 || len(tuneApp.TuneForNotes) != 0 {
-		fmt.Printf("'%v'", tuneApp.TuneForSolutions[0])
+		fmt.Println(len(tuneApp.TuneForSolutions))
 		fmt.Println(len(tuneApp.TuneForNotes))
 		t.Fatal(tuneApp)
 	}
 	// Read from non existing file
 	tuneApp = InitialiseApp("", "", AllTestNotes, AllTestSolutions)
 	if len(tuneApp.TuneForSolutions) != 0 || len(tuneApp.TuneForNotes) != 0 {
-		fmt.Printf("'%v'", tuneApp.TuneForSolutions[0])
+		fmt.Println(len(tuneApp.TuneForSolutions))
 		fmt.Println(len(tuneApp.TuneForNotes))
 		t.Fatal(tuneApp)
 	}

--- a/app/state.go
+++ b/app/state.go
@@ -3,11 +3,9 @@ package app
 import (
 	"encoding/json"
 	"github.com/SUSE/saptune/sap/note"
-	"github.com/SUSE/saptune/system"
 	"io/ioutil"
 	"os"
 	"path"
-	"strings"
 )
 
 // SaptuneStateDir defines saptunes saved state directory
@@ -78,35 +76,4 @@ func (state *State) Remove(noteID string) error {
 	} else {
 		return err
 	}
-}
-
-// CheckForOldRevertData checks, if there is saved state information in an older,
-// no longer supported saptune format available
-// return true, if old saved state files are found
-func (state *State) CheckForOldRevertData() (oldUpdFiles []string, check bool) {
-	check = false
-	oldUpdFiles = make([]string, 0, 0)
-	if savedNotes, err := state.List(); err == nil {
-		for _, entry := range savedNotes {
-			fileName := strings.TrimSuffix(entry, "_n2c")
-			if entry != fileName {
-				// there was a saved state file available during
-				// update from version 1 to version 2
-				// check, if the saved state file is already
-				// available (as a leftover from the migration)
-				if _, err := os.Stat(state.GetPathToNote(fileName)); err == nil {
-					// both saved state files exists
-					// (the saved state file of an applied
-					// note and the 'n2c' file from the
-					// update path v1 to v2
-					oldUpdFiles = append(oldUpdFiles, fileName)
-					system.WarningLog("found old saved state file for Note '%s'.", fileName)
-					check = true
-				} else {
-					oldUpdFiles = append(oldUpdFiles, entry)
-				}
-			}
-		}
-	}
-	return
 }

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ const (
 	footnote1             = "[1] setting is not supported by the system"
 	footnote2             = "[2] setting is not available on the system"
 	footnote3             = "[3] value is only checked, but NOT set"
+	footnote4             = "[4] cpu idle state settings differ"
 )
 
 // PrintHelpAndExit Print the usage and exit
@@ -257,7 +258,7 @@ func PrintNoteFields(header string, noteComparisons map[string]map[string]note.F
 	noteField := ""
 	sortkeys := make([]string, 0, len(noteComparisons))
 	remskeys := make([]string, 0, len(noteComparisons))
-	footnote := make([]string, 3, 3)
+	footnote := make([]string, 4, 4)
 	reminder := make(map[string]string)
 	override := ""
 	comment := ""
@@ -282,6 +283,10 @@ func PrintNoteFields(header string, noteComparisons map[string]map[string]note.F
 	// sort output
 	for noteID, comparisons := range noteComparisons {
 		for _, comparison := range comparisons {
+			if comparison.ReflectFieldName == "Inform" {
+				// skip inform map to avoid double entries in verify table
+				continue
+			}
 			if len(comparison.ReflectMapKey) != 0 && comparison.ReflectFieldName != "OverrideParams" {
 				if comparison.ReflectMapKey != "reminder" {
 					sortkeys = append(sortkeys, noteID+"§"+comparison.ReflectMapKey)
@@ -392,6 +397,14 @@ func PrintNoteFields(header string, noteComparisons map[string]map[string]note.F
 			compliant = compliant + " [3]"
 			comment = comment + " [3]"
 			footnote[2] = footnote3
+		}
+
+		// check inform map for special settings
+		// ANGI: future - check for 'nil', if using noteComparisons[noteID][fmt.Sprintf("%s[%s]", "Inform", comparison.ReflectMapKey)].ActualValue.(string) in general
+		if comparison.ReflectMapKey == "force_latency" && noteComparisons[noteID][fmt.Sprintf("%s[%s]", "Inform", comparison.ReflectMapKey)].ActualValue.(string) == "hasDiffs" {
+			compliant = "no [4]"
+			comment = comment + " [4]"
+			footnote[3] = footnote4
 		}
 
 		// print table header

--- a/main.go
+++ b/main.go
@@ -154,14 +154,7 @@ func checkUpdateLeftOvers() {
 		system.WarningLog("found file '/etc/tuned/saptune/tuned.conf' left over from the migration of saptune version 1 to saptune version 2. Please check and remove this file as it may work against the settings of some SAP Notes. For more information refer to the man page saptune-migrate(7)")
 	}
 
-	// check for saved state information in an older, no longer supported
-	// saptune format
-	leftOver, check := tuneApp.State.CheckForOldRevertData()
-	if check {
-		errorExit("found old saved state files '%s' related to applied notes. Seems there were some steps missed during the migration from saptune version 1 to version 2. Please check. Refer to saptune-migrate(7) for more information", strings.Join(leftOver, ", "))
-	} else if len(leftOver) != 0 {
-		system.WarningLog("found old saved state files '%s', but unrelated to applied notes. Seems there are some files left over from the migration of saptune version 1 to saptune version 2. Please check and remove these files. For more information refer to the man page saptune-migrate(7)", strings.Join(leftOver, ", "))
-	}
+	// check if old solution or notes are applied
 	if len(tuneApp.NoteApplyOrder) == 0 && (len(tuneApp.TuneForNotes) != 0 || len(tuneApp.TuneForSolutions) != 0) {
 		errorExit("There are 'old' solutions or notes defined in file '/etc/sysconfig/saptune'. Seems there were some steps missed during the migration from saptune version 1 to version 2. Please check. Refer to saptune-migrate(7) for more information")
 	}
@@ -504,9 +497,6 @@ func NoteAction(actionName, noteID string) {
 		fmt.Println("\nAll notes (+ denotes manually enabled notes, * denotes notes enabled by solutions, - denotes notes enabled by solutions but reverted manually later, O denotes override file exists for note):")
 		solutionNoteIDs := tuneApp.GetSortedSolutionEnabledNotes()
 		for _, noteID := range tuningOptions.GetSortedIDs() {
-			if strings.HasSuffix(noteID, "_n2c") {
-				continue
-			}
 			noteObj := tuningOptions[noteID]
 			format := "\t%s\t\t%s\n"
 			if len(noteID) >= 8 {

--- a/ospackage/man/saptune-migrate.7
+++ b/ospackage/man/saptune-migrate.7
@@ -63,8 +63,6 @@ The package update from version 1 to version 2 creates or copies some files duri
 and the directory
 .BI /etc/tuned/saptune
 .PP
-.BI /var/lib/saptune/saved_state/*_n2c
-.PP
 .BI /etc/sysconfig/saptune-note-*
 
 .SH SEE ALSO

--- a/sap/note/ini_sections_test.go
+++ b/sap/note/ini_sections_test.go
@@ -132,15 +132,15 @@ func TestOptVMVal(t *testing.T) {
 //SetVMVal
 
 func TestGetCPUVal(t *testing.T) {
-	val := GetCPUVal("force_latency")
+	val, _, _ := GetCPUVal("force_latency")
 	if val != "all:none" {
 		t.Logf("force_latency supported: '%s'\n", val)
 	}
-	val = GetCPUVal("energy_perf_bias")
+	val, _, _ = GetCPUVal("energy_perf_bias")
 	if val != "all:none" {
 		t.Logf("energy_perf_bias supported: '%s'\n", val)
 	}
-	val = GetCPUVal("governor")
+	val, _, _ = GetCPUVal("governor")
 	if val != "all:none" && val != "" {
 		t.Logf("governor supported: '%s'\n", val)
 	}

--- a/sap/note/note.go
+++ b/sap/note/note.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"github.com/SUSE/saptune/system"
 	"github.com/SUSE/saptune/txtparser"
-	"os"
 	"path"
 	"reflect"
 	"sort"
@@ -36,16 +35,6 @@ type Note interface {
 // TuningOptions is the collection of tuning options from SAP notes and
 // 3rd party vendors.
 type TuningOptions map[string]Note
-
-// Note2Convert checks, if there is a note in an older saptune format to revert
-// support revert from older saptune versions
-func Note2Convert(noteID string) string {
-	fileName := fmt.Sprintf("/var/lib/saptune/saved_state/%s_n2c", noteID)
-	if _, err := os.Stat(fileName); err == nil {
-		noteID = fmt.Sprintf("%s_n2c", noteID)
-	}
-	return noteID
-}
 
 // GetTuningOptions returns all built-in tunable SAP notes together with those
 // defined by 3rd party vendors.

--- a/sap/note/parameter.go
+++ b/sap/note/parameter.go
@@ -43,7 +43,7 @@ func IDInParameterList(noteID string, list []ParameterNoteEntry) bool {
 	return false
 }
 
-// ListParams lists all stored paramter states. Return paramter names
+// ListParams lists all stored parameter states. Return parameter names
 func ListParams() (ret []string, err error) {
 	if err = os.MkdirAll(SaptuneParameterStateDir, 0755); err != nil {
 		return
@@ -105,7 +105,7 @@ func AddParameterNoteValues(param, value, noteID string) {
 	}
 }
 
-// GetSavedParameterNotes reads content of stored paramter states.
+// GetSavedParameterNotes reads content of stored parameter states.
 // Return the content as ParameterNotes
 func GetSavedParameterNotes(param string) ParameterNotes {
 	pEntries := ParameterNotes{
@@ -168,7 +168,7 @@ func PositionInParameterList(noteID string, list []ParameterNoteEntry) int {
 
 // RevertParameter reverts parameter values and removes noteID reference
 // from the parameter file
-// return value of parameter, if needed to change, empty string else
+// return value of parameter and related noteID
 func RevertParameter(param, noteID string) (string, string) {
 	pvalue := ""
 	pnoteID := ""

--- a/system/cpu_test.go
+++ b/system/cpu_test.go
@@ -76,8 +76,8 @@ func TestGetdmaLatency(t *testing.T) {
 	}
 }
 
-func TestGetForceLatency(t *testing.T) {
-	value := GetForceLatency()
+func TestGetFLInfo(t *testing.T) {
+	value, _, _ := GetFLInfo()
 	if value == "all:none" {
 		t.Log("system does not support force_latency settings")
 	} else {


### PR DESCRIPTION
use the familiar 'force_latency' decimal value setting from tuned to set the cpu latency states and to display this value in the 'verify' table. Set the cpu latency states in  /sys/devices/system/cpu/cpu*/cpuidle/state*/disable instead of using /dev/cpu_dma_latency and save these current cpu latency states for a later 'revert' operation. The latency states for the cpus need to be consistently, so print an information footnote in the 'verify' table, if the states between the cpus differ. The latency values are only conforming, if the current latency state is less or equal the expected value and there is no inconsistency between the cpu states.

Additional change: 
Remove the handling of the _n2c helper files for the old saved states as they are no longer needed for the update/migration process.