### PR TITLE
support multi-queue I/O scheduler for block devices (bsc#1152598)

### DIFF
--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -68,11 +68,17 @@ Attention: The note description from the field NAME must be placed in double quo
 The section "[block]" can contain the following options:
 .TP
 .BI IO_SCHEDULER= STRING
-The default I/O scheduler for SLES is CFQ. It offers satisfactory performance for wide range of I/O task, however choosing an alternative scheduler may potentially yield better latency characteristics and throughput. 
-"noop" is an alternative scheduler, in comparison to CFQ it may offer more consistent performance, lower computation overhead, and potentially higher throughput.
+The default I/O scheduler for single-queued block layer devices offers satisfactory performance for wide range of I/O task, however choosing an alternative scheduler may potentially yield better latency characteristics and throughput.
+"noop" is an alternative scheduler, in comparison to other schedulers it may offer more consistent performance, lower computation overhead, and potentially higher throughput.
 For most SAP environments (RAID, storage arrays, virtualizaton) 'noop' is the better choice.
 .br
-When set, \fBall\fP block devices on the system will be switched to the chosen scheduler.
+With the new introduced multi-queue scheduler for block layer devices the recommended I/O scheduler is 'none' as an equivalent to 'noop' for single-queued block layer devices.
+
+So IO_SCHEDULER can now contain a comma separated list of possible schedulers, which are checked from left to right. The first one which is available in \fI/sys/block/<device>/queue/scheduler\fP will be used as new scheduler setting for the respective block device.
+.br
+The selection per device is logged.
+.br
+When set, \fBall\fP block devices on the system will be switched to one of the chosen schedulers.
 .br
 Valid values can be found in \fI/sys/block/<device>/queue/scheduler\fP.
 .TP

--- a/ospackage/usr/share/saptune/notes/1680803
+++ b/ospackage/usr/share/saptune/notes/1680803
@@ -10,18 +10,29 @@
 
 [block]
 ## Type:    string
-## Default: noop
+## Default: noop, none
 #
-# The default I/O scheduler for SLES is CFQ. It offers satisfactory performance
-# for wide range of I/O task, however choosing an alternative scheduler may 
-# potentially yield better latency characteristics and throughput. 
-# "noop" is an alternative scheduler, in comparison to CFQ it may offer more 
-# consistent performance, lower computation overhead, and potentially higher 
-# throughput.
+# The default I/O scheduler for single-queued block layer devices offers
+# satisfactory performance for wide range of I/O task, however choosing an
+# alternative scheduler may potentially yield better latency characteristics
+# and throughput.
+# "noop" is an alternative scheduler, in comparison to other schedulers it
+# may offer more consistent performance, lower computation overhead, and
+# potentially higher throughput.
+# For most SAP environments (RAID, storage arrays, virtualizaton) 'noop' is
+# the better choice.
+# With the new introduced multi-queue scheduler for block layer devices the
+# recommended I/O scheduler is 'none' as an equivalent to 'noop' for
+# single-queued block layer devices.
 #
-# When set, all block devices on the system will be switched to the chosen 
-# scheduler.
-IO_SCHEDULER=noop
+# So IO_SCHEDULER can now contain a comma separated list of possible
+# schedulers, which are checked from left to right. The first one which is
+# available in /sys/block/<device>/queue/scheduler will be used as new
+# scheduler setting for the respective block device.
+#
+# When set, all block devices on the system will be switched to one of the
+# chosen schedulers.
+IO_SCHEDULER=noop, none
 
 ## Type:    integer
 ## Default: 1024

--- a/ospackage/usr/share/saptune/notes/1984787
+++ b/ospackage/usr/share/saptune/notes/1984787
@@ -22,18 +22,27 @@ uuidd.socket=start
 sysstat.service=start
 
 [block]
-# The default I/O scheduler for SLES is CFQ. It offers satisfactory performance
-# for wide range of I/O task, however choosing an alternative scheduler may 
-# potentially yield better latency characteristics and throughput. 
-# "noop" is an alternative scheduler, in comparison to CFQ it may offer more 
-# consistent performance, lower computation overhead, and potentially higher 
-# throughput.
-# For most SAP environments (RAID, storage arrays, virtualizaton) 'noop' is the
-# better choice.
-#   
-# When set, all block devices on the system will be switched to the chosen 
-# scheduler.
-IO_SCHEDULER=noop
+# The default I/O scheduler for single-queued block layer devices offers
+# satisfactory performance for wide range of I/O task, however choosing an
+# alternative scheduler may potentially yield better latency characteristics
+# and throughput.
+# "noop" is an alternative scheduler, in comparison to other schedulers it
+# may offer more consistent performance, lower computation overhead, and
+# potentially higher throughput.
+# For most SAP environments (RAID, storage arrays, virtualizaton) 'noop' is
+# the better choice.
+# With the new introduced multi-queue scheduler for block layer devices the
+# recommended I/O scheduler is 'none' as an equivalent to 'noop' for
+# single-queued block layer devices.
+#
+# So IO_SCHEDULER can now contain a comma separated list of possible
+# schedulers, which are checked from left to right. The first one which is
+# available in /sys/block/<device>/queue/scheduler will be used as new
+# scheduler setting for the respective block device.
+#
+# When set, all block devices on the system will be switched to one of the
+# chosen schedulers.
+IO_SCHEDULER=noop, none
 
 [rpm]
 # dependencies handled by saptune package installation

--- a/ospackage/usr/share/saptune/notes/2161991
+++ b/ospackage/usr/share/saptune/notes/2161991
@@ -8,16 +8,27 @@
 
 [block]
 ## Type:    string
-## Default: noop
+## Default: noop or none
 #
-# The default I/O scheduler for SLES is CFQ. It offers satisfactory performance
-# for wide range of I/O task, however choosing an alternative scheduler may 
-# potentially yield better latency characteristics and throughput. 
-# "noop" is an alternative scheduler, in comparison to CFQ it may offer more 
-# consistent performance, lower computation overhead, and potentially higher 
-# throughput.
+# The default I/O scheduler for single-queued block layer devices offers
+# satisfactory performance for wide range of I/O task, however choosing an
+# alternative scheduler may potentially yield better latency characteristics
+# and throughput.
+# "noop" is an alternative scheduler, in comparison to other schedulers it
+# may offer more consistent performance, lower computation overhead, and
+# potentially higher throughput.
+# For most SAP environments (RAID, storage arrays, virtualizaton) 'noop' is
+# the better choice.
+# With the new introduced multi-queue scheduler for block layer devices the
+# recommended I/O scheduler is 'none' as an equivalent to 'noop' for
+# single-queued block layer devices.
 #
-# When set, all block devices on the system will be switched to the chosen 
-# scheduler.
-IO_SCHEDULER=noop
+# So IO_SCHEDULER can now contain a comma separated list of possible
+# schedulers, which are checked from left to right. The first one which is
+# available in /sys/block/<device>/queue/scheduler will be used as new
+# scheduler setting for the respective block device.
+#
+# When set, all block devices on the system will be switched to one of the
+# chosen schedulers.
+IO_SCHEDULER=noop, none
 

--- a/ospackage/usr/share/saptune/notes/2578899
+++ b/ospackage/usr/share/saptune/notes/2578899
@@ -22,18 +22,27 @@ uuidd.socket=start
 sysstat.service=start
 
 [block]
-# The default I/O scheduler for SLES is CFQ. It offers satisfactory performance
-# for wide range of I/O task, however choosing an alternative scheduler may 
-# potentially yield better latency characteristics and throughput. 
-# "noop" is an alternative scheduler, in comparison to CFQ it may offer more 
-# consistent performance, lower computation overhead, and potentially higher 
-# throughput.
-# For most SAP environments (RAID, storage arrays, virtualizaton) 'noop' is the
-# better choice.
-#   
-# When set, all block devices on the system will be switched to the chosen 
-# scheduler.
-IO_SCHEDULER=noop
+# The default I/O scheduler for single-queued block layer devices offers
+# satisfactory performance for wide range of I/O task, however choosing an
+# alternative scheduler may potentially yield better latency characteristics
+# and throughput.
+# "noop" is an alternative scheduler, in comparison to other schedulers it
+# may offer more consistent performance, lower computation overhead, and
+# potentially higher throughput.
+# For most SAP environments (RAID, storage arrays, virtualizaton) 'noop' is
+# the better choice.
+# With the new introduced multi-queue scheduler for block layer devices the
+# recommended I/O scheduler is 'none' as an equivalent to 'noop' for
+# single-queued block layer devices.
+#
+# So IO_SCHEDULER can now contain a comma separated list of possible
+# schedulers, which are checked from left to right. The first one which is
+# available in /sys/block/<device>/queue/scheduler will be used as new
+# scheduler setting for the respective block device.
+#
+# When set, all block devices on the system will be switched to one of the
+# chosen schedulers.
+IO_SCHEDULER=noop, none
 
 [rpm]
 # dependencies handled by saptune package installation

--- a/sap/note/ini_sections.go
+++ b/sap/note/ini_sections.go
@@ -138,10 +138,8 @@ func OptBlkVal(key, cfgval string, cur *param.BlockDeviceQueue, bOK map[string][
 		for _, sched := range strings.Split(cfgval, ",") {
 			sval = strings.ToLower(strings.TrimSpace(sched))
 			if !param.IsValidScheduler(bdev[1], sval) {
-				//system.WarningLog("'%s' is not a valid scheduler for device '%s', skipping.", sval, bdev[1])
 				continue
 			} else {
-				//system.InfoLog("'%s' will be used as new scheduler for device '%s'.", sval, bdev[1])
 				sfound = true
 				oval = bdev[1] + " " + sval
 				bOK[sval] = append(bOK[sval], bdev[1])

--- a/sap/note/ini_sections.go
+++ b/sap/note/ini_sections.go
@@ -94,16 +94,17 @@ var isNrreq = regexp.MustCompile(`^NRREQ_\w+$`)
 
 // GetBlkVal initialise the block device structure with the current
 // system settings
-func GetBlkVal(key string, cur *param.BlockDeviceQueue) (string, error) {
+func GetBlkVal(key string, cur *param.BlockDeviceQueue) (string, string, error) {
 	newQueue := make(map[string]string)
 	newReq := make(map[string]int)
 	retVal := ""
+	info := ""
 
 	switch {
 	case isSched.MatchString(key):
 		newIOQ, err := cur.BlockDeviceSchedulers.Inspect()
 		if err != nil {
-			return "", err
+			return "", info, err
 		}
 		newQueue = newIOQ.(param.BlockDeviceSchedulers).SchedulerChoice
 		retVal = newQueue[strings.TrimPrefix(key, "IO_SCHEDULER_")]
@@ -111,24 +112,49 @@ func GetBlkVal(key string, cur *param.BlockDeviceQueue) (string, error) {
 	case isNrreq.MatchString(key):
 		newNrR, err := cur.BlockDeviceNrRequests.Inspect()
 		if err != nil {
-			return "", err
+			return "", info, err
 		}
 		newReq = newNrR.(param.BlockDeviceNrRequests).NrRequests
 		retVal = strconv.Itoa(newReq[strings.TrimPrefix(key, "NRREQ_")])
 		cur.BlockDeviceNrRequests = newNrR.(param.BlockDeviceNrRequests)
 	}
-	return retVal, nil
+	return retVal, info, nil
 }
 
 // OptBlkVal optimises the block device structure with the settings
 // from the configuration file
-func OptBlkVal(key, cfgval string, cur *param.BlockDeviceQueue) string {
+func OptBlkVal(key, cfgval string, cur *param.BlockDeviceQueue, bOK map[string][]string) (string, string) {
+	info := ""
+	if cfgval == "" {
+		return cfgval, info
+	}
 	sval := cfgval
 	switch {
 	case isSched.MatchString(key):
-		sval = strings.ToLower(cfgval)
-		opt, _ := cur.BlockDeviceSchedulers.Optimise(sval)
-		cur.BlockDeviceSchedulers = opt.(param.BlockDeviceSchedulers)
+		oval := ""
+		sfound := false
+		dname := regexp.MustCompile(`^IO_SCHEDULER_(\w+)$`)
+		bdev := dname.FindStringSubmatch(key)
+		for _, sched := range strings.Split(cfgval, ",") {
+			sval = strings.ToLower(strings.TrimSpace(sched))
+			if !param.IsValidScheduler(bdev[1], sval) {
+				//system.WarningLog("'%s' is not a valid scheduler for device '%s', skipping.", sval, bdev[1])
+				continue
+			} else {
+				//system.InfoLog("'%s' will be used as new scheduler for device '%s'.", sval, bdev[1])
+				sfound = true
+				oval = bdev[1] + " " + sval
+				bOK[sval] = append(bOK[sval], bdev[1])
+				break
+			}
+		}
+		if !sfound {
+			sval = cfgval
+			info = "NA"
+		} else {
+			opt, _ := cur.BlockDeviceSchedulers.Optimise(oval)
+			cur.BlockDeviceSchedulers = opt.(param.BlockDeviceSchedulers)
+		}
 	case isNrreq.MatchString(key):
 		if sval == "0" {
 			sval = "1024"
@@ -137,7 +163,7 @@ func OptBlkVal(key, cfgval string, cur *param.BlockDeviceQueue) string {
 		opt, _ := cur.BlockDeviceNrRequests.Optimise(ival)
 		cur.BlockDeviceNrRequests = opt.(param.BlockDeviceNrRequests)
 	}
-	return sval
+	return sval, info
 }
 
 // SetBlkVal applies the settings to the system

--- a/sap/note/ini_sections_test.go
+++ b/sap/note/ini_sections_test.go
@@ -79,36 +79,111 @@ func TestOptSysctlVal(t *testing.T) {
 	}
 }
 
-//GetBlkVal
-func TestOptBlkVal(t *testing.T) {
+func TestGetBlkVal(t *testing.T) {
 	tblck := param.BlockDeviceQueue{BlockDeviceSchedulers: param.BlockDeviceSchedulers{SchedulerChoice: make(map[string]string)}, BlockDeviceNrRequests: param.BlockDeviceNrRequests{NrRequests: make(map[string]int)}}
-	val := OptBlkVal("IO_SCHEDULER_sda", "noop", &tblck)
+	_, _, err := GetBlkVal("IO_SCHEDULER_sda", &tblck)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestOptBlkVal(t *testing.T) {
+	blckOK := make(map[string][]string)
+	tblck := param.BlockDeviceQueue{BlockDeviceSchedulers: param.BlockDeviceSchedulers{SchedulerChoice: make(map[string]string)}, BlockDeviceNrRequests: param.BlockDeviceNrRequests{NrRequests: make(map[string]int)}}
+	val, info := OptBlkVal("IO_SCHEDULER_sda", "noop", &tblck, blckOK)
 	if val != "noop" {
-		t.Fatal(val)
+		t.Fatal(val, info)
 	}
-	val = OptBlkVal("IO_SCHEDULER_sdb", "NoOP", &tblck)
-	if val != "noop" {
-		t.Fatal(val)
+	if info == "NA" {
+		t.Logf("scheduler '%s' is not supported\n", val)
+		val, info := OptBlkVal("IO_SCHEDULER_sda", "none", &tblck, blckOK)
+		if val != "none" {
+			t.Fatal(val, info)
+		}
+		if info == "NA" {
+			t.Logf("scheduler '%s' is not supported\n", val)
+		}
 	}
-	val = OptBlkVal("IO_SCHEDULER_sdc", "cfq", &tblck)
-	if val != "cfq" {
-		t.Fatal(val)
+
+	val, info = OptBlkVal("IO_SCHEDULER_sda", "NoOP", &tblck, blckOK)
+	if val != "NoOP" && val != "noop" {
+		t.Fatal(val, info)
 	}
-	val = OptBlkVal("NRREQ_sda", "512", &tblck)
+	if info == "NA" {
+		t.Logf("scheduler '%s' is not supported\n", val)
+		val, info = OptBlkVal("IO_SCHEDULER_sda", "NoNE", &tblck, blckOK)
+		if val != "NoNE" && val != "none" {
+			t.Fatal(val, info)
+		}
+		if info == "NA" {
+			t.Logf("scheduler '%s' is not supported\n", val)
+		}
+	}
+	val, info = OptBlkVal("IO_SCHEDULER_sda", "deadline", &tblck, blckOK)
+	if val != "deadline" {
+		t.Fatal(val, info)
+	}
+	if info == "NA" {
+		t.Logf("scheduler '%s' is not supported\n", val)
+		val, info = OptBlkVal("IO_SCHEDULER_sda", "mq-deadline", &tblck, blckOK)
+		if val != "mq-deadline" {
+			t.Fatal(val, info)
+		}
+		if info == "NA" {
+			t.Logf("scheduler '%s' is not supported\n", val)
+		}
+	}
+	val, info = OptBlkVal("IO_SCHEDULER_sda", "noop, none", &tblck, blckOK)
+	if val != "noop" && val != "none" && info != "NA" {
+		t.Fatal(val, info)
+	}
+	val, info = OptBlkVal("IO_SCHEDULER_sda", "NoOp,NoNe", &tblck, blckOK)
+	if val != "noop" && val != "none" && info != "NA" {
+		t.Fatal(val, info)
+	}
+	val, info = OptBlkVal("IO_SCHEDULER_sda", " noop , none ", &tblck, blckOK)
+	if val != "noop" && val != "none" && info != "NA" {
+		t.Fatal(val, info)
+	}
+	val, info = OptBlkVal("IO_SCHEDULER_sda", "hugo", &tblck, blckOK)
+	if val != "hugo" && info != "NA" {
+		t.Fatal(val, info)
+	}
+	if info == "NA" {
+		t.Logf("scheduler '%s' is not supported\n", val)
+	}
+
+	val, info = OptBlkVal("NRREQ_sda", "512", &tblck, blckOK)
 	if val != "512" {
 		t.Fatal(val)
 	}
-	val = OptBlkVal("NRREQ_sdb", "0", &tblck)
+	val, info = OptBlkVal("NRREQ_sdb", "0", &tblck, blckOK)
 	if val != "1024" {
 		t.Fatal(val)
 	}
-	val = OptBlkVal("NRREQ_sdc", "128", &tblck)
+	val, info = OptBlkVal("NRREQ_sdc", "128", &tblck, blckOK)
 	if val != "128" {
 		t.Fatal(val)
 	}
 }
 
-//SetBlkVal apply and revert
+func TestSetBlkVal(t *testing.T) {
+	blckOK := make(map[string][]string)
+	tblck := param.BlockDeviceQueue{BlockDeviceSchedulers: param.BlockDeviceSchedulers{SchedulerChoice: make(map[string]string)}, BlockDeviceNrRequests: param.BlockDeviceNrRequests{NrRequests: make(map[string]int)}}
+	val, info, err := GetBlkVal("IO_SCHEDULER_sda", &tblck)
+	oval := val
+	if err != nil {
+		t.Error(err)
+	}
+	val, info = OptBlkVal("IO_SCHEDULER_sda", "noop, none", &tblck, blckOK)
+	if val != "noop" && val != "none" {
+		t.Fatal(val, info)
+	}
+	// apply - value not used, but map changed above in optimise
+	err = SetBlkVal("IO_SCHEDULER_sda", "notUsed", &tblck, false)
+	// revert - value will be used to change map before applying
+	err = SetBlkVal("IO_SCHEDULER_sda", oval, &tblck, true)
+}
 
 //GetLimitsVal
 func TestOptLimitsVal(t *testing.T) {

--- a/sap/param/io.go
+++ b/sap/param/io.go
@@ -51,9 +51,16 @@ func (ioe BlockDeviceSchedulers) Inspect() (Parameter, error) {
 
 // Optimise gets the expected scheduler value from the configuration
 func (ioe BlockDeviceSchedulers) Optimise(newElevatorName interface{}) (Parameter, error) {
-	newIOE := BlockDeviceSchedulers{SchedulerChoice: make(map[string]string)}
-	for k := range ioe.SchedulerChoice {
-		newIOE.SchedulerChoice[k] = newElevatorName.(string)
+	newIOE := ioe
+	fields := strings.Fields(newElevatorName.(string))
+	if len(fields) > 1 {
+		bdev := fields[0]
+		newSched := fields[1]
+		for k := range ioe.SchedulerChoice {
+			if k == bdev {
+				newIOE.SchedulerChoice[k] = newSched
+			}
+		}
 	}
 	return newIOE, nil
 }

--- a/system/logging.go
+++ b/system/logging.go
@@ -15,6 +15,7 @@ var debugLogger *log.Logger   // Debug logger
 var errorLogger *log.Logger   // Error logger
 var warningLogger *log.Logger // Warning logger
 var debugSwitch string        // Switch Debug on or off
+var verboseSwitch string      // Switch verbose mode on or off
 
 // calledFrom returns the name and the line number of the calling source file
 func calledFrom() string {
@@ -39,7 +40,9 @@ func DebugLog(txt string, stuff ...interface{}) {
 func InfoLog(txt string, stuff ...interface{}) {
 	if infoLogger != nil {
 		infoLogger.Printf(calledFrom()+txt+"\n", stuff...)
-		fmt.Fprintf(os.Stdout, "INFO: "+txt+"\n", stuff...)
+		if verboseSwitch == "on" {
+			fmt.Fprintf(os.Stdout, "    INFO: "+txt+"\n", stuff...)
+		}
 	}
 }
 
@@ -47,7 +50,9 @@ func InfoLog(txt string, stuff ...interface{}) {
 func WarningLog(txt string, stuff ...interface{}) {
 	if warningLogger != nil {
 		warningLogger.Printf(calledFrom()+txt+"\n", stuff...)
-		fmt.Fprintf(os.Stderr, "    WARNING: "+txt+"\n", stuff...)
+		if verboseSwitch == "on" {
+			fmt.Fprintf(os.Stderr, "    WARNING: "+txt+"\n", stuff...)
+		}
 	}
 }
 
@@ -61,7 +66,7 @@ func ErrorLog(txt string, stuff ...interface{}) error {
 }
 
 // LogInit initialise the different log writer saptune will use
-func LogInit(logFile, debug string) {
+func LogInit(logFile, debug, verbose string) {
 	var saptuneLog io.Writer
 	//define log format
 	logTimeFormat := time.Now().Format("2006-01-02 15:04:05.000 ")
@@ -93,4 +98,5 @@ func LogInit(logFile, debug string) {
 	errorLogger = log.New(saptuneLog, logTimeFormat+"ERROR    saptune.", 0)
 
 	debugSwitch = debug
+	verboseSwitch = verbose
 }

--- a/system/logging_test.go
+++ b/system/logging_test.go
@@ -15,7 +15,8 @@ func TestCalledFrom(t *testing.T) {
 func TestLog(t *testing.T) {
 	logFile := "/tmp/saptune_tst.log"
 	debug := "1"
-	LogInit(logFile, debug)
+	verbose := "on"
+	LogInit(logFile, debug, verbose)
 	DebugLog("TestMessage%s_%s", "1", "Debug")
 	if !CheckForPattern(logFile, "TestMessage1_Debug") {
 		t.Fatal("Debug message found in log file")

--- a/testdata/extra/extraNote.conf
+++ b/testdata/extra/extraNote.conf
@@ -13,7 +13,7 @@ kernel.sem = 250 32000 32 1024
 kernel.shmmax = 18446744073709551615
 
 [block]
-IO_SCHEDULER = noop
+IO_SCHEDULER = noop, none
 NRREQ = 1020
 
 [cpu]

--- a/testdata/extra/wrongName
+++ b/testdata/extra/wrongName
@@ -13,7 +13,7 @@ kernel.sem = 250 32000 32 1024
 kernel.shmmax = 18446744073709551615
 
 [block]
-IO_SCHEDULER = noop
+IO_SCHEDULER = noop, none
 NRREQ = 1020
 
 [cpu]

--- a/testdata/ini_all_test.ini
+++ b/testdata/ini_all_test.ini
@@ -6,7 +6,7 @@
 # SAP-NOTE=9876543 VERSION=3 DATE=02.01.2019 NAME="ini_all_test: SAP Note file for ini_all_test"
 
 [block]
-IO_SCHEDULER=NoOp
+IO_SCHEDULER=NoOp,NoNE
 NRREQ=1022
 
 [cpu]

--- a/testdata/override_ini_all_test.ini
+++ b/testdata/override_ini_all_test.ini
@@ -6,7 +6,7 @@
 # SAP-NOTE=9876543 VERSION=3 DATE=02.01.2019 NAME="ini_all_test: SAP Note file for ini_all_test"
 
 [block]
-IO_SCHEDULER=noop
+IO_SCHEDULER=noop, none
 NRREQ=1024
 
 [cpu]


### PR DESCRIPTION
To support multi-queued schedulers in parallel with single-queued schedulers for block devices, the note definition files now can contain a comma separated list of scheduler names, which will be checked from left to right. The first matching scheduler is used for the block device. The chosen scheduler will be reported  in the log file and on the screen.
I changed the affected man page and the comments in the note definition files dealing with scheduler settings.
The 'verify' table will get an additional footnote, if none of the configured schedulers are supported for a block device
And I changed the detection of valid block devices (we only want disks) by checking the file /sys/block/<bdev>/device/type. It should contain '0' for 'disk'.
