### PR TITLE
bsc#1159671 - if a parameter is not supported by the system, the note action 'verif

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ const (
 	footnote3             = "[3] value is only checked, but NOT set"
 	footnote4             = "[4] cpu idle state settings differ"
 	footnote5             = "[5] expected value does not contain a supported scheduler"
+	footnote6             = "[6] grub settings are mostly covered by other settings. See man page saptune-note(5) for details"
 )
 
 // PrintHelpAndExit Print the usage and exit
@@ -319,7 +320,7 @@ func PrintNoteFields(writer io.Writer, header string, noteComparisons map[string
 	compliant := "yes"
 	printHead := ""
 	noteField := ""
-	footnote := make([]string, 5, 5)
+	footnote := make([]string, 6, 6)
 	reminder := make(map[string]string)
 	override := ""
 	comment := ""
@@ -358,6 +359,9 @@ func PrintNoteFields(writer io.Writer, header string, noteComparisons map[string
 			compliant = "no "
 		} else {
 			compliant = "yes"
+		}
+		if comparison.ActualValue.(string) == "all:none" {
+			compliant = " - "
 		}
 
 		// check inform map for special settings
@@ -535,6 +539,11 @@ func prepareFootnote(comparison note.FieldComparison, compliant, comment, inform
 		compliant = compliant + " [5]"
 		comment = comment + " [5]"
 		footnote[4] = footnote5
+	}
+	if strings.Contains(comparison.ReflectMapKey, "grub") {
+		compliant = compliant + " [6]"
+		comment = comment + " [6]"
+		footnote[5] = footnote6
 	}
 	return compliant, comment, footnote
 }

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -1,5 +1,5 @@
 .\"/* 
-.\" * Copyright (c) 2018-2019 SUSE LLC.
+.\" * Copyright (c) 2018-2020 SUSE LLC.
 .\" * All rights reserved
 .\" * Authors: Angela Briel
 .\" *
@@ -15,7 +15,7 @@
 .\" */
 .\" 
 
-.TH "saptune-note" "5" "November 2019" "" "saptune note file format description"
+.TH "saptune-note" "5" "January 2029" "" "saptune note file format description"
 .SH NAME
 saptune\-note - Note definition files for saptune version \fB2\fP
 .SH DESCRIPTION
@@ -142,18 +142,18 @@ ATTENTION: not idling *at all* increases power consumption significantly and red
 The section "[grub]" is checking kernel command line settings for grub.
 The values from the Note definition files are only checked against \fI/proc/cmdline\fP. Changing the grub configuration is not supported by saptune.
 
-Some of these values are set by saptune during runtime, so changing the grub configuration is possible but not needed.
+Some of these values are set by 'alternative' settings by saptune during runtime, so changing the grub configuration is possible but not needed.
 
 This section can contain options like:
 .TP
 \fBintel_idle.max_cstate=1\fP and \fBprocessor.max_cstate=1\fP
-Configure C-States for lower latency in Linux (applies to Intel-based systems only) - see energy_perf_bias, governor and force latency in section [cpu]
+Configure C-States for lower latency in Linux (applies to Intel-based systems only) - see force_latency in section [cpu] as 'alternative' settings
 .TP
 .BI numa_balancing=disable
-Turn off autoNUMA balancing - see kernel.numa_balancing in section [sysctl]
+Turn off autoNUMA balancing - see kernel.numa_balancing in section [sysctl] as 'alternative' settings
 .TP
 .BI transparent_hugepage=never
-Disable transparent hugepages - see THP in section [vm]
+Disable transparent hugepages - see THP in section [vm] as 'alternative' settings
 \" section limits
 .SH "[limits]"
 The section "[limits]" is dealing with ulimit settings for user login sessions in the pam_limits module. The settings will \fBNOT\fP be done in the central limits file \fI/etc/security/limits.conf\fP. Instead there will be a \fBdrop-in file\fP in \fI/etc/security/limits.d\fP for each domain-item-type combination used in the Note definition file.

--- a/ospackage/man/saptune_v2.8
+++ b/ospackage/man/saptune_v2.8
@@ -1,5 +1,5 @@
 .\"/*
-.\" * Copyright (c) 2017-2019 SUSE LLC.
+.\" * Copyright (c) 2017-2020 SUSE LLC.
 .\" * All rights reserved
 .\" * Authors: Soeren Schmidt, Angela Briel
 .\" *
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\"
-.TH saptune "8" "November 2019" "" "System Optimisation For SAP"
+.TH saptune "8" "January 2020" "" "System Optimisation For SAP"
 .SH NAME
 saptune \- Comprehensive system optimisation management for SAP solutions (\fBVersion 2\fP)
 
@@ -120,13 +120,21 @@ e.g.
 .br
 [1] setting is not supported by the system
 .br
+This may result in a ' - ' in column 'Compliant', but the system will nevertheless be reported as fully conforms to the specified note.
+.br
 [2] setting is not available on the system
 .br
+In case of 'grub' settings, this may result in a 'no' in column 'Compliant', but the system will nevertheless be reported as fully conforms to the specified note, because most 'grub' settings mentioned in the SAP Notes are covered by other, alternative settings.
+.br
 [3] value is only checked, but NOT set
+.br
+In case of 'grub' settings, this may result in a 'no' in column 'Compliant', but the system will nevertheless be reported as fully conforms to the specified note, because most 'grub' settings mentioned in the SAP Notes are covered by other, alternative settings.
 .br
 [4] cpu idle state settings differ
 .br
 [5] expected value does not contain a supported scheduler
+.br
+[6] grub settings are mostly covered by other settings. See man page saptune-note(5) for details
 
 If a Note definition contains a '\fB[reminder]\fP' section, this section will be printed below the table and the footnotes. It will be highlighted with red color.
 .TP

--- a/ospackage/usr/share/saptune/notes/1680803
+++ b/ospackage/usr/share/saptune/notes/1680803
@@ -1,7 +1,14 @@
 # 1680803 - SYB: SAP Adaptive Server Enterprise
 # - Best Practice for SAP Business Suite and SAP BW
+#
 # as described in the best practice document appended to the note
-# capter 2.2 Configuration for Linux
+# or if outdated look at https://www.sap.com/documents/2016/06/26450353-767c-0010-82c7-eda71af511fa.html
+# chapter 3.2 Configuration for Linux
+#
+# SAP Applications on SAP Adaptive Server Enterprise
+# - Best Practices for Migration and Runtime
+# Version 1.6 from 2018-01-15
+#
 # SAP ASE (Sybase)
 # Version 24 from 20.11.2017 in English
 #
@@ -78,4 +85,4 @@ vm.swappiness = 15
 # For best performance, disable the journal via tune2fs ^has_journal.
 # For ext4 the recommended mount options are 'noatime,nodiratime', if journaling is disabled or 'noatime,nodiratime,cache=writeback,barrier=0', if journaling is not disabled
 # For xfs the recommended mount options are 'noatime,nodiratime,nobarrier,logbufs=8'
-# network tuning including transmit queue (ifconfig <eth#> txqueuelen <value>). See Best_Practices_SAP_ASE_v1.2b.pdf (appended to the SAP Note) for more information.
+# network tuning including transmit queue (ifconfig <eth#> txqueuelen <value>). See Best_Practices_SAP_ASE_v1.2b.pdf (appended to the SAP Note) for more information or look at https://www.sap.com/documents/2016/06/26450353-767c-0010-82c7-eda71af511fa.html

--- a/ospackage/usr/share/saptune/notes/2382421
+++ b/ospackage/usr/share/saptune/notes/2382421
@@ -1,8 +1,8 @@
 # 2382421 - Optimizing the Network Configuration on HANA- and OS-Level
-# Version 35 from 10.12.2019 in English
+# Version 36 from 16.01.2020 in English
 
 [version]
-# SAP-NOTE=2382421 CATEGORY=HANA VERSION=35 DATE=10.12.2019 NAME="Optimizing the Network Configuration on HANA- and OS-Level"
+# SAP-NOTE=2382421 CATEGORY=HANA VERSION=36 DATE=16.01.2020 NAME="Optimizing the Network Configuration on HANA- and OS-Level"
 
 [sysctl]
 # This parameter limits the size of the accept backlog of a listening socket.


### PR DESCRIPTION
…y' will no longer report this as an error even if the value is not compliant.

Additionally if there is a non compliant 'grub' parameter, which has a compliant 'alternative' setting availabel (see man page saptune-note(5) for details), the note action 'verify' will no longer report this as an error