### PR TITLE
fixed issues found during the first intensive tour of inspection

### DIFF
--- a/main.go
+++ b/main.go
@@ -410,7 +410,7 @@ func PrintNoteFields(header string, noteComparisons map[string]map[string]note.F
 		// print table header
 		if printHead != "" {
 			if header != "NONE" {
-				fmt.Printf("%s - %s \n\n", noteID, tuningOptions[noteID].Name())
+				fmt.Printf("\n%s - %s \n\n", noteID, tuningOptions[noteID].Name())
 			}
 			if printComparison {
 				// verify

--- a/main.go
+++ b/main.go
@@ -466,16 +466,20 @@ func PrintNoteFields(header string, noteComparisons map[string]map[string]note.F
 
 // VerifyAllParameters Verify that all system parameters do not deviate from any of the enabled solutions/notes.
 func VerifyAllParameters() {
-	unsatisfiedNotes, comparisons, err := tuneApp.VerifyAll()
-	if err != nil {
-		errorExit("Failed to inspect the current system: %v", err)
-	}
-	PrintNoteFields("NONE", comparisons, true)
-	tuneApp.PrintNoteApplyOrder()
-	if len(unsatisfiedNotes) == 0 {
-		fmt.Println("The running system is currently well-tuned according to all of the enabled notes.")
+	if len(tuneApp.NoteApplyOrder) == 0 {
+		fmt.Println("No notes or solutions enabled, nothing to verify.")
 	} else {
-		errorExit("The parameters listed above have deviated from SAP/SUSE recommendations.")
+		unsatisfiedNotes, comparisons, err := tuneApp.VerifyAll()
+		if err != nil {
+			errorExit("Failed to inspect the current system: %v", err)
+		}
+		PrintNoteFields("NONE", comparisons, true)
+		tuneApp.PrintNoteApplyOrder()
+		if len(unsatisfiedNotes) == 0 {
+			fmt.Println("The running system is currently well-tuned according to all of the enabled notes.")
+		} else {
+			errorExit("The parameters listed above have deviated from SAP/SUSE recommendations.")
+		}
 	}
 }
 

--- a/ospackage/usr/share/bash-completion/completions/saptune.completion
+++ b/ospackage/usr/share/bash-completion/completions/saptune.completion
@@ -1,13 +1,14 @@
-# v1.0 	
+# v1.1	
 #
 #   saptune daemon [ start | status | stop ]
 #   saptune note [ list | verify ]
-#   saptune note [ apply | simulate | verify | customise | revert ] NoteID
+#   saptune note [ apply | simulate | verify | customise | revert | create ] NoteID
 #   saptune solution [ list | verify ]
 #   saptune solution [ apply | simulate | verify | revert ] SolutionName
 #   saptune revert all
 #   saptune version
 #   saptune --version
+#   saptune help
 
 _saptune() {
     local cur prev opts base pattern
@@ -18,7 +19,7 @@ _saptune() {
     
     case ${COMP_CWORD} in 
 
-        1)  opts="daemon solution note revert version --version"
+        1)  opts="daemon solution note revert version --version help"
             ;;
         
         2)  case "${prev}" in
@@ -26,7 +27,7 @@ _saptune() {
                             ;;
                 solution)   opts="list verify apply simulate customise revert"
                             ;;
-                note)       opts="list verify apply simulate customise revert"       
+                note)       opts="list verify apply simulate customise revert create"       
                             ;;
 		revert)	    opts="all"	
 			    ;;
@@ -35,9 +36,9 @@ _saptune() {
             ;;
 
         3)  case "${prev}" in
-                apply|simulate|verify|customise|revert)
+                apply|simulate|verify|customise|revert|create)
                         case "${COMP_WORDS[COMP_CWORD-2]}" in
-                            note)       opts=$((ls -1q /usr/share/saptune/notes/ ; find /etc/saptune/extra/ -name '*.conf' -printf '%f\n' | cut -d '-' -f 1) | tr '\n' ' ') 
+                            note)       opts=$((ls -1q /usr/share/saptune/notes/ ; find /etc/saptune/extra/ -name '*.conf' -printf '%f\n' | cut -d '-' -f 1 | sed 's/\.conf$//') | tr '\n' ' ') 
                                         ;;
                             solution)   case "$(uname -i)" in
 						x86_64)	pattern="^\[ArchX86\]$" ;;

--- a/sap/note/ini.go
+++ b/sap/note/ini.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 // OverrideTuningSheets defines saptunes override directory
@@ -112,6 +113,13 @@ func (vend INISettings) Initialise() (Note, error) {
 	vend.Inform = make(map[string]string)
 	for _, param := range ini.AllValues {
 		if override && len(ow.KeyValue[param.Section]) != 0 {
+			chkKey := param.Key
+			if param.Section == "service" {
+				cKey := strings.TrimSuffix(chkKey, ".service")
+				if _, ok := ow.KeyValue[param.Section][cKey]; ok {
+					chkKey = cKey
+				}
+			}
 			if vend.ID == "1805750" {
 				// as note 1805750 does not set a limits
 				// domain, but the customer should be able to
@@ -125,16 +133,16 @@ func (vend INISettings) Initialise() (Note, error) {
 					}
 				}
 			}
-			if ow.KeyValue[param.Section][param.Key].Value == "" && param.Section != INISectionPagecache && (ow.KeyValue[param.Section][param.Key].Key != "" || (param.Section == INISectionLimits && ow.KeyValue[param.Section][param.Key].Key == "")) {
+			if ow.KeyValue[param.Section][chkKey].Value == "" && param.Section != INISectionPagecache && (ow.KeyValue[param.Section][chkKey].Key != "" || (param.Section == INISectionLimits && ow.KeyValue[param.Section][chkKey].Key == "")) {
 				// disable parameter setting in override file
 				vend.OverrideParams[param.Key] = "untouched"
 			}
-			if ow.KeyValue[param.Section][param.Key].Value != "" {
-				vend.OverrideParams[param.Key] = ow.KeyValue[param.Section][param.Key].Value
-				if ow.KeyValue[param.Section][param.Key].Operator != param.Operator {
+			if ow.KeyValue[param.Section][chkKey].Value != "" {
+				vend.OverrideParams[param.Key] = ow.KeyValue[param.Section][chkKey].Value
+				if ow.KeyValue[param.Section][chkKey].Operator != param.Operator {
 					// operator from override file will
 					// replace the operator from our note file
-					param.Operator = ow.KeyValue[param.Section][param.Key].Operator
+					param.Operator = ow.KeyValue[param.Section][chkKey].Operator
 				}
 			}
 		}

--- a/sap/note/ini.go
+++ b/sap/note/ini.go
@@ -244,7 +244,11 @@ func (vend INISettings) Optimise() (Note, error) {
 		case INISectionLogin:
 			vend.SysctlParams[param.Key] = OptLoginVal(param.Value)
 		case INISectionMEM:
-			vend.SysctlParams[param.Key] = OptMemVal(param.Key, vend.SysctlParams[param.Key], param.Value, ini.KeyValue["mem"]["ShmFileSystemSizeMB"].Value, ini.KeyValue["mem"]["VSZ_TMPFS_PERCENT"].Value)
+			if vend.OverrideParams["VSZ_TMPFS_PERCENT"] == "untouched" || vend.OverrideParams["VSZ_TMPFS_PERCENT"] == "" {
+				vend.SysctlParams[param.Key] = OptMemVal(param.Key, vend.SysctlParams[param.Key], param.Value, ini.KeyValue["mem"]["VSZ_TMPFS_PERCENT"].Value)
+			} else {
+				vend.SysctlParams[param.Key] = OptMemVal(param.Key, vend.SysctlParams[param.Key], param.Value, vend.OverrideParams["VSZ_TMPFS_PERCENT"])
+			}
 		case INISectionCPU:
 			vend.SysctlParams[param.Key] = OptCPUVal(param.Key, vend.SysctlParams[param.Key], param.Value)
 		case INISectionRpm:

--- a/sap/note/ini_sections.go
+++ b/sap/note/ini_sections.go
@@ -171,70 +171,68 @@ func SetBlkVal(key, value string, cur *param.BlockDeviceQueue, revert bool) erro
 // GetLimitsVal initialise the security limit structure with the current
 // system settings
 func GetLimitsVal(value string) (string, error) {
-	lim := strings.Fields(value)
-	// dom=[0], type=[1], item=[2], value=[3]
-	// no check, that the syntax/order of the entry in the config file is
-	// a valid limits entry
-
 	// Find out current limits
-	limit := ""
-	// /etc/security/limits.d/saptune-<domain>-<item>-<type>.conf
-	dropInFile := fmt.Sprintf("/etc/security/limits.d/saptune-%s-%s-%s.conf", lim[0], lim[2], lim[1])
-	secLimits, err := system.ParseSecLimitsFile(dropInFile)
-	if err != nil {
-		//ANGI TODO - check, if other files in /etc/security/limits.d contain a value for the touple "<domain>-<item>-<type>"
-		return "", err
+	limit := value
+	if limit != "" && limit != "NA" {
+		lim := strings.Fields(limit)
+		// dom=[0], type=[1], item=[2], value=[3]
+		// no check, that the syntax/order of the entry in the config file is
+		// a valid limits entry
+
+		// /etc/security/limits.d/saptune-<domain>-<item>-<type>.conf
+		dropInFile := fmt.Sprintf("/etc/security/limits.d/saptune-%s-%s-%s.conf", lim[0], lim[2], lim[1])
+		secLimits, err := system.ParseSecLimitsFile(dropInFile)
+		if err != nil {
+			//ANGI TODO - check, if other files in /etc/security/limits.d contain a value for the touple "<domain>-<item>-<type>"
+			return "", err
+		}
+		lim[3], _ = secLimits.Get(lim[0], lim[1], lim[2])
+		if lim[3] == "" {
+			lim[3] = "NA"
+		}
+		// current limit found
+		limit = strings.Join(lim, " ")
 	}
-	lim[3], _ = secLimits.Get(lim[0], lim[1], lim[2])
-	if lim[3] == "" {
-		lim[3] = "NA"
-	}
-	// current limit found
-	limit = strings.Join(lim, " ")
 	return limit, nil
 }
 
 // OptLimitsVal optimises the security limit structure with the settings
 // from the configuration file or with a calculation
 func OptLimitsVal(actval, cfgval string) string {
-	lim := strings.Fields(cfgval)
-
-	//ANGI - check, if we will preserve 'unlimited' or if we set value from config
-	actlim := strings.Fields(actval)
-	if actlim[3] == "unlimited" || actlim[3] == "infinity" || actlim[3] == "-1" {
-		lim[3] = actlim[3]
-	}
-
-	return strings.Join(lim, " ")
+	return cfgval
 }
 
 // SetLimitsVal applies the settings to the system
 func SetLimitsVal(key, noteID, value string, revert bool) error {
-	lim := strings.Fields(value)
-	// dom=[0], type=[1], item=[2], value=[3]
+	var err error
+	limit := value
+	if limit != "" && limit != "NA" {
+		lim := strings.Fields(limit)
+		// dom=[0], type=[1], item=[2], value=[3]
 
-	// /etc/security/limits.d/saptune-<domain>-<item>-<type>.conf
-	dropInFile := fmt.Sprintf("/etc/security/limits.d/saptune-%s-%s-%s.conf", lim[0], lim[2], lim[1])
+		// /etc/security/limits.d/saptune-<domain>-<item>-<type>.conf
+		dropInFile := fmt.Sprintf("/etc/security/limits.d/saptune-%s-%s-%s.conf", lim[0], lim[2], lim[1])
 
-	if revert && IsLastNoteOfParameter(key) {
-		// revert - remove limits drop-in file
-		os.Remove(dropInFile)
-		return nil
-	}
+		if revert && IsLastNoteOfParameter(key) {
+			// revert - remove limits drop-in file
+			os.Remove(dropInFile)
+			return nil
+		}
 
-	secLimits, err := system.ParseSecLimitsFile(dropInFile)
-	if err != nil {
-		return err
-	}
+		secLimits, err := system.ParseSecLimitsFile(dropInFile)
+		if err != nil {
+			return err
+		}
 
-	if lim[3] != "" && lim[3] != "NA" {
-		// revert with value from another former applied note
-		// or
-		// apply - Prepare limits drop-in file
-		secLimits.Set(lim[0], lim[1], lim[2], lim[3])
+		if lim[3] != "" && lim[3] != "NA" {
+			// revert with value from another former applied note
+			// or
+			// apply - Prepare limits drop-in file
+			secLimits.Set(lim[0], lim[1], lim[2], lim[3])
 
-		//err = secLimits.Apply()
-		err = secLimits.ApplyDropIn(lim, noteID)
+			//err = secLimits.Apply()
+			err = secLimits.ApplyDropIn(lim, noteID)
+		}
 	}
 	return err
 }

--- a/sap/note/ini_sections_test.go
+++ b/sap/note/ini_sections_test.go
@@ -210,11 +210,11 @@ func TestGetMemVal(t *testing.T) {
 }
 
 func TestOptMemVal(t *testing.T) {
-	val := OptMemVal("VSZ_TMPFS_PERCENT", "47", "80", "0", "80")
+	val := OptMemVal("VSZ_TMPFS_PERCENT", "47", "80", "80")
 	if val != "80" {
 		t.Fatal(val)
 	}
-	val = OptMemVal("VSZ_TMPFS_PERCENT", "-1", "75", "0", "75")
+	val = OptMemVal("VSZ_TMPFS_PERCENT", "-1", "75", "75")
 	if val != "75" {
 		t.Fatal(val)
 	}
@@ -222,47 +222,47 @@ func TestOptMemVal(t *testing.T) {
 	size75 := uint64(system.GetTotalMemSizeMB()) * 75 / 100
 	size80 := uint64(system.GetTotalMemSizeMB()) * 80 / 100
 
-	val = OptMemVal("ShmFileSystemSizeMB", "16043", "0", "0", "80")
+	val = OptMemVal("ShmFileSystemSizeMB", "16043", "0", "80")
 	if val != strconv.FormatUint(size80, 10) {
 		t.Fatal(val)
 	}
-	val = OptMemVal("ShmFileSystemSizeMB", "-1", "0", "0", "80")
+	val = OptMemVal("ShmFileSystemSizeMB", "-1", "0", "80")
 	if val != "-1" {
 		t.Fatal(val)
 	}
 
-	val = OptMemVal("ShmFileSystemSizeMB", "16043", "0", "0", "0")
+	val = OptMemVal("ShmFileSystemSizeMB", "16043", "0", "0")
 	if val != strconv.FormatUint(size75, 10) {
 		t.Fatal(val)
 	}
-	val = OptMemVal("ShmFileSystemSizeMB", "-1", "0", "0", "0")
+	val = OptMemVal("ShmFileSystemSizeMB", "-1", "0", "0")
 	if val != "-1" {
 		t.Fatal(val)
 	}
 
-	val = OptMemVal("ShmFileSystemSizeMB", "16043", "25605", "25605", "80")
+	val = OptMemVal("ShmFileSystemSizeMB", "16043", "25605", "80")
 	if val != "25605" {
 		t.Fatal(val)
 	}
-	val = OptMemVal("ShmFileSystemSizeMB", "-1", "25605", "25605", "80")
+	val = OptMemVal("ShmFileSystemSizeMB", "-1", "25605", "80")
 	if val != "-1" {
 		t.Fatal(val)
 	}
 
-	val = OptMemVal("ShmFileSystemSizeMB", "16043", "25605", "25605", "0")
+	val = OptMemVal("ShmFileSystemSizeMB", "16043", "25605", "0")
 	if val != "25605" {
 		t.Fatal(val)
 	}
-	val = OptMemVal("ShmFileSystemSizeMB", "-1", "25605", "25605", "0")
+	val = OptMemVal("ShmFileSystemSizeMB", "-1", "25605", "0")
 	if val != "-1" {
 		t.Fatal(val)
 	}
 
-	val = OptMemVal("UNKOWN_PARAMETER", "16043", "0", "0", "0")
+	val = OptMemVal("UNKOWN_PARAMETER", "16043", "0", "0")
 	if val != "" {
 		t.Fatal(val)
 	}
-	val = OptMemVal("UNKOWN_PARAMETER", "-1", "0", "0", "0")
+	val = OptMemVal("UNKOWN_PARAMETER", "-1", "0", "0")
 	if val != "" {
 		t.Fatal(val)
 	}

--- a/sap/param/io.go
+++ b/sap/param/io.go
@@ -31,6 +31,10 @@ func (ioe BlockDeviceSchedulers) Inspect() (Parameter, error) {
 		return nil, err
 	}
 	for _, entry := range dirContent {
+		if strings.Contains(entry.Name(), "dm-") {
+			// skip unsupported devices
+			continue
+		}
 		/*
 			Remember: GetSysChoice does not accept the leading /sys/.
 			The file "scheduler" may look like "[noop] deadline cfq", in which case the choice will be read successfully.

--- a/system/logging.go
+++ b/system/logging.go
@@ -30,6 +30,7 @@ func calledFrom() string {
 func DebugLog(txt string, stuff ...interface{}) {
 	if debugLogger != nil {
 		debugLogger.Printf(calledFrom()+txt+"\n", stuff...)
+		fmt.Fprintf(os.Stderr, "DEBUG: "+txt+"\n", stuff...)
 	}
 }
 
@@ -37,6 +38,7 @@ func DebugLog(txt string, stuff ...interface{}) {
 func InfoLog(txt string, stuff ...interface{}) {
 	if infoLogger != nil {
 		infoLogger.Printf(calledFrom()+txt+"\n", stuff...)
+		fmt.Fprintf(os.Stdout, "INFO: "+txt+"\n", stuff...)
 	}
 }
 
@@ -44,6 +46,7 @@ func InfoLog(txt string, stuff ...interface{}) {
 func WarningLog(txt string, stuff ...interface{}) {
 	if warningLogger != nil {
 		warningLogger.Printf(calledFrom()+txt+"\n", stuff...)
+		fmt.Fprintf(os.Stderr, "    WARNING: "+txt+"\n", stuff...)
 	}
 }
 
@@ -51,6 +54,7 @@ func WarningLog(txt string, stuff ...interface{}) {
 func ErrorLog(txt string, stuff ...interface{}) {
 	if errorLogger != nil {
 		errorLogger.Printf(calledFrom()+txt+"\n", stuff...)
+		fmt.Fprintf(os.Stderr, "ERROR: "+txt+"\n", stuff...)
 	}
 }
 
@@ -68,15 +72,20 @@ func LogInit() {
 	//saptuneWriter := io.MultiWriter(os.Stderr, saptuneLog)
 	//log.SetOutput(saptuneWriter)
 
-	debugLogWriter := io.MultiWriter(os.Stderr, saptuneLog)
-	infoLogWriter := io.MultiWriter(os.Stdout, saptuneLog)
-	warningLogWriter := io.MultiWriter(os.Stderr, saptuneLog)
-	errorLogWriter := io.MultiWriter(os.Stderr, saptuneLog)
+	//debugLogWriter := io.MultiWriter(os.Stderr, saptuneLog)
+	//infoLogWriter := io.MultiWriter(os.Stdout, saptuneLog)
+	//warningLogWriter := io.MultiWriter(os.Stderr, saptuneLog)
+	//errorLogWriter := io.MultiWriter(os.Stderr, saptuneLog)
 
-	debugLogger = log.New(debugLogWriter, logTimeFormat+"DEBUG    saptune.", 0)
-	infoLogger = log.New(infoLogWriter, logTimeFormat+"INFO     saptune.", 0)
-	warningLogger = log.New(warningLogWriter, logTimeFormat+"WARNING  saptune.", 0)
-	errorLogger = log.New(errorLogWriter, logTimeFormat+"ERROR    saptune.", 0)
+	//debugLogger = log.New(debugLogWriter, logTimeFormat+"DEBUG    saptune.", 0)
+	//infoLogger = log.New(infoLogWriter, logTimeFormat+"INFO     saptune.", 0)
+	//warningLogger = log.New(warningLogWriter, logTimeFormat+"WARNING  saptune.", 0)
+	//errorLogger = log.New(errorLogWriter, logTimeFormat+"ERROR    saptune.", 0)
 	//errorLogger = log.New(errorLogWriter, logTimeFormat+"ERROR    saptune.", log.Lshortfile)
 	//log.SetFlags(0)
+
+	debugLogger = log.New(saptuneLog, logTimeFormat+"DEBUG    saptune.", 0)
+	infoLogger = log.New(saptuneLog, logTimeFormat+"INFO     saptune.", 0)
+	warningLogger = log.New(saptuneLog, logTimeFormat+"WARNING  saptune.", 0)
+	errorLogger = log.New(saptuneLog, logTimeFormat+"ERROR    saptune.", 0)
 }

--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -177,6 +177,10 @@ func ParseINI(input string) *INIFile {
 		} else if currentSection == "block" {
 			_, sysDevs := system.ListDir("/sys/block", "the available block devices of the system")
 			for _, bdev := range sysDevs {
+				if strings.Contains(bdev, "dm-") {
+					// skip unsupported devices
+					continue
+				}
 				entry := INIEntry{
 					Section:  currentSection,
 					Key:      fmt.Sprintf("%s_%s", kov[1], bdev),

--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -165,9 +165,19 @@ func ParseINI(input string) *INIFile {
 			for _, limits := range strings.Split(kov[3], ",") {
 				limits = strings.TrimSpace(limits)
 				lim := strings.Fields(limits)
+				key := ""
+				if len(lim) == 0 {
+					// empty LIMITS parameter means
+					// override file is setting all limits to 'untouched'
+					// or a wrong limits entry in an 'extra' file
+					key = fmt.Sprintf("%s_NA", kov[1])
+					limits = "NA"
+				} else {
+					key = fmt.Sprintf("LIMIT_%s_%s_%s", lim[0], lim[1], lim[2])
+				}
 				entry := INIEntry{
 					Section:  currentSection,
-					Key:      fmt.Sprintf("LIMIT_%s_%s_%s", lim[0], lim[1], lim[2]),
+					Key:      key,
 					Operator: Operator(kov[2]),
 					Value:    limits,
 				}


### PR DESCRIPTION
- handle override value for ShmFileSystemSizeMB and/or VSZ_TMPFS_PERCENT correctly, especially during calculation of ShmFileSystemSizeMB
- skip unsupported block devices (at the moment: dm-*)
- allow override file to exclude all limit settings of the note from being changed - so handle all limits as 'untouched'
- avoid confusing verify message, if there are no notes or solutions applied
- support short form of service name in override file
- bash-completion: added 'help' and 'create'
- support different formats for the log messages depending on the destination (log file or stderr/stdout)
  (the logging topic needs some more attention. I will have a look next week and will add some small changes. Additionally I will start the discussion with Alliance team, what exactly we want to log, where and with which severity. But this will be a mid-term change.)
