### PR TITLE
fixed issues found during the second tour of inspection

### DIFF
--- a/main.go
+++ b/main.go
@@ -732,7 +732,7 @@ func SolutionAction(actionName, solName string) {
 				"\n    saptune daemon start")
 		}
 	case "list":
-		fmt.Println("\nAll solutions (* denotes enabled solution, O denotes override file exists for solution):")
+		fmt.Println("\nAll solutions (* denotes enabled solution, O denotes override file exists for solution, D denotes deprecated solutions):")
 		for _, solName := range solution.GetSortedSolutionNames(solutionSelector) {
 			format := "\t%-18s -"
 			if i := sort.SearchStrings(tuneApp.TuneForSolutions, solName); i < len(tuneApp.TuneForSolutions) && tuneApp.TuneForSolutions[i] == solName {
@@ -746,6 +746,9 @@ func SolutionAction(actionName, solName string) {
 			solNotes := ""
 			for _, noteString := range solution.AllSolutions[solutionSelector][solName] {
 				solNotes = solNotes + " " + noteString
+			}
+			if _, ok := solution.DeprecSolutions[solutionSelector][solName]; ok {
+				format = " D" + format
 			}
 			format = format + solNotes + resetTextColor + "\n"
 			fmt.Printf(format, solName)

--- a/main.go
+++ b/main.go
@@ -32,7 +32,8 @@ const (
 	setGreenText          = "\033[32m"
 	setRedText            = "\033[31m"
 	resetTextColor        = "\033[0m"
-	footnote1             = "[1] setting is not supported by the system"
+	footnote1X86          = "[1] setting is not supported by the system"
+	footnote1IBM          = "[1] setting is not relevant for the system"
 	footnote2             = "[2] setting is not available on the system"
 	footnote3             = "[3] value is only checked, but NOT set"
 	footnote4             = "[4] cpu idle state settings differ"
@@ -74,9 +75,13 @@ func cliArg(i int) string {
 
 var tuneApp *app.App                 // application configuration and tuning states
 var tuningOptions note.TuningOptions // Collection of tuning options from SAP notes and 3rd party vendors.
+var footnote1 = footnote1X86         // set 'unsupported' footnote regarding the architecture
 var solutionSelector = runtime.GOARCH
 
 func main() {
+	if runtime.GOARCH == "ppc64le" {
+		footnote1 = footnote1IBM
+	}
 	// activate logging
 	system.LogInit()
 

--- a/ospackage/man/saptune-migrate.7
+++ b/ospackage/man/saptune-migrate.7
@@ -15,7 +15,7 @@
 .\" */
 .\"
 
-.TH "saptune-migrate" "7" "March 2019" "" "migration from saptune version 1 to saptune version 2"
+.TH "saptune-migrate" "7" "May 2019" "" "migration from saptune version 1 to saptune version 2"
 .SH NAME
 saptune\-migration \- migration of saptune version 1 to saptune version 2
 
@@ -27,27 +27,26 @@ As there are too many logical and structural changes between the saptune version
 see below the needed steps. And refer to the blog post <add here the link> for more information.
 
 .SH ACTIONS 
-The following steps need to perform during a migration from a running and configured saptune version 1 to saptune version 2
+The following steps need to be performed during a migration from a running and configured saptune version 1 to saptune version 2. A more detailed guide can be found below in the \fBEXAMPLE\fP section.
 
+.IP \[bu] 2
+check the old, in the future no longer used configuration files \fB/etc/sysconfig/saptune-note-*\fP for customer specific changes
 .IP \[bu]
-check the old, in the future no longer used configuration files \fI/etc/sysconfig/saptune-note-*\fR for customer specific changes
-
+check the new Note definition files in \fB/usr/share/saptune/\fP to see if there is a need to transfer the old customization to the new Note definitions and how to do this transition
 .IP \[bu]
-check the new note configuration files in \fB/usr/share/saptune/\fR to see if there is a need to transfer the old customization to the new note definitions and how to do this transition
+Create override files for notes in \fB/etc/saptune/override\fP if needed
 .IP \[bu]
-Create override files for notes in \fB/etc/saptune/override\fR if needed
+check for \fB/etc/tuned/saptune/tuned.conf\fP.
 .IP \[bu]
-check for \fI/etc/tuned/saptune/tuned.conf\fR.
+check \fB/etc/saptune/extras\fP, if the settings needed any longer
 .IP \[bu]
-check \fB/etc/saptune/extras\fR, if the settings needed any longer
+use the command '\fBsaptune note revert <note id>\fP' or '\fBsaptune solution revert <solution name>\fP' to revert all setting properly and to clean the configuration
 .IP \[bu]
-use the command '\fIsaptune note revert <note id>\fR' or '\fIsaptune solution revert <solution name>\fR' to revert all setting properly and to clean the configuration
+check and remove all files listed in the section \fBFILES to remove after the migration\fP
 .IP \[bu]
-check and remove all files listed in the section "FILES to remove after the migration"
+change saptune version in file \fB/etc/sysconfig/saptune\fP from '1' to '\fB2\fP'
 .IP \[bu]
-change saptune version in file \fI/etc/sysconfig/saptune\fR from '1' to '\fB2\fR'
-.IP \[bu]
-use the command '\fIsaptune solution apply <solution name>\fR' and/or '\fIsaptune note apply <note id>\fR' to get back you tuning for the SAP workload
+use the command '\fBsaptune solution apply <solution name>\fP' and/or '\fBsaptune note apply <note id>\fP' to get back you tuning for the SAP workload
 .IP \[bu]
 check again the configuration for left overs
 
@@ -64,6 +63,316 @@ and the directory
 .BI /etc/tuned/saptune
 .PP
 .BI /etc/sysconfig/saptune-note-*
+
+.SH SOLUTIONS
+
+The following solutions are shipped:
+.TS
+tab(:) box;
+c | l | l
+l | l | l.
+SOLUTION:Version 1:Version 2
+_
+BOBJ:T{
+1275776* 1557506** 1984787 SAP_BOBJ
+T}:T{
+941735 1771258 1984787 SAP_BOBJ
+T}
+HANA:T{
+1275776* 1557506** 1984787 2205917
+T}:T{
+941735 1771258 1980196 1984787 2205917 2382421 2534844
+T}
+MAXDB:T{
+1275776* 1557506** 1984787
+T}:T{
+941735 1771258 1984787
+T}
+NETWEAVER:T{
+1275776* 1557506** 1984787
+T}:T{
+941735 1771258 1984787
+T}
+NETWEAVER+HANA:T{
+-
+T}:T{
+941735 1771258 1980196 1984787 2205917 2382421 2534844
+T}
+S4HANA-APP+DB:T{
+-
+T}:T{
+941735 1771258 1980196 1984787 2205917 2382421 2534844
+T}
+S4HANA-APPSERVER:T{
+1275776* 1557506** 1984787
+T}:T{
+941735 1771258 1984787
+T}
+S4HANA-DBSERVER:T{
+1275776* 1557506** 1984787 2205917
+T}:T{
+941735 1771258 1980196 1984787 2205917 2382421 2534844
+T}
+SAP-ASE:T{
+1275776* 1557506** 1984787 2205917 SAP_ASE
+T}:T{
+941735 1410736 1680803 1771258 1984787
+T}
+.TE
+
+*   SAP Note \fB1275776\fP has been rewritten and removed in version 2.
+.HP 4
+** SAP Note \fB1557506\fP has been removed from the solutions in version 1 because it always has to be configured!
+.PP
+Note: In version 1 the solutions BOBJ and SAP-ASE have not been available on ppc64 little-endian.
+
+For details about the SAP Notes see section \fBSAP NOTES\fP.
+
+.SH SAP NOTES
+
+The following notes are shipped:
+.TS
+tab(:) box;
+c | l | l | c
+l | l | l | l
+l | l | l | l
+l | l | l | l
+l | l s s
+l | l l l
+l | l l l
+l | l l l
+l | l l l
+l | l l l
+l | l l l
+l | l l l
+l | l l l
+l | l l l
+l | l | l | l.
+note:v1:v2:comment
+_
+941735:no:yes:T{
+newly introduced in version 2
+T}
+_
+1275776:yes*:no:T{
+The SAP Note has been rewritten and does not contain any settings recommendation anymore.
+.br
+The note is still part of version 1 with the former recommendations.
+.br
+It has been removed in version 2.
+T}
+:
+:T{
+The parameters are now covered by the following notes
+T}
+
+:kernel.sem:->:SAP_BOBJ (new default)
+:kernel.shmall:->:941735 (now fixed value)
+:kernel.shmmax:->:T{
+941735 and SAP_BOBJ (new default)
+T}
+:T{
+nofile for @sapsys, @sdba, @dba
+T}:->:1771258 (new default)
+:vm.max_map_count:->:1980196 (same default)
+:VSZ_TMPFS_PERCENT:->:941735 (same default)
+:SHM_COUNT_REF_VALUE:->:T{
+2534844(as kernel.shmmni with new default)
+T}
+
+_
+1410736:no:yes:T{
+newly introduced in version 2
+T}
+_
+1557506:yes:yes:T{
+In version 2 only the HANA formula is used.
+.br
+Pagecache limit is \fBnot\fP available in SLES 15!
+T}
+_
+1680803:no:yes:T{
+newly introduced in version 2
+T}
+_
+1771258:no:yes:T{
+newly introduced in version 2
+T}
+_
+1805750:no:yes:T{
+newly introduced in version 2
+T}
+_
+1980196:no:yes:T{
+newly introduced in version 2
+T}
+_
+1984787:yes**:yes:T{
+In version 1 UserDefaultTasksMax was set by a drop-in file on installation.
+.br
+In version 2 DefaultUserTaskMax is set/removed at note apply. A reboot is not necessary anymore.
+T}
+_
+2161991:yes**:yes:T{
+same defaults between version 1 and 2
+T}
+_
+2205917:yes*:yes:T{
+In version 1 the configuration was partially hard coded and partially done by tuned (always enabled regardless if note was active or not!)
+.br
+In version 2 this done by saptune itself.
+T}
+_
+2382421:no:yes:T{
+newly introduced in version 2
+T}
+_
+2534844:no:yes:T{
+newly introduced in version 2
+T}
+_
+SAP_ASE:yes:no:T{
+Has been replaced by \fB1680803\fP in version 2. The same defaults, but 1680803 also covers
+.br
+net.ipv4.tcp_keepalive_intvl and
+.br
+net.ipv4.tcp_keepalive_time.
+T}
+_
+SAP_BOBJ:yes:yes:T{
+no changes between version 1 and 2
+T}
+_
+SUSE-GUIDE-01:yes:no:T{
+deprecated since not an official SAP recommendation
+T}
+_
+SUSE-GUIDE-02:yes:no:T{
+deprecated since not an official SAP recommendation
+T}
+.TE
+
+*  Configuration was partially hard coded in version 1.
+.br
+** Configuration was fully hard coded in version 1.
+
+In version 1 part of configuration was hard coded or configurable via /etc/sysconfig/saptune-note-*, /etc/saptune/extra/{SAP_BOBJ-SAP_Business_OBJects.conf,SAP_ASE-SAP_Adaptive_Server_Enterprise.conf} and /etc/tuned/saptune/tuned.conf.
+
+Due to tuned CPU tuning (see SAP Note 2205917) was always active.
+
+In version 2 everything can be configured via an override file in /etc/saptune/override/.
+
+For details and defaults read the configuration in the corresponding Note definition files in /usr/share/saptune/notes/.
+
+Package requirements are always realized by dependency requirements to the saptune package.
+
+.SH EXAMPLE
+
+Scenario 1 - saptune version 1 is running with the default setting
+
+.SS Prerequisites:
+
+.IP \[bu] 2
+The files /etc/sysconfig/saptune-note-* have \fBNOT\fP been altered
+.IP \[bu]
+The files /etc/saptune/extra/SAP_BOBJ-SAP_Business_OBJects.conf and /etc/saptune/extra/SAP_ASE-SAP_Adaptive_Server_Enterprise.conf have \fBNOT\fP been altered
+.IP \[bu]
+There are \fBNO\fP additional files in /etc/saptune/extra/ except SAP_BOBJ-SAP_Business_OBJects.conf and SAP_ASE-SAP_Adaptive_Server_Enterprise.conf.
+.IP \[bu]
+There is \fBNO\fP manually created /etc/tuned/saptune/tuned.conf (the upgrade might have created this file. Check the comment in the file.)
+.IP \[bu]
+The variable \fISAPTUNE_VERSION\fP in /etc/sysconfig/saptune is set to \fB1\fP.
+.IP \[bu]
+The tuned profile 'saptune' is selected.
+
+.SS Planning:
+Before you start the migration, get yourself familiar with the version 2.
+.br
+Please read the man pages of saptune_v2(8) and saptune-note(5).
+
+Solutions of version 2 can encompass more SAP Notes than in version 1.
+.br
+Please check section \fBSOLUTIONS\fP for details. You might want to deselect some SAP Notes, change or disable parameters.
+
+SAP Notes are more comprehensive in version 2.
+.br
+Please check section \fBSAP NOTES\fP for details. You might want to change or disable parameters.
+
+Some SAP Notes have been removed in version 2.
+.br
+Please check section \fBSAP NOTES\fP for details. You might want to add your own configuration file.
+
+In version 1 multiple solutions can be applied. In saptune version 2 only one solution can be applied at the same time.
+
+If you had multiple solutions in the past, choose the most suitable one and add additional notes.
+
+Version 1 has changed system parameters only when the current value was lower.
+
+Version 2 will set the parameter always to the configured value, no matter the current value.
+
+.SS Migration steps:
+.nr step 1 1
+.IP \n[step]. 4
+Note the configured solutions and notes and plan the future solution and notes.
+    saptune solution list
+    saptune note list
+.IP \n+[step].
+Revert all solutions and additional applied notes:
+    saptune solution revert <solution>
+    saptune note revert <note>
+.IP \n+[step].
+Open /etc/sysconfig/saptune with an editor
+
+The variables TUNE_FOR_SOLUTIONS,
+              TUNE_FOR_NOTES and
+              NOTE_APPLY_ORDER
+ have to be empty.
+ (If this is not the case, check step 2 again.)
+
+Change SAPTUNE_VERSION from "1" to "2"
+.IP \n+[step].
+Delete /etc/tuned/saptune/ (Verify, that it was created by the saptune update!).
+    rm -rf /etc/tuned/saptune/
+.IP \n+[step].
+Delete the configuration files SAP_BOBJ-SAP_Business_OBJects.conf and SAP_ASE-SAP_Adaptive_Server_Enterprise.conf .
+.nf
+    rm /etc/saptune/extra/SAP_BOBJ-SAP_Business_OBJects.conf
+    rm /etc/saptune/extra/SAP_ASE-SAP_Adaptive_Server_Enterprise.conf
+.fi
+
+(( Delete obsolete save state files.  rm /var/lib/saptune/saved_state/* ))
+.IP \n+[step].
+Restart tuned.
+    systemctl restart tuned
+.IP \n+[step].
+Check the log file /var/log/tuned/tuned.log for any errors.
+.IP \n+[step].
+Create override files if necessary.
+Please leave only parameters in the override file, you wish to change or to disable.
+    saptune note customise <note>
+.IP \n+[step].
+Create extra files for if necessary.
+.IP \n+[step].
+Apply the solutions and notes you need.
+    saptune solution apply <solution>
+    saptune note apply <note>
+.IP \n+[step].
+Clean up the system, to avoid confusion.
+
+Delete old configuration files.
+    rm /etc/sysconfig/saptune-note-*
+
+Delete /etc/systemd/logind.conf.d/sap.conf.
+Be aware that the file also is used by sapconf and is only created on package installation!
+    rm /etc/systemd/logind.conf.d/sap.conf
+
+Remove 'nofile' entries for @sapsys, @sdba and @dba in /etc/security/limits.conf.
+This is handled by individual files in /etc/security/limits.d/ now.
+
+Remove any entries in /etc/sysctl.conf or files in /etc/sysctl.d/*.conf which are handled by saptune.
+Consider moving SAP-related settings from there to a saptune extra file.
+.IP \n+[step].
+Please verify, that any configuration management system or scripts which configure saptune are adjusted accordingly.
 
 .SH SEE ALSO
 .NF

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -15,15 +15,15 @@
 .\" */
 .\" 
 
-.TH "saptune-note" "5" "March 2019" "" "saptune note file format description"
+.TH "saptune-note" "5" "May 2019" "" "saptune note file format description"
 .SH NAME
-saptune\-note - saptune note definition files
+saptune\-note - Note definition files for saptune version \fB2\fP
 .SH DESCRIPTION
-This man page documents the format of the saptune note definition files.
+This man page documents the format of the Note definition files for saptune version \fB2\fP. If you still use version \fB1\fP of saptune please refer to the configuration files \fI/etc/sysconfig/saptune-note-*\fP
+
+The saptune Note definitions will be searched in \fI/usr/share/saptune/notes\fP for the saptune SAP Note definitions or \fI/etc/saptune/override\fP for customer specific changes to the saptune SAP Note definitions or \fI/etc/saptune/extra\fP for vendor or customer specific tuning definitions.
 .br
-The saptune note definitions will be searched in \fI/usr/share/saptune/notes\fR for the saptune SAP Note definitions or \fI/etc/saptune/override\fR for customer specific changes to the saptune SAP Note definitions or \fI/etc/saptune/extra\fR for vendor or customer specific tuning definitions.
-.br
-The \fBnote definition\fR files use the INI file format.
+The \fBNote definition\fP files use the INI file format.
 .br
 A comment line starts with #.
 .br
@@ -31,19 +31,21 @@ Lines starting with '[' indicate the begin of a new section.
 .SH SECTIONS
 A section starts with a '[section_name]' keyword in the first line, followed by lines with options and comments.
 
-The following section definitions are available and used in the saptune SAP Note definition files. Each of these sections can be used in a vendor or customer specific tuning definition placed in \fI/etc/saptune/extra\fR.
-.SH "[version]"
-This section is used to display version, description and last change date of the underlying Note during saptune option 'list'.
-.br
-Syntax:
-# <prefix>NOTE=<noteId> CATEGORY=<category> VERSION=<versionNo> DATE=<release date of used note and related values> NAME="<description of the note>"
+The following section definitions are available and used in the saptune SAP Note definition files. Each of these sections can be used in a vendor or customer specific tuning definition placed in \fI/etc/saptune/extra\fP.
 
-.SH "[sysctl]"
-The section "[sysctl]" can be used to modify kernel parameters. The parameters available are those listed under /proc/sys/. 
+List of supported sections:
+version, block, cpu, grub, limits, login, mem, pagecache, reminder, rpm, service, sysctl, vm
+
+See detailed description below:
+\" section version - Mandatory
+.SH "[version]"
+This section is a mandatory section and is used to display version, description and last change date of the underlying Note during saptune option 'list'.
+
+Syntax:
 .br
-Please write the section keyword '[sysctl]' in the first line and add the desired tunables in 'sysctl.conf' syntax.
-.TP
-.BI sysctl.parameter = <value>
+.nf
+.B # <prefix>NOTE=<noteId> CATEGORY=<category> VERSION=<versionNo> DATE=<release date of used note and related values> NAME="<description of the note>"
+\" section block
 .SH "[block]"
 The section "[block]" can contain the following options:
 .TP
@@ -51,193 +53,156 @@ The section "[block]" can contain the following options:
 The default I/O scheduler for SLES is CFQ. It offers satisfactory performance for wide range of I/O task, however choosing an alternative scheduler may potentially yield better latency characteristics and throughput. 
 "noop" is an alternative scheduler, in comparison to CFQ it may offer more consistent performance, lower computation overhead, and potentially higher throughput.
 For most SAP environments (RAID, storage arrays, virtualizaton) 'noop' is the better choice.
-When set, all block devices on the system will be switched to the chosen scheduler.
 .br
-Valid values can be found in \fI/sys/block/<device>/queue/scheduler\fR.
+When set, \fBall\fP block devices on the system will be switched to the chosen scheduler.
+.br
+Valid values can be found in \fI/sys/block/<device>/queue/scheduler\fP.
 .TP
 .BI NRREQ= INT
-IO nr_requests
-When set, the number of requests for all block devices on the system will be switched to the chosen value
-.SH "[limits]"
-The section "[limits]" is dealing with ulimit settings for user login sessions in the pam_limits module. The settings are done in the file \fI/etc/security/limits.conf\fR. For more information and a description of the syntax and the needed fileds please look at limits.conf(5).
+IO nr_requests specifies the maximum number of read and write requests that can be queued at one time. The default value is 128, which means that 128 read requests and 128 write requests can be queued before the next process to request a read or write is put to sleep.
 .br
-This section has to contain the following options:
-.TP
-.BI LIMIT_HARD= INT
-the hard resource limits. Beside integer values the values \fBunlimited\fR, \fBinfinity\fR and \fB\-1 are supported.
-.TP
-.BI LIMIT_SOFT= INT
-the soft resource limits. Beside integer values the values \fBunlimited\fR, \fBinfinity\fR and \fB\-1 are supported.
-.TP
-.BI LIMIT_ITEM= STRING
-At the moment we support settings for 
-.RS 8
-\fBmemlock\fR
-.RS 4
-maximum locked-in-memory address space (KB) e.g. for user \fBsybase\fR. If \fILIMIT_HARD\fR and/or \fILIMIT_SOFT\fR are set to \fB0\fR, the limits will be calculated as (MainMemSize in KB  - 10%)
-.RE
-.RE
-.RS 8
-\fBnofile\fR 
-.RS 4
-Maximum number of open files e.g. for SAP application groups \fBsapsys\fR, \fBsdba\fR and \fBdba\fR.
-.RE
-.RE
-.TP
-.BI LIMIT_DOMAIN= STRING
-At the moment we provide settings for the user \fBsybase\fR (memlock) and for the groups \fBsapsys\fR, \fBsdba\fR and \fBdba\fR (nofile).
-.br
-Note: The "@" sign matches a group. 
-.br
-If you want to change specific users, e.g. sidadm, you can simply write 'LIMIT_DOMAIN=sidadm' or 'LIMIT_DOMAIN=@sapsys @sdba @dba sidadm' to add an entry "sidadm - nofile 65536" to the file (with LIMIT_ITEM=nofile and LIMIT_SOFT=65536 or LIMIT_HARD=65536).
-.SH "[vm]"
-The section "[vm]" manipulates \fB/sys/kernel/mm\fR switches. 
-.br
-This section can to contain the following options:
-.TP
-.BI THP= STRING
-This option disables transparent hugepages (applies to Intel-based systems only) by changing \fB/sys/kernel/mm/transparent_hugepage/enabled\fR
-.br
-Possible values are '\fBnever\fR' to disable and '\fBalways\fR' to enable.
-.TP
-.BI KSM= INT
-Kernel Samepage Merging (KSM). KSM allows for an application to register with the kernel so as to have its memory pages merged with other processes that also register to have their pages merged. For KVM the KSM mechanism allows for guest virtual machines to share pages with each other. In todays environment where many of the guest operating systems like XEN, KVM are similar and are running on same host machine, this can result in significant memory savings, the default value is set to 0.
-.br
-ATTENTION: /usr/share/saptune/note/SUSE-GUIDE-01 will change it to 1, if
-activated after note 2205917 or solution HANA
-.SH "[mem]"
-The section "[mem]" manipulates the size of TMPFS (\fB/dev/shm\fR).
-
-With the STD implementation, the SAP Extended Memory is no longer stored in the TMPFS (under /dev/shm). However, the TMPFS is required by the Virtual Machine Container (VMC). For this reason, we still recommend the same configuration of the TMPFS:
-.br
-75% (RAM + Swap) is still recommended as the size.
-.br
-This section can to contain the following options:
-.TP
-.BI ShmFileSystemSizeMB= INT
-Use ShmFileSystemSizeMB to set an absolute value for your TMPFS.
-.br
-If ShmFileSystemSizeMB is set to a value > 0, the setting for VSZ_TMPFS_PERCENT will be ignored and the size will NOT be calculated.
-.br
-If ShmFileSystemSizeMB is set to '\fB0\fR' the size will be calculated using VSZ_TMPFS_PERCENT
-.TP
-.BI VSZ_TMPFS_PERCENT= INT
-Size of tmpfs mounted on \fI/dev/shm\fR in percent of the virtual memory.
-.br
-Depending on the size of the virtual memory (physical+swap) the value is calculated by (RAM + SWAP) * VSZ_TMPFS_PERCENT/100
-.br
-If VSZ_TMPFS_PERCENT is set to '\fB0\fR', the value is calculated by (RAM + SWAP) * 75/100, as the default is 75.
+When set, the number of requests for \fBall\fP block devices on the system will be switched to the chosen value
+\" section cpu
 .SH "[cpu]"
-The section "[cpu]" manipulates files in \fB/sys/devices/system/cpu/cpu*\fR.
+The section "[cpu]" manipulates files in \fI/sys/devices/system/cpu/cpu*\fP.
 .br
-This section can to contain the following options:
+This section can contain the following options:
 .TP
 .BI energy_perf_bias= STRING
 Energy Performance Bias EPB (applies to Intel-based systems only)
 .br
-supported values are: \fBperformance\fR (0), \fBnormal\fR (6) and \fBpowersave\fR (15)
+supported values are: \fBperformance\fP (0), \fBnormal\fP (6) and \fBpowersave\fP (15)
 .br
 The command 'cpupower set -b <value>' is used to set the value, if the system supports Intel's performance bias setting.
 See cpupower(1) and cpupower-set(1) for more information.
 .br
-If system does not support Intel's performance bias setting - '\fBall:none\fR' is used in the column '\fIActual\fR' of the verify table and the \fIfootnote\fR '[1] setting is not supported by the system' is displayed.
+If system does not support Intel's performance bias setting - '\fBall:none\fP' is used in the column '\fIActual\fP' of the verify table and the \fIfootnote\fP '[1] setting is not supported by the system' is displayed.
 
-When set as 'energy_perf_bias=<performance|normal|powersave> in the Note definition file, the value will be set for \fBall\fR available CPUs.
+When set as 'energy_perf_bias=<performance|normal|powersave> in the Note definition file, the value will be set for \fBall\fP available CPUs.
 .br
-The command '\fBcpupower -c all set -b <value>\fR' or '\fBcpupower -c <cpu> set -b <value>\fR' is used to set the value.
+The command '\fBcpupower -c all set -b <value>\fP' or '\fBcpupower -c <cpu> set -b <value>\fP' is used to set the value.
 .TP
-.BI governor
+.BI governor= STRING
 CPU Frequency/Voltage scaling (applies to Intel-based systems only)
 .br
-The clock frequency and voltage of modern CPUs can scale, in order to save energy when there’s less work to be done. However HANA as a high-performance database benefits from high CPU frequencies.
+The clock frequency and voltage of modern CPUs can scale, in order to save energy when there's less work to be done. However HANA as a high-performance database benefits from high CPU frequencies.
 .br
-The command 'cpupower frequency-set -g <value>' is used to set the value, if the value is a supported governor listed in \fI/sys/devices/system/cpu/cpu*/cpufreq/scaling_governor\fR'
+supported values are: \fBperformance\fP (0), \fBnormal\fP (6) and \fBpowersave\fP (15)
+.br
+The command 'cpupower frequency-set -g <value>' is used to set the value, if the value is a supported governor listed in \fI/sys/devices/system/cpu/cpu*/cpufreq/scaling_governor\fP'
 See cpupower(1) and cpupower-frequency-set(1) for more information.
 .br
-If the governor settings of all available CPUs are equal, '\fBall:<governor>\fR' is used in the column '\fIActual\fR' of the verify table. If not, each CPU with its assigned governor is listed (e.g. cpu1:powersave cpu2:powersave cpu3:powersave cpu4:powersave cpu5:powersave cpu6:powersave cpu7:powersave cpu0:performance)
+If the governor settings of all available CPUs are equal, '\fBall:<governor>\fP' is used in the column '\fIActual\fP' of the verify table. If not, each CPU with its assigned governor is listed (e.g. cpu1:powersave cpu2:powersave cpu3:powersave cpu4:powersave cpu5:powersave cpu6:powersave cpu7:powersave cpu0:performance)
 
-When set as 'governor=<performance|powersave> in the Note definition file, the value will be set for \fBall\fR available CPUs.
+When set as 'governor=<performance|powersave> in the Note definition file, the value will be set for \fBall\fP available CPUs.
 .br
-The command '\fBcpupower -c all frequency-set -g <value>\fR' or '\fBcpupower -c <cpu> frequency-set -g <value>\fR' is used to set the value.
+The command '\fBcpupower -c all frequency-set -g <value>\fP' or '\fBcpupower -c <cpu> frequency-set -g <value>\fP' is used to set the value.
 .TP
 .BI force_latency= STRING
+force latency - configure C-States for lower latency (applies to Intel-based systems only)
+.br
+Input is a string, which is internally treated as a decimal (not a hexadecimal) integer number representing a maximum response time in microseconds.
+.br
+It is used to establish a latency upper limit by limiting the use of C-States (CPU idle or CPU latency states) to only those with an exit latency smaller than the value set here. That means only those states that require less than the requested number of microseconds to wake up are enabled, all the other C-States are disabled.
+.br
+The files \fI/sys/devices/system/cpu/cpu*/cpuidle/state*/latency\fP and \fI/sys/devices/system/cpu/cpu*/cpuidle/state*/disable\fP are used to limit the C-States.
 
-.SH "[service]"
-The section "[service]" is dealing with starting and stopping services controlled by systemd.
-.br
-The syntax for the entries are:
-.TP
-.BI <servicename>=<start|stop>
-Valid services are those listed by the command '\fIsystemctl list-unit-files\fR'.
-.br
-Valid values are '\fBstart\fR' or '\fBstop\fR'.
-.TP
-.BI Exceptions\ and\ Warnings:
-.TP
-For the service \fBuuidd.socket\fR only '\fBstart\fR' is a valid value, because the uuidd.socket service is essential for a working SAP environment.
-.TP
-Concerning \fBsysstat.service\fR please be in mind: A running sysstat service can effect the system performance. But if there are real performance trouble with the SAP system, SAP service normally orders the sysstat reports collected in /var/log/sa.
-.br
-See sar(1), sa2(8), sa1(8) for more information
-.SH "[reminder]"
-The section "[reminder]" contains important information and all settings of a SAP Note, which can not set by saptune. 
+If system does not support force latency settings - '\fBall:none\fP' is used in the column '\fIActual\fP' of the verify table and the \fIfootnote\fP '[1] setting is not supported by the system' is displayed.
 
-This section is displayed at the end of the saptune options 'verify', 'simulate' and 'apply'. It will be highlighted with red colour to get the attention of the customer.
-.SH "[rpm]"
-The section "[rpm]" is checking rpm versions on the system.
-The values from the Note definition files are only checked against the installed rpm versions on the system. No other action is supported.
-.br
-Package dependencies - if needed - are handled by the saptune package installation.
+When set in the Note definition file for all available CPUs all CPU latency states with a value read from \fI/sys/devices/system/cpu/cpu*/cpuidle/state*/latency\fP \fB>=\fP (higher than) the value from the Note definition file are disabled by writing '\fB1\fP' to \fI/sys/devices/system/cpu/cpu*/cpuidle/state*/disable\fP
 
-Syntax:
-.br
-<rpm package name> <SLE Version> <rpm package version>
-.br
-Add one line for each SLE version a package should be checked for, even if the package version is the same.
-.br
-The SLE version has to be noted in the same format as the '\fBVERSION=\fR' entry in \fI/etc/os-release\fR.
-
-e.g
-.br
-systemd 12-SP2 228-142.1
-.br
-sapinit-systemd-compat 12 1.0-2.1
-.br
-sapinit-systemd-compat 12-SP1 1.0-2.1
-.br
-util-linux 12-SP1 2.25-22.1
-
-Only the lines where the SLE version is matching the running system OS are checked and displayed during the 'verify' and 'simulate' option.
-.br
-That means, if there is no matching SLE version for the running OS no rpm entries are listed during the 'verify' and 'simulate' operation.
-
+ATTENTION: not idling *at all* increases power consumption significantly and reduces the life span of the machine because of wear and tear. So do not use a too strict latency setting. For SAP HANA workloads a value of '\fB70\fP' microseconds (as a "light sleep") seems to be sufficient. And the impact on power consumption and life of the CPUs is less severe. But don't forget: The deeper the idle state, the larger is the exit latency.
+\" section grub
 .SH "[grub]"
-The section "[grub]" is checking kernel commandline settings for grub.
-The values from the Note definition files are only checked against \fI/proc/cmdline\fR. Changing the grub configuration is not supported by saptune.
+The section "[grub]" is checking kernel command line settings for grub.
+The values from the Note definition files are only checked against \fI/proc/cmdline\fP. Changing the grub configuration is not supported by saptune.
 
 Some of these values are set by saptune during runtime, so changing the grub configuration is possible but not needed.
 
-This section can contain the following options:
+This section can contain options like:
 .TP
-.BI intel_idle.max_cstate=1
-and
-.BI processor.max_cstate=1
-Configure C-States for lower latency in Linux (applies to Intel-based systems only) - see energy_perf_bias and governor in section [cpu]
+\fBintel_idle.max_cstate=1\fP and \fBprocessor.max_cstate=1\fP
+Configure C-States for lower latency in Linux (applies to Intel-based systems only) - see energy_perf_bias, governor and force latency in section [cpu]
 .TP
 .BI numa_balancing=disable
 Turn off autoNUMA balancing - see kernel.numa_balancing in section [sysctl]
 .TP
 .BI transparent_hugepage=never
 Disable transparent hugepages - see THP in section [vm]
-.SH "[pagecache]"
-The section "[pagecache]" is dealing with the pagecache limit feature as described in SAP Note 1557506, which is only availabe on SLE12.
+\" section limits
+.SH "[limits]"
+The section "[limits]" is dealing with ulimit settings for user login sessions in the pam_limits module. The settings will \fBNOT\fP be done in the central limits file \fI/etc/security/limits.conf\fP. Instead there will be a \fBdrop-in file\fP in \fI/etc/security/limits.d\fP for each domain-item-type combination used in the Note definition file.
+
+The drop-in file name syntax will be:
 .br
-ATTENTION: The pagecache limit Note will NOT be part of any solution definition by default. As it is essential to configure this feature really carefully, you need to customize the note definition file first to enable the feature and then you can apply the note settings manually. After that, the settings will be applied automatically during each startup of the system.
+saptune-<domain>-<item>-<type>.conf
+
+For more information and a description of the syntax and the needed fields please look at limits.conf(5).
+
+This section has to contain the following option:
+.TP
+.BI LIMITS= STRING
+.br
+where STRING is a list of valid limit definitions separated by '\fB,\fP'
+.br
+a valid limit definition contains the fields 'domain item type value' separated by space
+.br
+For more information about the syntax of valid limit definitions please refer to limits.conf(5) or the comment section of \fI/etc/security/limits.conf\fP.
+.br
+Note: The "@" sign in front of the domain name matches a group.
+
+To leave \fBall\fP limits definitions of a Note definition file 'untouched' in the system, leave the \fBLIMITS\fP string in the \fBoverride file\fP of the Note definition file empty
+
+To leave only \fBsome\fP of the limits definitions of a Note definition file 'untouched' in the system, remove these limits definitions from the \fBLIMITS\fP string in the \fBoverride file\fP of the Note definition file.
+\" section login
+.SH "[login]"
+The section "[login]" manipulates the behaviour of the systemd login manager.
+.br
+This section can to contain the following option:
+.TP
+.BI UserTasksMax= STRING
+This option configures a parameter of the systemd login manager. It sets the maximum number of OS tasks each user may run concurrently. The behaviour of the systemd login manager was changed starting SLES12SP2 to prevent fork bomb attacks.
+
+Recommended value is '\fBinfinity\fP'.
+
+If set, the drop-in file \fI/etc/systemd/logind.conf.d/saptune-UserTasksMax.conf\fP is created and for all currently logged in users the maximum number of OS tasks each user may run concurrently is changed using the command '\fBsystemctl --runtime set-property user-<uid>.slice TasksMax=<value>\fP'.
+.br
+After creating the drop-in file the \fIsystemd-logind.service\fP will be restarted.
+
+ATTENTION: With this setting your system is vulnerable to fork bomb attacks
+\" section mem
+.SH "[mem]"
+The section "[mem]" manipulates the size of TMPFS (\fI/dev/shm\fP).
+
+With the STD implementation, the SAP Extended Memory is no longer stored in the TMPFS (under /dev/shm). However, the TMPFS is required by the Virtual Machine Container (VMC). For this reason, we still recommend the same configuration of the TMPFS:
+.br
+75% (RAM + Swap) is still recommended as the size.
+.br
+This section can contain the following options:
+.TP
+.BI ShmFileSystemSizeMB= INT
+Use ShmFileSystemSizeMB to set an absolute value for your TMPFS.
+.br
+If ShmFileSystemSizeMB is set to a value > 0, the setting for VSZ_TMPFS_PERCENT will be ignored and the size will NOT be calculated.
+.br
+If ShmFileSystemSizeMB is set to '\fB0\fP' the size will be calculated using VSZ_TMPFS_PERCENT
+.TP
+.BI VSZ_TMPFS_PERCENT= INT
+Size of tmpfs mounted on \fI/dev/shm\fP in percent of the virtual memory.
+.br
+Depending on the size of the virtual memory (physical+swap) the value is calculated by (RAM + SWAP) * VSZ_TMPFS_PERCENT/100
+.br
+If VSZ_TMPFS_PERCENT is set to '\fB0\fP', the value is calculated by (RAM + SWAP) * 75/100, as the default is 75.
+\" section pagecache
+.SH "[pagecache]"
+The section "[pagecache]" is dealing with the pagecache limit feature as described in SAP Note 1557506, which is only available on SLE12.
+
+ATTENTION: The pagecache limit Note will \fBNOT\fP be part of any solution definition by default. As it is essential to configure this feature really carefully, you need to customize the Note definition file first to enable the feature and then you can apply the note settings manually. After that, the settings will be applied automatically during each startup of the system.
 .br
 This section can contain the following options:
 .TP
 .BI ENABLE_PAGECACHE_LIMIT= yesno
-This defines whether pagecache limit feature should be enabled or not. It is a yesno value. By default it is set to \fBno\fR
+This defines whether pagecache limit feature should be enabled or not. It is a yesno value. By default it is set to \fBno\fP
 .br
 Consider to enable pagecache limit feature if your SAP workloads cause frequent and excessive swapping activities.
 It is recommended to leave pagecache limit disabled if the system has low or no swap space.
@@ -252,12 +217,95 @@ If set to 1 (default), dirty memory will not be freed when enforcing the pagecac
 If set to 2 - a middle ground, some dirty memory will be freed when enforcing the limit.
 .TP
 .BI OVERRIDE_PAGECACHE_LIMIT_MB= INT
-When pagecache limit feature is enabled, the limit value is usually automatically calculated.
+When pagecache limit feature is enabled, the limit value is usually automatically calculated using the 'HANA formula', which means 2% of system memory is used as pagecache limit.
 .br
-However, the value can be overriden if you set this parameter to the desired limit value.
+However, the value can be overridden if you set this parameter to the desired limit value.
 .br
 To remove the override, set the parameter to empty string.
+\" section reminder
+.SH "[reminder]"
+The section "[reminder]" contains important information and all settings of a SAP Note, which can not set by saptune. 
+
+This section is displayed at the end of the saptune options 'verify', 'simulate' and 'apply'. It will be highlighted with red color to get the attention of the customer.
+\" section rpm
+.SH "[rpm]"
+The section "[rpm]" is checking rpm versions on the system.
+The values from the Note definition files are only checked against the installed rpm versions on the system. No other action is supported.
+.br
+Package dependencies - if needed - are handled by the saptune package installation.
+
+Syntax:
+.br
+<rpm package name> <SLE Version> <rpm package version>
+.br
+Add one line for each SLE version a package should be checked for, even if the package version is the same.
+.br
+The SLE version has to be noted in the same format as the '\fBVERSION=\fP' entry in \fI/etc/os-release\fP.
+
+e.g
+.br
+systemd 12-SP2 228-142.1
+.br
+sapinit-systemd-compat 12 1.0-2.1
+.br
+sapinit-systemd-compat 12-SP1 1.0-2.1
+.br
+util-linux 12-SP1 2.25-22.1
+
+Only the lines where the SLE version is matching the running system OS are checked and displayed during the 'verify' and 'simulate' option.
+.br
+That means, if there is no matching SLE version for the running OS no rpm entries are listed during the 'verify' and 'simulate' operation.
+\" section service
+.SH "[service]"
+The section "[service]" is dealing with starting and stopping services controlled by systemd.
+.br
+The syntax for the entries are:
+.TP
+.BI <servicename>=<start|stop>
+Valid services are those listed by the command '\fIsystemctl list-unit-files\fP'.
+.br
+Valid values are '\fBstart\fP' or '\fBstop\fP'.
+.TP
+.BI Exceptions\ and\ Warnings:
+For the service \fBuuidd.socket\fP only '\fBstart\fP' is a valid value, because the uuidd.socket service is essential for a working SAP environment.
+
+Concerning \fBsysstat.service\fP please be in mind: A running sysstat service can effect the system performance. But if there are real performance trouble with the SAP system, SAP service normally orders the sysstat reports collected in /var/log/sa.
+.br
+See sar(1), sa2(8), sa1(8) for more information
+\" section sysctl
+.SH "[sysctl]"
+The section "[sysctl]" can be used to modify kernel parameters. The parameters available are those listed under /proc/sys/.
+.br
+Please write the section keyword '[sysctl]' in the first line and add the desired tunables in 'sysctl.conf' syntax.
+.TP
+.BI sysctl.parameter= VALUE
+\" section vm
+.SH "[vm]"
+The section "[vm]" manipulates \fI/sys/kernel/mm\fP switches.
+.br
+This section can to contain the following options:
+.TP
+.BI THP= STRING
+This option disables transparent hugepages (applies to Intel-based systems only) by changing \fI/sys/kernel/mm/transparent_hugepage/enabled\fP
+.br
+Possible values are '\fBnever\fP' to disable and '\fBalways\fP' to enable.
+.TP
+.BI KSM= INT
+Kernel Samepage Merging (KSM). KSM allows for an application to register with the kernel so as to have its memory pages merged with other processes that also register to have their pages merged. For KVM the KSM mechanism allows for guest virtual machines to share pages with each other. In today's environment where many of the guest operating systems like XEN, KVM are similar and are running on same host machine, this can result in significant memory savings, the default value is set to 0.
+
+.SH FILES
+\fI/usr/share/saptune/notes\fP
+.RS 4
+here you can find examples how to set the 'parameter value' pairs of the available sections.
+.br
+But please do not change the files located here. You will lose all your changes during a saptune package update. Use an override or extra file for your changes as described in saptune_v2(8).
+.RE
+
 .SH "SEE ALSO"
 .LP
 saptune-migrate(7) saptune(8) saptune_v1(8) saptune_v2(8) tuned(8) tuned-adm(8)
+
+.SH AUTHOR
+.NF
+Soeren Schmidt <soeren.schmidt@suse.com>, Angela Briel <abriel@suse.com>
 

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -286,7 +286,7 @@ The section "[vm]" manipulates \fI/sys/kernel/mm\fP switches.
 This section can to contain the following options:
 .TP
 .BI THP= STRING
-This option disables transparent hugepages (applies to Intel-based systems only) by changing \fI/sys/kernel/mm/transparent_hugepage/enabled\fP
+This option disables transparent hugepages by changing \fI/sys/kernel/mm/transparent_hugepage/enabled\fP
 .br
 Possible values are '\fBnever\fP' to disable and '\fBalways\fP' to enable.
 .TP

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\"
-.TH saptune "8" "March 2019" "" "System Optimisation For SAP"
+.TH saptune "8" "May 2019" "" "System Optimisation For SAP"
 .SH NAME
 saptune \- Comprehensive system optimisation management for SAP solutions
 
@@ -24,7 +24,7 @@ saptune has been improved to much more better adapt the needs of an SAP environm
 We now have our good old version 1 of saptune, which is now deprecated and will be removed with the next release. It's available for compatibility reasons and to give the admin the ability to smoothly migrate his SAP system tunings to the new settings demanded by SAP. To get the man page for the version 1 of saptune please use saptune_v1(8).
 To get more information about the migration path from saptune version 1 to saptune version 2 please see saptune-migrate(7)
 
-Our new improved saptune version 2 and the new configuration possibilities and syntax are described in saptuen_v2(8).
+Our new improved saptune version 2 and the new configuration possibilities and syntax are described in saptune_v2(8).
 
 .SH SEE ALSO
 .NF

--- a/ospackage/man/saptune_v2.8
+++ b/ospackage/man/saptune_v2.8
@@ -14,9 +14,11 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\"
-.TH saptune "8" "March 2019" "" "System Optimisation For SAP"
+.TH saptune "8" "May 2019" "" "System Optimisation For SAP"
 .SH NAME
-saptune \- Comprehensive system optimisation management for SAP solutions (Version 2)
+saptune \- Comprehensive system optimisation management for SAP solutions (\fBVersion 2\fP)
+
+ATTENTION: If you still use version \fB1\fP of saptune please refer to man page  saptune_v1(8) instead.
 
 .SH SYNOPSIS
 \fBsaptune daemon\fP
@@ -51,9 +53,11 @@ Additionally, it can simulate the setting of a single SAP Note definition or a d
 
 saptune does not only set kernel values (like sysctl does), but also values like cpu governor, energy perf bias, force latency (dma latency) and the disk io scheduler. Additionally it will check/verify, if suitable rpm versions are installed and special kernel command line values are set, according to the relevant SAP Notes. So saptune checks and applies values in various locations during runtime like
 .PP
-/proc/sys/, /proc/sys/vm/, /proc/sys/kernel, /proc/sys/fs, /sys/block/*/queue/scheduler and /sys/block/*/queue/nr_requests, /sys/devices/system/cpu/*/cpufreq/scaling_governor, /sys/devices/system/cpu/*/cpuidle/state*/latency, /sys/devices/system/cpu/*/cpuidle/state*/disable, /dev/shm, /etc/security/limits.conf and some others.
+/proc/sys/, /proc/sys/vm/, /proc/sys/kernel, /proc/sys/fs, /sys/block/*/queue/scheduler and /sys/block/*/queue/nr_requests, /sys/devices/system/cpu/*/cpufreq/scaling_governor, /sys/devices/system/cpu/*/cpuidle/state*/latency, /sys/devices/system/cpu/*/cpuidle/state*/disable, /dev/shm, /etc/security/limits.d/, /etc/systemd/logind.conf.d/ and some others.
 
 saptune fully integrates with tuned(8), the tuned-profile name associated with this utility is "saptune".
+
+We decided to have only ONE solution applied, but multiple Notes. Each Note is applied exactly once.
 
 .SH DAEMON ACTIONS
 .SS
@@ -68,35 +72,46 @@ Report the status of tuned(8) daemon and whether it is using the correct profile
 Stop tuned(8) daemon, and revert all optimisations that were previously applied by saptune. The daemon will no longer automatically activate upon boot.
 
 .SH NOTE ACTIONS
-Note denotes either a SAP note, a vendor specific tuning definition or SUSE recommendation article.
+Note denotes either a SAP Note, a vendor specific tuning definition or SUSE recommendation article.
 .SS
 .TP
 .B apply
 Apply optimisation settings specified in the Note. The Note will be automatically activated upon system boot if the daemon is enabled.
 
-If a Note definition contains a '\fB[reminder]\fR' section, this section will be printed after the note has applied successfully. It will be highlighted with red colour.
+If a Note definition contains a '\fB[reminder]\fP' section, this section will be printed after the note has applied successfully. It will be highlighted with red color.
+
+A Note can only be applied once.
+
+ATTENTION:
+Please be in mind: If a Note definition to be applied contains parameter settings which are likewise set before by an already applied Note these settings get be overwritten.
+.br
+The last comes, the last wins, it's all about 'order'.
+
+So be careful when applying solutions or notes or when reverting notes, especially if these notes are part of an already applied solution. You can re-apply such a note, but the order - and may be the resulting parameter settings - will be unlike before.
+.br
+Special attention is needed, if customer or vendor specific notes from \fI/etc/saptune/extra\fP are used.
 .TP
 .B list
-List all SAP notes, vendor specific tuning definitions and SUSE recommendation articles that saptune is capable of implementing.
+List all SAP Notes, vendor specific tuning definitions and SUSE recommendation articles that saptune is capable of implementing.
 
-Currently implemented notes are marked with '\fB+\fR', if manually enabled, or '\fB*\fR', if enabled by solutions. In both cases the notes are highlighted with green colour.
+Currently implemented notes are marked with '\fB+\fP', if manually enabled, '\fB*\fP', if enabled by solutions or '\fB-\fP', if a note belonging to an enabled solution was reverted manually. In all cases the notes are highlighted with green color.
 .br
-If an \fBoverride\fR file exists for a NoteID, the note is marked with '\fBO\fR'.
+If an \fBoverride\fP file exists for a NoteID, the note is marked with '\fBO\fP'.
 .TP
 .B verify
 If a Note ID is specified, saptune verifies the current running system against the recommendations specified in the Note. If Note ID is not specified, saptune verifies all system parameters against all implemented Notes. As a result you will see a table containing the following columns
 
 SAPNote, Version | Parameter | Expected | Override | Actual | Compliant
 
-\fBExpected\fR shows the values read from the Note definition file
+\fBExpected\fP shows the values read from the Note definition file
 .br
-\fBOverride\fR shows the values found in an \fBoverride\fR file
+\fBOverride\fP shows the values found in an \fBoverride\fP file
 .br
-\fBActual\fR shows the current system value
+\fBActual\fP shows the current system value
 .br
-\fBCompliant\fR shows \fByes\fR, if the 'Expected' and 'Actual' value matches, or \fBno\fR, if there is no match.
+\fBCompliant\fP shows \fByes\fP, if the 'Expected' and 'Actual' value matches, or \fBno\fP, if there is no match.
 .br
-In some rows you can find references to \fBfootnotes\fR containing additional information. They may explain, why a value does not match.
+In some rows you can find references to \fBfootnotes\fP containing additional information. They may explain, why a value does not match.
 
 e.g.
 .br
@@ -105,8 +120,10 @@ e.g.
 [2] setting is not available on the system
 .br
 [3] value is only checked, but NOT set
+.br
+[4] cpu idle state settings differ
 
-If a Note definition contains a '\fB[reminder]\fR' section, this section will be printed below the table and the footnotes. It will be highlighted with red colour.
+If a Note definition contains a '\fB[reminder]\fP' section, this section will be printed below the table and the footnotes. It will be highlighted with red color.
 .TP
 .B simulate
 Show all changes that will be applied to the system if the specified Note is applied.
@@ -114,13 +131,13 @@ As a result you will see a table containing the following columns
 
 Parameter | Value set | Value expected | Override | Comment
 
-\fBValue set\fR shows the current system value
+\fBValue set\fP shows the current system value
 .br
-\fBValue expected\fR shows the values read from the Note definition file
+\fBValue expected\fP shows the values read from the Note definition file
 .br
-\fBOverride\fR shows the values found in an \fBoverride\fR file
+\fBOverride\fP shows the values found in an \fBoverride\fP file
 .br
-\fBComment\fR shows references to \fBfootnotes\fR containing additional information. They may explain, why a value will not be set by saptune.
+\fBComment\fP shows references to \fBfootnotes\fP containing additional information. They may explain, why a value will not be set by saptune.
 
 e.g.
 .br
@@ -129,17 +146,19 @@ e.g.
 [2] setting is not available on the system
 .br
 [3] value is only checked, but NOT set
+.br
+[4] cpu idle state settings differ
 
-If a Note definition contains a '\fB[reminder]\fR' section, this section will be printed below the table and the footnotes. It will be highlighted with red colour.
+If a Note definition contains a '\fB[reminder]\fP' section, this section will be printed below the table and the footnotes. It will be highlighted with red color.
 .TP
 .B customise
-This allows to customize the values of the saptune Note definitions. The Note definition file will be copied from \fI/usr/share/saptune/notes\fR or \fI/etc/saptune/extra\fR to the override location at \fI/etc/saptune/override\fR, if the file does not exist already. After that an editor will be launched to allow changing the Note definitions.
-The editor is defined by the \fBEDITOR\fR environment variable. If not set editor defaults to /usr/bin/vim.
+This allows to customize the values of the saptune Note definitions. The Note definition file will be copied from \fI/usr/share/saptune/notes\fP or \fI/etc/saptune/extra\fP to the override location at \fI/etc/saptune/override\fP, if the file does not exist already. After that an editor will be launched to allow changing the Note definitions.
+The editor is defined by the \fBEDITOR\fP environment variable. If not set editor defaults to /usr/bin/vim.
 .TP
 .B create
-This allows to create own Note definition files in \fI/etc/saptune/extra\fR. The Note definition file will be created from a template file into the location \fI/etc/saptune/extra\fR, if the file does not exist already. After that an editor will be launched to allow changing the Note definitions.
-The editor is defined by the \fBEDITOR\fR environment variable. If not set editor defaults to /usr/bin/vim.
-You need to choose an unique NoteID for this operation. Use '\fIsaptune note list\fR' to find the already used NoteIDs.
+This allows to create own Note definition files in \fI/etc/saptune/extra\fP. The Note definition file will be created from a template file into the location \fI/etc/saptune/extra\fP, if the file does not exist already. After that an editor will be launched to allow changing the Note definitions.
+The editor is defined by the \fBEDITOR\fP environment variable. If not set editor defaults to /usr/bin/vim.
+You need to choose an unique NoteID for this operation. Use '\fIsaptune note list\fP' to find the already used NoteIDs.
 .TP
 .B revert
 Revert optimisation settings carried out by the Note, and the Note will no longer be activated automatically upon system boot.
@@ -147,7 +166,9 @@ Revert optimisation settings carried out by the Note, and the Note will no longe
 .SH SOLUTION ACTIONS
 A solution is a collection of one or more Notes. Activation of a solution will activate all associated Notes.
 .br
-The solution definitions can be found in the file \fI/usr/share/saptune/solutions\fR
+The solution definitions can be found in the file \fI/usr/share/saptune/solutions\fP
+
+It's not possible to combine solutions, there can only be\fBone\fP solution enabled.
 .SS
 .TP
 .B apply
@@ -181,11 +202,11 @@ Will display the currently active saptune version.
 Will display the syntax of saptune
 
 .SH VENDOR SUPPORT
-To support vendor or customer specific tuning values, saptune supports 'drop-in' files residing in \fI/etc/saptune/extra\fR. All files found in \fI/etc/saptune/extra\fR are listed when running '\fBsaptune note list\fR'. All \fBnote options\fR are available for these files.
+To support vendor or customer specific tuning values, saptune supports 'drop-in' files residing in \fI/etc/saptune/extra\fP. All files found in \fI/etc/saptune/extra\fP are listed when running '\fBsaptune note list\fP'. All \fBnote options\fP are available for these files.
 
 We simplify the file name syntax for these vendor files. But the old file names still valid and supported.
 .br
-Related to this we add 'header' support (see description of section [version] in saptune-note(5)) for the vendor files as already available for the note definition files in /usr/share/saptune/notes to get a proper description during saptune option 'list'
+Related to this we add 'header' support (see description of section [version] in saptune-note(5)) for the vendor files as already available for the Note definition files in /usr/share/saptune/notes to get a proper description during saptune option 'list'
 
 .SS
 .RS 0
@@ -207,26 +228,11 @@ Syntax of the file:
 The content of the 'drop-in' file should be written in a INI file style with sections headed by '[section_name]' keywords. See saptune-note(5) to find the supported sections and their available options.
 .PP
 
-.SH "PACKAGE REQUIREMENTS"
-.TP 4
-.BI USERTASKSMAX=infinity
-The file \fB/etc/systemd/logind.conf.d/sap.conf\fP configures a parameter of the systemd login manager. It sets the maximum number of OS tasks each user may run concurrently. The behaviour of the systemd login manager was changed starting SLES12SP2 to prevent fork bomb attacks. So no need to set in SLES12SP1.
-
-The file will be created during package installation, if it does not already exists.
-.br
-Note: A reboot is needed after the first setup to get the change take effect.
-A message will indicate if a reboot is necessary.
-
-There is no rollback. So please remove the file manually, if it is not needed any longer.
-.br
-Note: A reboot is needed after the removal of the file to get the change take effect.
-.PP
-
 .SH FILES
 .PP
-\fI/usr/share/saptune/notes\fR
+\fI/usr/share/saptune/notes\fP
 .RS 4
-the saptune SAP Note definitions, which can be listed by '\fBsaptune note list\fR'
+the saptune SAP Note definitions, which can be listed by '\fBsaptune note list\fP'
 
 The files are named with the number of their corresponding SAP Note (==NoteID).
 .br
@@ -235,46 +241,54 @@ A description of the syntax and the available tuning options can be found in sap
 Please do not change the files located here. You will lose all your changes during a saptune package update.
 .RE
 .PP
-\fI/etc/saptune/extra\fR
+\fI/etc/sysconfig/saptune\fP
+.RS 4
+the central saptune configuration file containing the information about the currently enabled notes and solutions, the order in which these notes are applied and the version of saptune currently used.
+.RE
+.PP
+\fI/etc/saptune/extra\fP
 .RS 4
 vendor or customer specific tuning definitions.
 .br
-Please see \fBVENDOR SUPPORT\fR above for more information.
+Please see \fBVENDOR SUPPORT\fP above for more information.
 .RE
 .PP
-\fI/etc/saptune/override\fR
+\fI/etc/saptune/override\fP
 .RS 4
 the saptune Note definition override location.
 
-If you need to customize the Note definitions found in \fI/usr/share/saptune/notes\fR or \fI/etc/saptune/extra\fR, you can copy them to \fI/etc/saptune/override\fR and modify them as you need. Please stay with the original name of the Note definition (the NoteID) and do \fBNOT\fR rename it.
+If you need to customize the Note definitions found in \fI/usr/share/saptune/notes\fP or \fI/etc/saptune/extra\fP, you can copy them to \fI/etc/saptune/override\fP and modify them as you need. Please stay with the original name of the Note definition (the NoteID) and do \fBNOT\fP rename it.
 
-Or use '\fBsaptune note customize NoteID\fR' to do the job for you.
+Or use '\fBsaptune note customize NoteID\fP' to do the job for you.
 
-You can only change the value from already available parameters of the note. But you are not able to add new parameters. If you want to use new parameters to tune the system, please create your own custom Note definition file in \fI/etc/saptune/extra\fR.
+You can only change the value from already available parameters of the note. But you are not able to add new parameters. If you want to use new parameters to tune the system, please create your own custom Note definition file in \fI/etc/saptune/extra\fP.
 
-The values from the override files will take precedence over the values from \fI/usr/share/saptune/notes\fR or \fI/etc/saptune/extra\fR. In such case you will not lose your customized Notes between saptune or vendor updates.
+You can prevent a parameter from being changed by leaving the parameter value in the override file empty. The parameter will be marked as 'untouched' in the override column of the verify table.
+
+The values from the override files will take precedence over the values from \fI/usr/share/saptune/notes\fP or \fI/etc/saptune/extra\fP. In such case you will not lose your customized Notes between saptune or vendor updates.
 .br
 The saptune options 'list', 'verify' and 'simulate' will mark the existence of an override file and the contained values.
 
 When creating an override file for an already applied SAP Note definition, please do a 'revert all' and then apply the Notes again, to get the changes take effect.
 .RE
 .PP
-\fI/usr/share/saptune/solutions\fR
+\fI/usr/share/saptune/solutions\fP
 .RS 4
-this file contains the saptune solution definitions, which can be listed by '\fBsaptune solution list\fR'
+this file contains the saptune solution definitions, which can be listed by '\fBsaptune solution list\fP'
 .br
-At the moment saptune supports two architectures - \fIArchX86\fR for the x86 platform and \fIArchPPC64LE\fR for 64-bit PowerPC little endian platform - with different solution definitions.
+At the moment saptune supports two architectures - \fIArchX86\fP for the x86 platform and \fIArchPPC64LE\fP for 64-bit PowerPC little endian platform - with different solution definitions.
 
 Please do not change as maintenance updates of package saptune will overwrite this file without preserving any custom changes.
 .RE
 .PP
-\fI/var/lib/saptune/saved_state/\fR
+\fI/var/lib/saptune/saved_state/\fP
+\fI/var/lib/saptune/parameter/\fP
 .RS 4
 saptune was designed to preserve the state of the system before starting the SAP specific tuning, so that it will be possible to restore this previous state of the system, if the SAP specific tuning is no longer needed or should be changed.
 
-This system state is saved during the 'apply' operation of saptune in the saptune internal used files in /var/lib/saptune/saved_state. The content of these files highly depends on the previous state of the system.
+This system state is saved during the 'apply' operation of saptune in the saptune internal used files in /var/lib/saptune/saved_state and /var/lib/saptune/parameter. The content of these files highly depends on the previous state of the system.
 .br
-If the values are applied by saptune, no further monitoring of the system parameters are done, so changes of saptune relevant parameters will not be observed. If a SAP Note or a SAP solution should be reverted, then first the values read from the /var/lib/saptune/saved_state files will be applied to the system to restore the previous system state and then the corresponding save_state file will be removed.
+If the values are applied by saptune, no further monitoring of the system parameters are done, so changes of saptune relevant parameters will not be observed. If a SAP Note or a SAP solution should be reverted, then first the values read from the /var/lib/saptune/saved_state and /var/lib/saptune/parameter files will be applied to the system to restore the previous system state and then the corresponding save_state file will be removed.
 
 Please do not change or remove files in this directory. The knowledge about the previous system state gets lost and the revert functionality of saptune will be destructed. So you will lose the capability to revert back the tunings saptune has done.
 .RE
@@ -283,9 +297,9 @@ Please do not change or remove files in this directory. The knowledge about the 
 When the values from the saptune Note definitions are applied to the system, no further monitoring of the system parameters are done. So changes of saptune relevant parameters by using the 'sysctl' command or by editing configuration files will not be observed. If the values set by saptune should be reverted, these unrecognized changed settings will be overwritten by the previous saved system settings from saptune.
 
 .SH ATTENTION
-Higher or lower system values set by the system, the SAP installer or by the administrator using sysctl command or sysctl configuration files will be now \fBoverwritten\fR by saptune, if they are part of the applied Note definitions.
+Higher or lower system values set by the system, the SAP installer or by the administrator using sysctl command or sysctl configuration files will be now \fBoverwritten\fP by saptune, if they are part of the applied Note definitions.
 
-saptune now sets the values read from the Note definition files irrespective of already set higher system values. If you need other tuning values as defined in the Note definition files, please use the possibility to create \fBoverride\fR files, which contain the values you need.
+saptune now sets the values read from the Note definition files irrespective of already set higher system values. If you need other tuning values as defined in the Note definition files, please use the possibility to create \fBoverride\fP files, which contain the values you need.
 
 .SH SEE ALSO
 .NF

--- a/ospackage/man/saptune_v2.8
+++ b/ospackage/man/saptune_v2.8
@@ -28,7 +28,7 @@ ATTENTION: If you still use version \fB1\fP of saptune please refer to man page 
 [ list | verify ]
 
 \fBsaptune note\fP
-[ apply | simulate | verify | customise | create | revert ]  NoteID
+[ apply | simulate | verify | customise | create | revert | show ]  NoteID
 
 \fBsaptune solution\fP
 [ list | verify ]
@@ -162,6 +162,9 @@ You need to choose an unique NoteID for this operation. Use '\fIsaptune note lis
 .TP
 .B revert
 Revert optimisation settings carried out by the Note, and the Note will no longer be activated automatically upon system boot.
+.TP
+.B show
+Print content of Note definition file to stdout
 
 .SH SOLUTION ACTIONS
 A solution is a collection of one or more Notes. Activation of a solution will activate all associated Notes.

--- a/ospackage/usr/share/bash-completion/completions/saptune.completion
+++ b/ospackage/usr/share/bash-completion/completions/saptune.completion
@@ -2,7 +2,7 @@
 #
 #   saptune daemon [ start | status | stop ]
 #   saptune note [ list | verify ]
-#   saptune note [ apply | simulate | verify | customise | revert | create ] NoteID
+#   saptune note [ apply | simulate | verify | customise | revert | create | show ] NoteID
 #   saptune solution [ list | verify ]
 #   saptune solution [ apply | simulate | verify | revert ] SolutionName
 #   saptune revert all
@@ -27,7 +27,7 @@ _saptune() {
                             ;;
                 solution)   opts="list verify apply simulate revert"
                             ;;
-                note)       opts="list verify apply simulate customise revert create"       
+                note)       opts="list verify apply simulate customise revert create show"
                             ;;
 		revert)	    opts="all"	
 			    ;;
@@ -36,7 +36,7 @@ _saptune() {
             ;;
 
         3)  case "${prev}" in
-                apply|simulate|verify|customise|revert|create)
+                apply|simulate|verify|customise|revert|create|show)
                         case "${COMP_WORDS[COMP_CWORD-2]}" in
                             note)       opts=$((ls -1q /usr/share/saptune/notes/ ; find /etc/saptune/extra/ -name '*.conf' -printf '%f\n' | cut -d '-' -f 1 | sed 's/\.conf$//') | tr '\n' ' ') 
                                         ;;

--- a/ospackage/usr/share/bash-completion/completions/saptune.completion
+++ b/ospackage/usr/share/bash-completion/completions/saptune.completion
@@ -1,4 +1,4 @@
-# v1.1	
+# v1.2
 #
 #   saptune daemon [ start | status | stop ]
 #   saptune note [ list | verify ]
@@ -25,7 +25,7 @@ _saptune() {
         2)  case "${prev}" in
                 daemon)     opts="start status stop"
                             ;;
-                solution)   opts="list verify apply simulate customise revert"
+                solution)   opts="list verify apply simulate revert"
                             ;;
                 note)       opts="list verify apply simulate customise revert create"       
                             ;;

--- a/ospackage/usr/share/doc/packages/saptune/sapconf2saptune
+++ b/ospackage/usr/share/doc/packages/saptune/sapconf2saptune
@@ -1,0 +1,389 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*
+
+"""
+sapconf2saptune migrates a sapconf configuration to a saptune v2 configuration file by
+
+    - inspecting a given sapconf sysconfig file (/etc/sysconfig/sapconf)
+    - inspecting a given sapconf tuned.conf file
+    - Adding all what is done by the sapconf RPM installation
+
+On stdout the resulting saptune configuration is printed which is suitable for an extra file, 
+on stderr important messages.
+
+Example:
+
+sapconf2saptune /etc/sysconfig/sapconf /usr/lib/tuned/sapconf/tuned.conf > /etc/saptune/extra/sapconf-migration\ file.conf  
+
+by soeren.schmidt@suse.com
+"""
+
+import datetime
+import os
+import re
+import signal
+import socket
+import sys
+
+
+VERSION = '1.5'
+GLOBAL_ERROR = 0
+
+# -------------------------------------------------------
+# These are common functions used throughout the program.
+# -------------------------------------------------------
+
+def signal_handler(signal, frame):
+    """
+    Terminate on signal.
+    """
+    sys.exit(1)
+
+def help_and_exit(exitcode=0):
+    """
+    Prints help to stdout and exits.
+    """
+    name = sys.argv[0].rpartition('/')[2]
+    error('''Usage: %s [PROFILE]
+       %s SAPCONF_SYCONFIG TUNED_CONFIG
+       %s -h|--help
+
+v%s
+
+Translates a sapconf configuration into a saptune extra file.
+See man page for details.
+
+    PROFILE            sapconf profile to use
+    SAPCONF_SYCONFIG   sapconf sysconfig file (/etc/sysconfig/sapconf)
+    TUNED_CONFIG       sapconf tuned.conf file (/usr/lib/tuned/<profile>/tuned.conf)
+    -h|--help          this help\n\n''' % (name, name, name, VERSION), exitcode)
+
+def write(text):
+    """
+    Prints text on stdout.
+    """
+    sys.stdout.write(text)
+
+def error(text, exitcode=1):
+    """
+    Prints text on stderr and exits with exitcode.
+    """
+    sys.stderr.write(text)
+    sys.exit(exitcode)
+ 
+def write_err(text):
+    """
+    Prints prefixed error text on stderr.
+    """ 
+    sys.stderr.write('[ERROR] %s\n' % text)
+
+def write_warn(text):
+    """
+    Prints prefixed warning text on stderr.
+    """
+    sys.stderr.write('[WARN ] %s\n' % text)
+
+def write_info(text):
+    """
+    Prints prefixed warning text on stderr.
+    """
+    sys.stderr.write('[INFO ] %s\n' % text)        
+
+def load_sysconfig_file(filename):
+    """
+    Loads sysconfig style file and returns a dictionary with the parameter-value pairs.
+    """
+    assignment = re.compile('^\s*[A-Z_0-9]{1,}\s*=')
+    content = {}
+    
+    try:
+        with open(filename, 'r') as f:
+            for line in f:
+                if assignment.match(line):
+                    name, value = line.split('=', 2)
+                    content[name.strip()] = value.strip('\n" ')
+        return content, None
+    except Exception as err:
+        return None, str(err)
+
+def load_tunedconf_file(filename):
+    """
+    Load tuned.conf file and return a dictionary with the parameter-value pairs.
+    """
+    section = re.compile('^\s*\[[a-z]{1,}\]')
+    assignment = re.compile('^\s*[0-9A-Za-z_.-]{1,}\s*=')
+
+    id = ''    
+    content = {}
+    
+    try:
+        with open(filename, 'r') as f:
+            for line in f:
+                if section.match(line):
+                    id = line.strip('\n')
+                if assignment.match(line):
+                    name, value = line.split('=', 2)
+                    name = '%s:%s' % (id.strip(), name.strip())
+                    content[name] = value.strip('\n" ')
+        return content, None
+    except Exception as err:
+        return None, str(err)
+
+def convert_sysconfig(filename, sapconf):
+    """
+    Reads sapconf sysconfig file, translates the variables into a saptune configuration and updates the
+    sapconf dictionary.
+
+    Translation rules:
+
+        sapconf variable                            saptune section
+        ----------------------------------------    --------------------------------------------------------------------
+        DIRTY_BG_BYTES                              [sysctl]:vm.dirty_background_bytes
+        DIRTY_BYTES                                 [sysctl]:vm.dirty_bytes
+        KSM=0                                       [vm]:KSM
+        LIMIT_n="<domain> <type> <item> <value>"    [limits]:LIMIT="<domain> <type> <item> <value>, ..."
+        MAX_MAP_COUNT                               [sysctl]:vm.max_map_count
+        NUMA_BALANCING                              [sysctl]:kernel.numa_balancing                                                                                                                                                                                        
+        SHMALL                                      [sysctl]:kernel.shmall
+        SHMMAX                                      [sysctl]:kernel.shmmax
+        SHMMNI                                      [sysctl]:kernel.shmmni
+        TCP_SLOW_START                              [sysctl]:net.ipv4.tcp_slow_start_after_idle
+        THP                                         [vm]:THP
+        VSZ_TMPFS_PERCENT                           [mem]:VSZ_TMPFS_PERCENT
+        ENABLE_PAGECACHE_LIMIT                      (determines if PAGECACHE_LIMIT_MB is used or not)                      
+        PAGECACHE_LIMIT_MB                          [sysctl]:vm.pagecache_limit_mb
+        PAGECACHE_LIMIT_IGNORE_DIRTY                [sysctl]:vm.pagecache_limit_ignore_dirty
+        SEMMSL SEMMNS SEMOPM SEMMNI                 [sysctl]:kernel.sem = SEMMSL SEMMNS SEMOPM SEMMNI
+    """
+
+    simple_translation = {'DIRTY_BG_BYTES': '[sysctl]:vm.dirty_background_bytes:int',
+                          'DIRTY_BYTES': '[sysctl]:vm.dirty_bytes:int',
+                          'KSM': '[vm]:KSM:int',
+                          'MAX_MAP_COUNT': '[sysctl]:vm.max_map_count:int',
+                          'NUMA_BALANCING': '[sysctl]:kernel.numa_balancing:int',
+                          'SHMALL': '[sysctl]:kernel.shmall:int',
+                          'SHMMAX': '[sysctl]:kernel.shmmax:int',
+                          'SHMMNI': '[sysctl]:kernel.shmmni:int',
+                          'TCP_SLOW_START': '[sysctl]:net.ipv4.tcp_slow_start_after_idle:int',
+                          'THP': '[vm]:THP:str',
+                          'PAGECACHE_LIMIT_IGNORE_DIRTY': '[sysctl]:vm.pagecache_limit_ignore_dirty:int',
+                          'PAGECACHE_LIMIT_MB': '[sysctl]:vm.pagecache_limit_mb:int',
+                          'VSZ_TMPFS_PERCENT': '[mem]:VSZ_TMPFS_PERCENT:int'}
+
+    limits = []
+    semaphores = {'SEMMSL': 0, 'SEMMNS': 0, 'SEMOPM': 0, 'SEMMNI': 0}
+    semaphores_found = False
+    pagecache_limit = False
+
+    # Read the sysconfig file.
+    config, err = load_sysconfig_file(filename)
+    if err:
+        error('Error reading %s: %s\n' % (filename, err))
+
+    if not config:
+        write_warn('%s: No variables found! Sure this is a valid sapconf sysconfig file?' % filename)
+        return
+
+    # Go thru each parameter and convert.
+    for param, value in config.items():
+        
+        # First go thru "special" translations.
+        if param.startswith('LIMIT_'):    
+            limits.append(value)
+            continue
+        if param in ['SEMMSL', 'SEMMNS', 'SEMOPM', 'SEMMNI']:    
+            semaphores_found = True
+            semaphores[param] = int(value)
+            continue
+        if param == 'ENABLE_PAGECACHE_LIMIT':
+            pagecache_limit = True if value == 'yes' else False
+            continue
+            
+        # Now the normal translations.
+        if param not in simple_translation.keys():
+            write_warn('%s: Variable %s unknown! Ignored.' % (filename, param))
+            continue
+        section, new_param, datatype = simple_translation[param].split(':')   
+        datatype = eval(datatype)  # convert name of the datatype into datatype itself
+        if section not in sapconf.keys():
+            sapconf[section] = {}
+        try:
+            sapconf[section][new_param] = (datatype)(value)
+        except Exception as err:
+            write_err('%s: Cannot convert: %s = %s: %s' % (filename, param, value, err))
+
+    # Pagecache limit has to be enabled to have the limit set.
+    if not pagecache_limit:
+        try:
+            del(sapconf['[sysctl]']['vm.pagecache_limit_mb'])
+        except:
+            pass
+
+    # Put limits altogether into the configuration.
+    if '[limits]' not in sapconf.keys():
+        sapconf['[limits]'] = {'LIMIT': '%s' % ', '.join(limits)}
+    else:  # needed if LIMITS already exist (in the future)
+        sapconf['[limits]']['LIMIT'] = '%s, %s' % (sapconf['[limits]']['LIMIT'], ', '.join(sapconf['[limits]']['LIMIT']))
+
+    # Put kernel semaphores together.
+    if semaphores_found:
+        if '[sysctl]' not in sapconf.keys():
+            sapconf['[sysctl]'] = {'kernel.sem': ''}
+        sapconf['[sysctl]']['kernel.sem'] = '%s %s %s %s' % (semaphores['SEMMSL'], semaphores['SEMMNS'], semaphores['SEMOPM'], semaphores['SEMMNI'])
+
+    # Add ShmFileSystemSizeMB = 0 if VSZ_TMPFS_PERCENT is used.
+    if '[mem]' in sapconf  and 'VSZ_TMPFS_PERCENT' in sapconf['[mem]']:
+        sapconf['[mem]']['ShmFileSystemSizeMB'] = 0
+
+def convert_tunedconf(filename, sapconf):
+    """
+    Reads sapconf tuned.conf file, translates it into a saptune configuration and updates the
+    sapconf dictionary.
+
+    Translation rules:
+
+        tuned setting               saptune section
+        -----------------------     --------------------------------------------------
+        [cpu]:governor              [cpu]:governor
+        [cpu]:energy_perf_bias      [cpu]:energy_perf_bias
+        [cpu]:min_perf_pct          (removed)
+        [cpu]:force_latency         [cpu]:force_latency
+        [disk]:elevator             [block]:IO_SCHEDULER
+    """
+
+    ignore_list = ['[main]:summary', '[script]:script']
+    translation = {'[cpu]:governor': '[cpu]:governor:str',
+                   '[cpu]:energy_perf_bias': '[cpu]:energy_perf_bias:str',
+                   '[cpu]:min_perf_pct:int': None,
+                   '[cpu]:force_latency': '[cpu]:force_latency:int',
+                   '[disk]:elevator': '[block]:IO_SCHEDULER:str'}
+
+    # Read the tuned.conf file.
+    config, err = load_tunedconf_file(filename)
+    if err:
+        error('Error reading %s: %s\n' % (filename, err))
+
+    if not config:
+        write_warn('%s: No parameters found! Sure this is a valid tuned.conf file?' % filename)
+        return 
+    
+    for param, value in config.items():
+        if param in ignore_list:
+            continue
+        
+        if param in translation.keys():
+            if translation[param]:
+                section, new_param, datatype = translation[param].split(':') 
+                datatype = eval(datatype)  # convert name of the datatype into datatype itself  
+                if section not in sapconf.keys():
+                    sapconf[section] = {}
+                
+                try:
+                    sapconf[section][new_param] = (datatype)(value)
+                except Exception as err:
+                    write_err('%s: Cannot convert: %s = %s: %s' % (filename, param, value, err))
+            else:
+                write_warn('%s: Parameter %s is not supported in saptune v2! Not migrated.' % (filename, param))
+            continue
+        
+        write_warn('%s: Unsupported entry found! It will not get migrated: %s = %s' % (filename, param, value ))
+
+def write_saptune_config(sapconf, sapconf_sysconfig_file, sapconf_tunedconf_file):
+    """
+    Writes sapconf configuration on stdout in the right format
+    for saptune v2.
+    """
+ 
+    # A small header...
+    write('# saptune v2 drop-in of sapconf configuration\n#\n# Created by %s v%s\n#\n' % (sys.argv[0].rpartition('/')[2], VERSION))
+    write('# Host: %s\n# Date: %s\n#\n' % (socket.getfqdn(), datetime.datetime.now()))
+    write('# Used configurations: "%s" "%s"\n' % (sapconf_sysconfig_file, sapconf_tunedconf_file))
+    write('\n[version]\n# SAP-NOTE=sapconf CATEGORY=SUSE VERSION=0 DATE=%s NAME="Configuration drop-in of sapconf configuration"\n' % datetime.datetime.now().strftime("%d.%m.%Y"))
+
+    # ...and the configuration.
+    for section in sapconf.keys():
+        write('\n%s\n' % section)
+        for param, value in sapconf[section].items():
+            qutoation_mark = '"' if type(value) == str else '' 
+            write('%s = %s%s%s\n' %(param, qutoation_mark, value, qutoation_mark)) 
+
+
+# --------------------------
+# The main function finally.
+# --------------------------
+
+def main():
+
+    sapconf = {}    # for our converted configuration
+
+    # Disable stdout buffering to prevent errors together with redirection.
+    # http://stackoverflow.com/questions/3515757/
+    #    python-print-statements-being-buffered-with-output-redirection
+    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+
+    # Prevent "IOError: [Errno 32] Broken pipe" using the pipe.
+    # http://coding.derkeiler.com/Archive/Python/comp.lang.python/2004-06/3823.html
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+    # Clean termination on ^C.
+    signal.signal(signal.SIGINT, signal_handler)
+    
+    # Check parameters.
+    sapconf_profile, sapconf_sysconfig_file, sapconf_tunedconf_file = None, None, None
+    if len(sys.argv) == 1:  # We try to detect the used sapconf profile.
+        try:
+            with open('/etc/tuned/active_profile', 'r') as f:
+                sapconf_profile = f.read().strip()        
+        except Exception as err:
+            error('Cannot determine the current sapconf profile: %s\n' % err, 1)
+        write_info('Detected current sapconf profile: %s' % sapconf_profile)
+
+    elif len(sys.argv) == 2:    # Either help is wanted or a sapconf profile was specified.
+        if sys.argv[1] in ['-h', '--help']:
+            help_and_exit(1)
+        else:
+            sapconf_profile = sys.argv[1]
+
+    elif len(sys.argv) == 3:    # The configuration files have been stated.
+        sapconf_sysconfig_file, sapconf_tunedconf_file = sys.argv[1], sys.argv[2]
+        
+    else:
+        help_and_exit(1)
+
+    # If we've been called with a profile, check if it is valid and determine the configuration files.
+    if sapconf_profile:
+        if sapconf_profile not in ['sapconf', 'sap-hana', 'sap-netweaver', 'sap-ase', 'sap-bobj']:
+            error('The tuned profile \"%s\" is not a sapconf profile.\n' % sapconf_profile, 1)
+        sapconf_sysconfig_file = '/etc/sysconfig/sapconf'
+        sapconf_tunedconf_file = '/etc/tuned/%s/tuned.conf' % sapconf_profile if os.path.exists('/etc/tuned/%s' % sapconf_profile) else '/usr/lib/tuned/%s/tuned.conf' % sapconf_profile
+        write_info('Used configuration files: "%s" and "%s"' % (sapconf_sysconfig_file, sapconf_tunedconf_file))
+        
+    # Convert sapconf sysconfig file.
+    convert_sysconfig(sapconf_sysconfig_file, sapconf)
+
+    # Convert sapconf tuned.conf file.
+    convert_tunedconf(sapconf_tunedconf_file, sapconf)
+
+    # Adding some parameters that are handled by sapconf rpm package.
+    for section in ['[login]', '[service]', '[rpm]']:
+        if section not in sapconf.keys():
+            sapconf[section] = {}
+    sapconf['[login]']['UserTasksMax'] = 'infinity'
+    sapconf['[service]']['uuidd.socket'] = 'start'
+    sapconf['[service]']['sysstat.service'] = 'start'
+    # The [rpm] entries do not have a equal sign, which is not supported
+    # by the code at the moment. Since the requirement for this systemd
+    # version (SP2) is very old and should be fulfilled by sapconf/saptune
+    # rpm dependency anyway, we ignore it.
+    #sapconf['[rpm]']['systemd'] = '12-SP2 228-142.1'
+
+    # Print saptune configuration to stdout.
+    write_saptune_config(sapconf, sapconf_sysconfig_file, sapconf_tunedconf_file)
+
+    # Bye.
+    sys.exit(GLOBAL_ERROR)
+        
+
+if __name__ == '__main__':
+    main()
+

--- a/ospackage/usr/share/saptune/notes/1680803
+++ b/ospackage/usr/share/saptune/notes/1680803
@@ -33,7 +33,7 @@ IO_SCHEDULER=noop
 NRREQ=1024
 
 [vm]
-# Disable transparent hugepages (THP, applies to Intel-based systems only)
+# Disable transparent hugepages (THP)
 # changes /sys/kernel/mm/transparent_hugepage/enabled
 # 'never' to disable, 'always' to enable
 THP=never

--- a/ospackage/usr/share/saptune/notes/2205917
+++ b/ospackage/usr/share/saptune/notes/2205917
@@ -51,8 +51,24 @@ energy_perf_bias=performance
 # cpupower frequency-set -g performance
 governor=performance
 
-# force latency
-# input is a decimal (not a hexadecimal) number
+# force latency (applies to Intel-based systems only)
+# configure C-States for lower latency
+#
+# input is a string, which is internally treated as a decimal (not a
+# hexadecimal) integer number representing a maximum response time in
+# microseconds.
+# It is used to establish a latency upper limit by limiting the use of C-States
+# (CPU idle or CPU latency states) to only those with an exit latency smaller
+# than the value set here. That means only those states that require less than
+# the requested number of microseconds to wake up are enabled, all the other
+# C-States are disabled.
+#
+# ATTENTION: not idling *at all* increases power consumption significantly and
+# reduces the life span of the machine because of wear and tear. So do not use
+# a too strict latency setting. Prefere a "light sleep", because the impact on
+# power consumption and life of the CPUs is less severe.
+# But don't forget: The deeper the idle state, the larger is the exit latency.
+#
 force_latency=70
 
 [sysctl]
@@ -120,4 +136,4 @@ numa_balancing=disable
 transparent_hugepage=never
 
 [reminder]
-# IBM EnergyScale for POWER8 Processor-Based Systems (applies to IBM Power systems only) - not supported by saptune!
+# IBM EnergyScale for POWER8 Processor-Based Systems (applies to IBM Power systems only) - not handled by saptune!

--- a/ospackage/usr/share/saptune/notes/2205917
+++ b/ospackage/usr/share/saptune/notes/2205917
@@ -17,7 +17,7 @@
 UserTasksMax=infinity
 
 [vm]
-# Disable transparent hugepages (THP, applies to Intel-based systems only)
+# Disable transparent hugepages (THP)
 # changes /sys/kernel/mm/transparent_hugepage/enabled
 # 'never' to disable, 'always' to enable
 # SAP Note 2131662, 2031375

--- a/ospackage/usr/share/saptune/notes/2382421
+++ b/ospackage/usr/share/saptune/notes/2382421
@@ -17,32 +17,9 @@ net.core.somaxconn = 4096
 # log, the size of the SYN backlog should be set to a reasonably high value.
 net.ipv4.tcp_max_syn_backlog = 8192
 
-# This setting allows HANA to reuse a client port immediately after the
-# connection has been closed, even though the connection is still in TIME_WAIT
-# state. A precondition for it to take effect is that TCP timestamps are
-# enabled, i.e. net.ipv4.tcp_timestamps = 1, which is the default on most
-# modern systems. Please note that this setting must not be applied if the HANA
-# node needs to communicate with hosts behind a NAT firewall. Moreover, it must
-# not be applied if not all hosts that use a TCP connection to communicate with
-# the HANA node have TCP timestamps enabled. Otherwise you might encounter TCP
-# connection issues after applying this configuration parameter.
-net.ipv4.tcp_tw_reuse = 1
-
-# This setting reduces the time a connection spends in the TIME_WAIT state.
-# One precondition for it to take effect is that TCP timestamps are enabled,
-# i.e. net.ipv4.tcp_timestamps = 1, which is the default on most modern systems.
-# Please note that this setting must not be applied if the HANA node has to
-# communicate with hosts behind a NAT firewall. Moreover, it must not be
-# applied if not all hosts that use a TCP connection to communicate with the
-# HANA node have TCP timestamps enabled. Otherwise you might encounter TCP
-# connection issues after applying this configuration parameter.
-net.ipv4.tcp_tw_recycle = 1
-
 # This setting adds the timestamp field to the TCP header.
 # It should already be active on most modern systems and is a prerequisite for
 # net.ipv4.tcp_tw_reuse and net.ipv4.tcp_tw_recycle.
-# ATTENTION: SUSE-GUIDE-02 will set the value back to 0, if applied after 
-# note 2382421 or solution HANA
 net.ipv4.tcp_timestamps = 1
 
 # net.ipv4.tcp_slow_start_after_idle
@@ -81,7 +58,7 @@ net.ipv4.tcp_window_scaling = 1
 net.ipv4.tcp_syn_retries = 8
 
 [reminder]
-# SAP HANA Parameters - all '.ini' file changes - not supported by saptune
+# SAP HANA Parameters - all '.ini' file changes - not handled by saptune
 #
 # As HANA uses a considerable number of connections for the internal
 # communication, it makes sense to have as many client ports available as
@@ -135,4 +112,27 @@ net.ipv4.tcp_syn_retries = 8
 # To ensure complete functionality it must be ensured that the wmem_max and
 # rmem_max values are at least the same as the respective maximum value of the
 # parameters net.ipv4.tcp_wmem and net.ipv4.tcp_rmem.
+#
+# net.ipv4.tcp_tw_reuse
+# This setting allows HANA to reuse a client port immediately after the
+# connection has been closed, even though the connection is still in TIME_WAIT
+# state. A precondition for it to take effect is that TCP timestamps are
+# enabled, i.e. net.ipv4.tcp_timestamps = 1, which is the default on most
+# modern systems. Please note that this setting must not be applied if the HANA
+# node needs to communicate with hosts behind a NAT firewall. Moreover, it must
+# not be applied if not all hosts that use a TCP connection to communicate with
+# the HANA node have TCP timestamps enabled. Otherwise you might encounter TCP
+# connection issues after applying this configuration parameter.
+#net.ipv4.tcp_tw_reuse = 1
+#
+# net.ipv4.tcp_tw_recycle
+# This setting reduces the time a connection spends in the TIME_WAIT state.
+# One precondition for it to take effect is that TCP timestamps are enabled,
+# i.e. net.ipv4.tcp_timestamps = 1, which is the default on most modern systems.
+# Please note that this setting must not be applied if the HANA node has to
+# communicate with hosts behind a NAT firewall. Moreover, it must not be
+# applied if not all hosts that use a TCP connection to communicate with the
+# HANA node have TCP timestamps enabled. Otherwise you might encounter TCP
+# connection issues after applying this configuration parameter.
+#net.ipv4.tcp_tw_recycle = 1
 #

--- a/ospackage/usr/share/saptune/notes/2684254
+++ b/ospackage/usr/share/saptune/notes/2684254
@@ -40,8 +40,24 @@ energy_perf_bias=performance
 # cpupower frequency-set -g performance
 governor=performance
 
-# force latency
-# input is a decimal (not a hexadecimal) number
+# force latency (applies to Intel-based systems only)
+# configure C-States for lower latency
+#
+# input is a string, which is internally treated as a decimal (not a
+# hexadecimal) integer number representing a maximum response time in
+# microseconds.
+# It is used to establish a latency upper limit by limiting the use of C-States
+# (CPU idle or CPU latency states) to only those with an exit latency smaller
+# than the value set here. That means only those states that require less than
+# the requested number of microseconds to wake up are enabled, all the other
+# C-States are disabled.
+#
+# ATTENTION: not idling *at all* increases power consumption significantly and
+# reduces the life span of the machine because of wear and tear. So do not use
+# a too strict latency setting. Prefere a "light sleep", because the impact on
+# power consumption and life of the CPUs is less severe.
+# But don't forget: The deeper the idle state, the larger is the exit latency.
+#
 force_latency=70
 
 [sysctl]
@@ -90,7 +106,7 @@ numa_balancing=disable
 transparent_hugepage=never
 
 [reminder]
-# IBM EnergyScale for POWER8 Processor-Based Systems (applies to IBM Power systems only) - not supported by saptune!
+# IBM EnergyScale for POWER8 Processor-Based Systems (applies to IBM Power systems only) - not handled by saptune!
 
 # Intel Cluster-On-Die (COD) / sub-NUMA clustering technology
 # HANA is not supported neither on Intel Cluster-On-Die (COD) technology nor on sub-NUMA clustering technology.

--- a/ospackage/usr/share/saptune/notes/2684254
+++ b/ospackage/usr/share/saptune/notes/2684254
@@ -6,7 +6,7 @@
 # SAP-NOTE=2684254 CATEGORY=HANA VERSION=5 DATE=03.01.2019 NAME="SAP HANA DB: Recommended OS settings for SLES 15 / SLES for SAP Applications 15"
 
 [vm]
-# Disable transparent hugepages (THP, applies to Intel-based systems only)
+# Disable transparent hugepages (THP)
 # changes /sys/kernel/mm/transparent_hugepage/enabled
 # 'never' to disable, 'always' to enable
 # SAP Note 2131662, 2031375

--- a/ospackage/usr/share/saptune/solsdeprecated
+++ b/ospackage/usr/share/saptune/solsdeprecated
@@ -1,0 +1,5 @@
+[ArchX86]
+MAXDB = deprecated
+
+[ArchPPC64LE]
+MAXDB = deprecated

--- a/sap/note/ini.go
+++ b/sap/note/ini.go
@@ -377,7 +377,7 @@ func (vend INISettings) Apply() error {
 		case INISectionMEM:
 			errs = append(errs, SetMemVal(param.Key, vend.SysctlParams[param.Key]))
 		case INISectionCPU:
-			errs = append(errs, SetCPUVal(param.Key, vend.SysctlParams[param.Key], vend.ID, flstates, revertValues))
+			errs = append(errs, SetCPUVal(param.Key, vend.SysctlParams[param.Key], vend.ID, flstates, vend.OverrideParams[param.Key], revertValues))
 		case INISectionPagecache:
 			if revertValues {
 				switch param.Key {

--- a/sap/note/ini.go
+++ b/sap/note/ini.go
@@ -377,7 +377,7 @@ func (vend INISettings) Apply() error {
 		case INISectionMEM:
 			errs = append(errs, SetMemVal(param.Key, vend.SysctlParams[param.Key]))
 		case INISectionCPU:
-			errs = append(errs, SetCPUVal(param.Key, vend.SysctlParams[param.Key], vend.ID, flstates, vend.OverrideParams[param.Key], revertValues))
+			errs = append(errs, SetCPUVal(param.Key, vend.SysctlParams[param.Key], vend.ID, flstates, vend.OverrideParams[param.Key], vend.Inform[param.Key], revertValues))
 		case INISectionPagecache:
 			if revertValues {
 				switch param.Key {

--- a/sap/note/ini_sections.go
+++ b/sap/note/ini_sections.go
@@ -313,7 +313,11 @@ func GetCPUVal(key string) (string, string, string) {
 			val = val + fmt.Sprintf("%s:%s ", k, v)
 		}
 	}
-	return strings.TrimSpace(val), flsVal, info
+	val = strings.TrimSpace(val)
+	if val == "all:none" {
+		info = "notSupported"
+	}
+	return val, flsVal, info
 }
 
 // OptCPUVal optimises the cpu performance structure with the settings
@@ -358,12 +362,12 @@ func OptCPUVal(key, actval, cfgval string) string {
 }
 
 // SetCPUVal applies the settings to the system
-func SetCPUVal(key, value, noteID, savedStates, oval string, revert bool) error {
+func SetCPUVal(key, value, noteID, savedStates, oval, info string, revert bool) error {
 	var err error
 	switch key {
 	case "force_latency":
 		if oval != "untouched" {
-			err = system.SetForceLatency(value, savedStates, revert)
+			err = system.SetForceLatency(value, savedStates, info, revert)
 			if !revert {
 				// the cpu state values of the note need to be stored
 				// after they are set. Special for 'force_latency'
@@ -377,7 +381,7 @@ func SetCPUVal(key, value, noteID, savedStates, oval string, revert bool) error 
 	case "energy_perf_bias":
 		err = system.SetPerfBias(value)
 	case "governor":
-		err = system.SetGovernor(value)
+		err = system.SetGovernor(value, info)
 	}
 
 	return err

--- a/sap/note/ini_sections.go
+++ b/sap/note/ini_sections.go
@@ -358,19 +358,21 @@ func OptCPUVal(key, actval, cfgval string) string {
 }
 
 // SetCPUVal applies the settings to the system
-func SetCPUVal(key, value, noteID, savedStates string, revert bool) error {
+func SetCPUVal(key, value, noteID, savedStates, oval string, revert bool) error {
 	var err error
 	switch key {
 	case "force_latency":
-		err = system.SetForceLatency(value, savedStates, revert)
-		if !revert {
-			// the cpu state values of the note need to be stored
-			// after they are set. Special for 'force_latency'
-			// as we set and handle 2 different sort of values
-			// the 'force_latency' value and the related
-			// cpu state values
-			_, flstates, _ = system.GetFLInfo()
-			AddParameterNoteValues("fl_states", flstates, noteID)
+		if oval != "untouched" {
+			err = system.SetForceLatency(value, savedStates, revert)
+			if !revert {
+				// the cpu state values of the note need to be stored
+				// after they are set. Special for 'force_latency'
+				// as we set and handle 2 different sort of values
+				// the 'force_latency' value and the related
+				// cpu state values
+				_, flstates, _ = system.GetFLInfo()
+				AddParameterNoteValues("fl_states", flstates, noteID)
+			}
 		}
 	case "energy_perf_bias":
 		err = system.SetPerfBias(value)

--- a/sap/note/note.go
+++ b/sap/note/note.go
@@ -184,6 +184,8 @@ func CompareNoteFields(actualNote, expectedNote Note) (allMatch bool, comparison
 
 				if key.String() == "force_latency" && actualValue.(string) != "all:none" {
 					op = "<="
+				} else {
+					op = ""
 				}
 				actualValueJS, expectedValueJS, match := CompareJSValue(actualValue, expectedValue, op)
 				if strings.Split(key.String(), ":")[0] == "rpm" {

--- a/system/cpu.go
+++ b/system/cpu.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -125,7 +126,13 @@ func GetGovernor() map[string]string {
 	}
 	for _, entry := range dirCont {
 		if isCPU.MatchString(entry.Name()) {
-			gov, _ = GetSysString(path.Join(cpuDirSys, entry.Name(), "cpufreq", "scaling_governor"))
+			if _, err = os.Stat(path.Join(cpuDir, entry.Name(), "cpufreq", "scaling_governor")); os.IsNotExist(err) {
+				// os.Stat needs cpuDir as path - including /sys
+				gov = ""
+			} else {
+				// GetSysString needs cpuDirSys as path - without /sys
+				gov, _ = GetSysString(path.Join(cpuDirSys, entry.Name(), "cpufreq", "scaling_governor"))
+			}
 			if gov == "" {
 				gov = "none"
 			}
@@ -148,12 +155,16 @@ func GetGovernor() map[string]string {
 
 // SetGovernor set performance configuration regarding to cpu frequency
 // to the system using 'cpupower' command
-func SetGovernor(value string) error {
+func SetGovernor(value, info string) error {
 	//cmd := exec.Command("cpupower", "-c", "all", "frequency-set", "-g", value)
 	cpu := ""
 	tst := ""
 	cmdName := cpupowerCmd
 
+	if value == "all:none" || info == "notSupported" {
+		WarningLog("governor settings not supported by the system")
+		return nil
+	}
 	if !CmdIsAvailable(cmdName) {
 		WarningLog("command '%s' not found", cmdName)
 		return nil
@@ -205,7 +216,9 @@ func GetFLInfo() (string, string, bool) {
 	cpuStateMap := make(map[string]string)
 
 	// read /sys/devices/system/cpu
-	if dirCont, err := ioutil.ReadDir(cpuDir); err == nil {
+	dirCont, err := ioutil.ReadDir(cpuDir)
+	if runtime.GOARCH != "ppc64le" && err == nil {
+		// latency settings are only relevant for Intel-based systems
 		for _, entry := range dirCont {
 			// cpu0 ... cpuXY
 			if isCPU.MatchString(entry.Name()) {
@@ -241,16 +254,8 @@ func GetFLInfo() (string, string, bool) {
 		}
 	}
 	// check, if all cpus have the same state settings
-	oldcpuState := ""
-	for _, cpuState := range cpuStateMap {
-		if oldcpuState == "" {
-			oldcpuState = cpuState
-		}
-		if oldcpuState != cpuState {
-			cpuStateDiffer = true
-			break
-		}
-	}
+	cpuStateDiffer = CheckCPUState(cpuStateMap)
+
 	if !stateDisabled {
 		// start value for force latency, if no states are disabled
 		lat = maxlat
@@ -265,11 +270,12 @@ func GetFLInfo() (string, string, bool) {
 }
 
 // SetForceLatency set CPU latency configuration to the system
-func SetForceLatency(value, savedStates string, revert bool) error {
+func SetForceLatency(value, savedStates, info string, revert bool) error {
 	oldState := ""
 
-	if value == "all:none" {
-		return fmt.Errorf("latency settings not supported by the system")
+	if value == "all:none" || info == "notSupported" {
+		WarningLog("latency settings not supported by the system")
+		return nil
 	}
 
 	flval, _ := strconv.Atoi(value) // decimal value for force latency
@@ -313,7 +319,9 @@ func SetForceLatency(value, savedStates string, revert bool) error {
 						if lat >= flval {
 							// set new latency states
 							err = SetSysString(path.Join(cpuDirSys, entry.Name(), "cpuidle", centry.Name(), "disable"), "1")
-						} else if oldState == "1" {
+						}
+						if lat < flval && oldState == "1" {
+							// reset previous set latency state
 							err = SetSysString(path.Join(cpuDirSys, entry.Name(), "cpuidle", centry.Name(), "disable"), "0")
 						}
 					}
@@ -323,6 +331,22 @@ func SetForceLatency(value, savedStates string, revert bool) error {
 	}
 
 	return err
+}
+
+// CheckCPUState checks, if all cpus have the same state settings
+func CheckCPUState(csMap map[string]string) bool {
+	ret := false
+	oldcpuState := ""
+	for _, cpuState := range csMap {
+		if oldcpuState == "" {
+			oldcpuState = cpuState
+		}
+		if oldcpuState != cpuState {
+			ret = true
+			break
+		}
+	}
+	return ret
 }
 
 // GetdmaLatency retrieve DMA latency configuration from the system

--- a/system/login.go
+++ b/system/login.go
@@ -15,17 +15,19 @@ func GetCurrentLogins() []string {
 		WarningLog("command '%s' not found", cmdName)
 		return uID
 	}
-	cmdOut, err := exec.Command(cmdName, cmdArgs...).CombinedOutput()
-	if err != nil {
-		WarningLog("failed to invoke external command '%s %v': %v, output: %s", cmdName, cmdArgs, err, string(cmdOut))
-		return uID
-	}
-	for _, logins := range strings.Split(string(cmdOut), "\n") {
-		if logins == "" {
-			continue
+	if IsSystemRunning() {
+		cmdOut, err := exec.Command(cmdName, cmdArgs...).CombinedOutput()
+		if err != nil {
+			WarningLog("failed to invoke external command '%s %v': %v, output: %s", cmdName, cmdArgs, err, string(cmdOut))
+			return uID
 		}
-		user := strings.Split(strings.TrimSpace(logins), " ")
-		uID = append(uID, user[0])
+		for _, logins := range strings.Split(string(cmdOut), "\n") {
+			if logins == "" {
+				continue
+			}
+			user := strings.Split(strings.TrimSpace(logins), " ")
+			uID = append(uID, user[0])
+		}
 	}
 	return uID
 }

--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -185,6 +185,7 @@ func ParseINI(input string) *INIFile {
 				currentEntriesMap[entry.Key] = entry
 			}
 		} else if currentSection == "block" {
+			system.WarningLog("[block] section detected: Traversing all block devices can take a considerable amount of time.")
 			_, sysDevs := system.ListDir("/sys/block", "the available block devices of the system")
 			for _, bdev := range sysDevs {
 				if strings.Contains(bdev, "dm-") {


### PR DESCRIPTION
- use different text for the 'unsupported' footnote regarding to the architecture to not confuse the 'Power' customers. Let's see, if this is sufficient or if we need more finegrained differentiation
- bash-completion: remove unsupported 'customize' from 'solution'
- reset the operator value (op) for each parameter back to the 'default' operator to get a reliable and working Note field comparision
- handle 'untouched' force latency state settings correctly
  do not set the cpu idle states and do not add saved_state information to the parameter saved state file, if the force latency parameter is defined as 'untouched' in an override file
- adjust note definition files
- adjust man pages to the add-ons and changes of the last weeks
  alphabetically reordering of the sections in saptune-note
  add some more information regarding migration of v1 to v2
