### PR TITLE
additional fixes for multi-queue I/O scheduler support (bsc#1152598)

### DIFF
--- a/main.go
+++ b/main.go
@@ -759,9 +759,9 @@ func NoteActionCustomise(noteID string) {
 	}
 	i := tuneApp.PositionInNoteApplyOrder(noteID)
 	if i < 0 { // noteID not yet available
-		system.InfoLog("Do not forget to apply the just edited Note to get your changes take effect\n")
+		system.InfoLog("Do not forget to apply the just edited Note to get your changes to take effect\n")
 	} else { // noteID already applied
-		system.InfoLog("Your just edited Note is already applied. To get your changes take effect, please 'revert' the Note and apply again.\n")
+		system.InfoLog("Your just edited Note is already applied. To get your changes to take effect, please 'revert' the Note and apply again.\n")
 	}
 	if err := syscall.Exec(editor, []string{editor, editFileName}, os.Environ()); err != nil {
 		errorExit("Failed to start launch editor %s: %v", editor, err)

--- a/main.go
+++ b/main.go
@@ -748,7 +748,7 @@ func NoteActionCustomise(noteID string) {
 		}
 		editFileName = ovFileName
 	} else if err == nil {
-		system.InfoLog("Note override file already exists, using file '%s' as base for editing\n", ovFileName)
+		system.InfoLog("Note override file already exists, using file '%s' as base for editing", ovFileName)
 		editFileName = ovFileName
 	} else {
 		errorExit("Failed to read file '%s' - %v", ovFileName, err)
@@ -757,10 +757,16 @@ func NoteActionCustomise(noteID string) {
 	if editor == "" {
 		editor = "/usr/bin/vim" // launch vim by default
 	}
-	//if err := syscall.Exec(editor, []string{editor, fileName}, os.Environ()); err != nil {
+	i := tuneApp.PositionInNoteApplyOrder(noteID)
+	if i < 0 { // noteID not yet available
+		system.InfoLog("Do not forget to apply the just edited Note to get your changes take effect\n")
+	} else { // noteID already applied
+		system.InfoLog("Your just edited Note is already applied. To get your changes take effect, please 'revert' the Note and apply again.\n")
+	}
 	if err := syscall.Exec(editor, []string{editor, editFileName}, os.Environ()); err != nil {
 		errorExit("Failed to start launch editor %s: %v", editor, err)
 	}
+	// if syscall.Exec returns 'nil' the execution of the program ends immediately
 }
 
 // NoteActionCreate helps the customer to create an own Note definition

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -15,7 +15,7 @@
 .\" */
 .\" 
 
-.TH "saptune-note" "5" "June 2019" "" "saptune note file format description"
+.TH "saptune-note" "5" "November 2019" "" "saptune note file format description"
 .SH NAME
 saptune\-note - Note definition files for saptune version \fB2\fP
 .SH DESCRIPTION

--- a/ospackage/man/saptune_v2.8
+++ b/ospackage/man/saptune_v2.8
@@ -169,7 +169,10 @@ The values from the override files will take precedence over the values from \fI
 .br
 The saptune options 'list', 'verify' and 'simulate' will mark the existence of an override file and the contained values.
 
-When creating an override file for an already applied SAP Note definition, please do a 'revert all' and then apply the Notes again, to get the changes take effect.
+ATTENTION:
+Creating or changing an override file just changes the configuration \fIinside\fP this Note definition file, but does not change the \fIrunning\fP configuration of the system.
+.br
+That means: When creating or changing an override file for an \fBalready applied\fP Note definition, please do a '\fIsaptune note revert <NoteID>\fP' and then apply this Note again, to get the changes take effect.
 .TP
 .B create
 This allows to create own Note definition files in \fI/etc/saptune/extra\fP. The Note definition file will be created from a template file into the location \fI/etc/saptune/extra\fP, if the file does not exist already. After that an editor will be launched to allow changing the Note definitions.

--- a/ospackage/man/saptune_v2.8
+++ b/ospackage/man/saptune_v2.8
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\"
-.TH saptune "8" "June 2019" "" "System Optimisation For SAP"
+.TH saptune "8" "November 2019" "" "System Optimisation For SAP"
 .SH NAME
 saptune \- Comprehensive system optimisation management for SAP solutions (\fBVersion 2\fP)
 
@@ -122,6 +122,8 @@ e.g.
 [3] value is only checked, but NOT set
 .br
 [4] cpu idle state settings differ
+.br
+[5] expected value does not contain a supported scheduler
 
 If a Note definition contains a '\fB[reminder]\fP' section, this section will be printed below the table and the footnotes. It will be highlighted with red color.
 .TP
@@ -148,6 +150,8 @@ e.g.
 [3] value is only checked, but NOT set
 .br
 [4] cpu idle state settings differ
+.br
+[5] expected value does not contain a supported scheduler
 
 If a Note definition contains a '\fB[reminder]\fP' section, this section will be printed below the table and the footnotes. It will be highlighted with red color.
 .TP
@@ -245,6 +249,13 @@ or   SAP4711-very_aromatic_tunings
 .RS 0
 Syntax of the file:
 The content of the 'drop-in' file should be written in a INI file style with sections headed by '[section_name]' keywords. See saptune-note(5) to find the supported sections and their available options.
+
+ATTENTION:
+If renaming or removing an active (aka 'already applied') note definition file from the file system the \fBold\fP name of this note still remains in the configuration of saptune. This may lead to unexpected messages.
+.br
+So please always revert the note \fBbefore\fP renaming or removing it from the file system.
+.br
+Even if editing an active vendor or customer specific note definition file on the file system level, please do a revert of that note and then apply the Note again, to get the changes take effect.
 .PP
 
 .SH FILES


### PR DESCRIPTION
suppress double print of the scheduler information during 'apply' operation
correct the information about the used schedulers in case the settings should remain untouched

Inform the customer that - by intention - the command
         'saptune note customise <NoteID>'
does not apply changes immediately. It just changes the configuration in the 'override' file. These changes have to be  applied in a second step.
This is explained in the man page saptune_v2(8) and a message is  printed in the logs and on the screen to inform the customer.  (bsc#1142467)

Add warning to man page, not to rename/remove/modify active configurations (bsc#1149002)

