### PR TITLE
add correct SAP Note version and date

### DIFF
--- a/ospackage/usr/share/saptune/notes/1984787
+++ b/ospackage/usr/share/saptune/notes/1984787
@@ -1,9 +1,9 @@
 # 1984787 - SUSE LINUX Enterprise Server 12: Installation notes
 # Description:    You want to use SAP software on SUSE Linux Enterprise Server 12 (SLES 12) or SUSE Linux Enterprise Server for SAP Applications 12 (SLES for SAP 12).
-# Version 32 from 26.06.2018 in English
+# Version 35 from 29.11.2019 in English
 
 [version]
-# SAP-NOTE=1984787 CATEGORY=LINUX VERSION=32 DATE=26.06.2018 NAME="SUSE LINUX Enterprise Server 12: Installation notes"
+# SAP-NOTE=1984787 CATEGORY=LINUX VERSION=35 DATE=29.11.2019 NAME="SUSE LINUX Enterprise Server 12: Installation notes"
 
 [login]
 # /etc/systemd/logind.conf.d/saptune-UserTasksMax.conf UserTasksMax setting

--- a/ospackage/usr/share/saptune/notes/2161991
+++ b/ospackage/usr/share/saptune/notes/2161991
@@ -1,10 +1,10 @@
 # 2161991 - VMware vSphere configuration guidelines
 # Description:    3. Recommendations for the guest operating system
-# Version 25 from 14.08.2018 in English
+# Version 26 from 02.12.2019 in English
 
 #
 [version]
-# SAP-NOTE=2161991 CATEGORY=VIRT VERSION=25 DATE=14.08.2018 NAME="VMware vSphere configuration guidelines"
+# SAP-NOTE=2161991 CATEGORY=VIRT VERSION=26 DATE=02.12.2019 NAME="VMware vSphere configuration guidelines"
 
 [block]
 ## Type:    string

--- a/ospackage/usr/share/saptune/notes/2578899
+++ b/ospackage/usr/share/saptune/notes/2578899
@@ -1,9 +1,9 @@
 # 2578899 - SUSE Linux Enterprise Server 15: Installation Note
 # Description:    You want to use SAP software on SUSE Linux Enterprise Server 15 (SLES 15) or SUSE Linux Enterprise Server 15 for SAP Applications  (SLES for SAP 15).
-# Version 11 from 03.01.2019 in English
+# Version 20 from 29.11.2019 in English
 
 [version]
-# SAP-NOTE=2578899 CATEGORY=LINUX VERSION=11 DATE=03.01.2019 NAME="SUSE LINUX Enterprise Server 15: Installation notes"
+# SAP-NOTE=2578899 CATEGORY=LINUX VERSION=20 DATE=29.11.2019 NAME="SUSE LINUX Enterprise Server 15: Installation notes"
 
 [login]
 # /etc/systemd/logind.conf.d/saptune-UserTasksMax.conf UserTasksMax setting
@@ -48,6 +48,8 @@ IO_SCHEDULER=noop, none
 # dependencies handled by saptune package installation
 libopenssl1_0_0 15 1.0.2n-3.3.1
 libssh2-1 15 1.8.0-2.35
+tcsh 15 6.20.00-4.9.1
+tcsh 15-SP1 6.20.00-4.9.1
 
 [sysctl]
 # vm.dirty_bytes (indirect vm.dirty_ratio)


### PR DESCRIPTION
for the notes including the support of multi-queue I/O scheduler for block devices
(bsc#1152598)