### PR TITLE
enhance bash completion for the new actions 'delete' and 'rename'

### DIFF
--- a/ospackage/usr/share/bash-completion/completions/saptune.completion
+++ b/ospackage/usr/share/bash-completion/completions/saptune.completion
@@ -1,8 +1,9 @@
-# v1.2
+# v1.3
 #
 #   saptune daemon [ start | status | stop ]
 #   saptune note [ list | verify ]
-#   saptune note [ apply | simulate | verify | customise | revert | create | show ] NoteID
+#   saptune note [ apply | simulate | verify | customise | revert | create | show | delete ] NoteID
+#   saptune note rename NoteID NoteID
 #   saptune solution [ list | verify ]
 #   saptune solution [ apply | simulate | verify | revert ] SolutionName
 #   saptune revert all
@@ -27,7 +28,7 @@ _saptune() {
                             ;;
                 solution)   opts="list verify apply simulate revert"
                             ;;
-                note)       opts="list verify apply simulate customise revert create show"
+                note)       opts="list verify apply simulate customise revert create show delete rename"
                             ;;
 		revert)	    opts="all"	
 			    ;;
@@ -36,7 +37,7 @@ _saptune() {
             ;;
 
         3)  case "${prev}" in
-                apply|simulate|verify|customise|revert|create|show)
+                apply|simulate|verify|customise|revert|create|show|delete|rename)
                         case "${COMP_WORDS[COMP_CWORD-2]}" in
                             note)       opts=$((ls -1q /usr/share/saptune/notes/ ; find /etc/saptune/extra/ -name '*.conf' -printf '%f\n' | cut -d '-' -f 1 | sed 's/\.conf$//') | tr '\n' ' ') 
                                         ;;


### PR DESCRIPTION
I missed to enhance the bash completion when I introduced the 2 new note actions. Thanks to Sören, who reminds me and even better sends me the enhancement.