### PR TITLE
Fixes for problems found by QA during release of 2.0.1

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -250,6 +250,10 @@ func (app *App) TuneSolution(solName string) (removedExplicitNotes []string, err
 // TuneAll tune for all currently enabled solutions and notes.
 func (app *App) TuneAll() error {
 	for _, noteID := range app.NoteApplyOrder {
+		if _, err := app.GetNoteByID(noteID); err != nil {
+			_ = system.ErrorLog(err.Error())
+			continue
+		}
 		if err := app.TuneNote(noteID); err != nil {
 			return err
 		}

--- a/ospackage/usr/share/saptune/scripts/upd_helper
+++ b/ospackage/usr/share/saptune/scripts/upd_helper
@@ -113,11 +113,17 @@ change_note_names() {
                 echo "### changing old, SLE12 specific Note name '$oldNote' to the new, SLE15 Note name '$newNote'"
                 sed -i "s/$srch_pat2/$new_pat2/g" $SAPTUNE_SYSCONFIG
             fi
-            srch_pat3="\"${oldNote}\""
-            new_pat3="\"${newNote}\""
+            srch_pat3="\"${oldNote} "
+            new_pat3="\"${newNote} "
             if grep "$srch_pat3" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
                 echo "### changing old, SLE12 specific Note name '$oldNote' to the new, SLE15 Note name '$newNote'"
                 sed -i "s/$srch_pat3/$new_pat3/g" $SAPTUNE_SYSCONFIG
+            fi
+            srch_pat4="\"${oldNote}\""
+            new_pat4="\"${newNote}\""
+            if grep "$srch_pat4" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
+                echo "### changing old, SLE12 specific Note name '$oldNote' to the new, SLE15 Note name '$newNote'"
+                sed -i "s/$srch_pat4/$new_pat4/g" $SAPTUNE_SYSCONFIG
             fi
 
             # 2. check existence of override file and change name
@@ -171,11 +177,17 @@ delete_notes() {
                 echo "### removing old, SLE12 specific Note name '$delnote' from $SAPTUNE_SYSCONFIG"
                 sed -i "s/$srch_pat2/$del_pat2/g" $SAPTUNE_SYSCONFIG
             fi
-            srch_pat3="\"${delnote}\""
-            del_pat3="\"\""
+            srch_pat3="\"${delnote} "
+            del_pat3="\""
             if grep "$srch_pat3" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
                 echo "### removing old, SLE12 specific Note name '$delnote' from $SAPTUNE_SYSCONFIG"
                 sed -i "s/$srch_pat3/$del_pat3/g" $SAPTUNE_SYSCONFIG
+            fi
+            srch_pat4="\"${delnote}\""
+            del_pat4="\"\""
+            if grep "$srch_pat4" $SAPTUNE_SYSCONFIG >/dev/null 2>&1; then
+                echo "### removing old, SLE12 specific Note name '$delnote' from $SAPTUNE_SYSCONFIG"
+                sed -i "s/$srch_pat4/$del_pat4/g" $SAPTUNE_SYSCONFIG
             fi
 
             # 2. check existence of override file and print a WARNING

--- a/system/limits.go
+++ b/system/limits.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -183,7 +184,13 @@ func (limits *SecLimits) ToDropIn(lim []string, noteID, fileName string) string 
 // ApplyDropIn overwrite file 'dropInFile' with the content of this structure.
 func (limits *SecLimits) ApplyDropIn(lim []string, noteID string) error {
 	// /etc/security/limits.d/saptune-<domain>-<item>-<type>.conf
-	dropInFile := fmt.Sprintf("/etc/security/limits.d/saptune-%s-%s-%s.conf", lim[0], lim[2], lim[1])
+	limitsDropDir := "/etc/security/limits.d"
+	dropInFile := fmt.Sprintf("%s/saptune-%s-%s-%s.conf", limitsDropDir, lim[0], lim[2], lim[1])
+	if _, err := os.Stat(limitsDropDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(limitsDropDir, 0755); err != nil {
+			return ErrorLog("failed to create needed directories for the limits drop in file: %v", err)
+		}
+	}
 	return ioutil.WriteFile(dropInFile, []byte(limits.ToDropIn(lim, noteID, dropInFile)), 0644)
 }
 

--- a/system/system.go
+++ b/system/system.go
@@ -73,7 +73,7 @@ func CheckForPattern(file, pattern string) bool {
 func GetServiceName(service string) string {
 	serviceName := ""
 	cmdName := "/usr/bin/systemctl"
-	cmdArgs := []string{"list-unit-files"}
+	cmdArgs := []string{"--no-pager", "list-unit-files"}
 	cmdOut, err := exec.Command(cmdName, cmdArgs...).CombinedOutput()
 	if err != nil {
 		WarningLog("There was an error running external command %s: %v, output: %s", cmdArgs, err, cmdOut)


### PR DESCRIPTION
the update problem bsc#1142526 occurs only with a special order of notes. This case was tested during the development of the update helper script, but this part of the coding was unfortunately missed in the submission. Sorry for that.
The missing directory /etc/security/limits.d was found during 12SP2 tests as there is an older pam package than in 12SP3, which does not create the package itself. To be on the safe side I added a check for the existence of the directory and create the directory, if it is not available.