### PR TITLE
Support Release and Architecture Specific Configurations

### DIFF
--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -31,9 +31,50 @@ Lines starting with '[' indicate the begin of a new section.
 .SH SECTIONS
 A section starts with a '[section_name]' keyword in the first line, followed by lines with options and comments.
 
-The following section definitions are available and used in the saptune SAP Note definition files. Each of these sections can be used in a vendor or customer specific tuning definition placed in \fI/etc/saptune/extra\fP.
+It is possible to limit the scope of a section (e.g. to a special \fIhardware architecture\fP and/or a special \fIos version\fP) by adding tags to the section definition.
+.br
+Tags are separated  by ':' and can appear in any order. Unsupported tags are considered an error and the whole section is ignored.
+
+The \fBsyntax\fP for such sections is:
+
+[section_name:[tag=value]...]
+
+Supported tags are:
+.TP
+.BI os= <os_version>
+to define a special \fIos version\fP
+.br
+Valid values for \fBos=\fP are the values from the \fBVERSION=\fP line of \fB/etc/os-release\fP, e.g. 12-SP5 or 15-SP1
+.br
+To mark an entire major release the string 1[256]-* (wildcard) can be used.
+.TP
+.BI arch= <hardware_architecture>
+to define a special \fIhardware architecture\fP:
+.br
+Valid values for \fBarch=\fP are the output from \fBuname -i\fP
+
+.RE
+Example:
+.br
+[sysctl:os=15-SP1:arch=ppc64le]
+
+For processing a section the following rules apply:
+.IP \[bu]
+Only sections that match the system are processed. Sections without a tag are always used.
+.IP \[bu]
+The order of the section within the file matter. Eache section and each line in a section gets processed from top to down.
+.RE
+
+The rules apply for shipped Note definition files as well as for customer defined Note definition files. Tagged sections can be used in override files.
+
+\fBATTENTION:\fP To be clear - if there are more sections with the \fBsame\fP \fIsection_name\fP containing the \fBsame\fP \fIparameters\fP with \fBdifferent\fP \fIvalues\fP, the last valid section will win.
+.br
+So it's all about \fBorder\fP.
+
+The following section definitions are available and used in the saptune SAP Note definition files. Each of these sections can be used in a vendor or customer specific Note definition file placed in \fI/etc/saptune/extra\fP.
 
 List of supported sections:
+.br
 version, block, cpu, grub, limits, login, mem, pagecache, reminder, rpm, service, sysctl, vm
 
 See detailed description below:

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -309,9 +309,13 @@ The values from the Note definition files are only checked against the installed
 .br
 Package dependencies - if needed - are handled by the saptune package installation.
 
-Syntax:
+With the availability of tagged sections, we support 2 different types of rpm line syntax. The first one - our \fBOld\fP Syntax - only for compatibility reasons. The second one - our \fBNew\fP Syntax - is our prefered syntax in combination with tagged rpm sections.
+
+\fBOld\fP Syntax:
 .br
 <rpm package name> <SLE Version> <rpm package version>
+.br
+this syntax is mainly used for compatibility reasons and when using a 'non-tagged' rpm section.
 .br
 Add one line for each SLE version a package should be checked for, even if the package version is the same.
 .br
@@ -330,6 +334,26 @@ util-linux 12-SP1 2.25-22.1
 Only the lines where the SLE version is matching the running system OS are checked and displayed during the 'verify' and 'simulate' option.
 .br
 That means, if there is no matching SLE version for the running OS no rpm entries are listed during the 'verify' and 'simulate' operation.
+
+\fBNew\fP Syntax:
+.br
+<rpm package name> <rpm package version>
+.br
+this syntax is the prefered syntax when using a 'tagged' rpm section, where the targeted operating system and/or system architecture is defined by using the tags \fBos=\fP and/or \fBarch=\fP
+.br
+Add one line for each package and package version to be checked.
+
+e.g
+.br
+systemd 228-142.1
+.br
+util-linux 2.25-22.1
+
+Only the lines where the tags of the section match the running system OS and/or the system architecture are checked and displayed during the 'verify' and 'simulate' option.
+.br
+That means, if there is no matching SLE version for the running OS and/or no matching system architecture in the tags of the rpm section no rpm entries are listed during the 'verify' and 'simulate' operation.
+
+
 \" section service
 .SH "[service]"
 The section "[service]" is dealing with starting and stopping services controlled by systemd.

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -128,6 +128,13 @@ Valid values can be found in \fI/sys/block/<device>/queue/scheduler\fP.
 IO nr_requests specifies the maximum number of read and write requests that can be queued at one time. The default value is 128, which means that 128 read requests and 128 write requests can be queued before the next process to request a read or write is put to sleep.
 .br
 When set, the number of requests for \fBall\fP block devices on the system will be switched to the chosen value
+.TP
+.BI READ_AHEAD_KB= INT
+disk readahead (queue/read_ahead_kb) defines the maximum number of kilobytes that the operating system may read ahead during a sequential read operation. As a result, the likely-needed information is already present within the kernel page cache for the next sequential read, which improves read I/O performance.
+Device mappers often benefit from a high read_ahead_kb value.
+Increasing the read_ahead_kb value might improve performance in environments where sequential reading of large files takes place.
+.br
+When set, the value of read_ahead_kb for \fBall\fP block devices on the system will be switched to the chosen value
 \" section cpu
 .SH "[cpu]"
 The section "[cpu]" manipulates files in \fI/sys/devices/system/cpu/cpu*\fP.

--- a/ospackage/usr/share/saptune/notes/2205917
+++ b/ospackage/usr/share/saptune/notes/2205917
@@ -1,9 +1,9 @@
 # 2205917 - SAP HANA DB: Recommended OS settings for SLES 12 / SLES for SAP Applications 12
 # Description:    HANA DB settings
-# Version 57 from 23.04.2019 in English
+# Version 58 from 23.03.2020 in English
 
 [version]
-# SAP-NOTE=2205917 CATEGORY=HANA VERSION=57 DATE=23.04.2019 NAME="SAP HANA DB: Recommended OS settings for SLES 12 / SLES for SAP Applications 12"
+# SAP-NOTE=2205917 CATEGORY=HANA VERSION=58 DATE=23.03.2020 NAME="SAP HANA DB: Recommended OS settings for SLES 12 / SLES for SAP Applications 12"
 
 [login]
 # /etc/systemd/logind.conf.d/saptune-UserTasksMax.conf UserTasksMax setting
@@ -117,6 +117,15 @@ systemd 12-SP2 228-142.1
 sapinit-systemd-compat 12 1.0-2.1
 sapinit-systemd-compat 12-SP1 1.0-2.1
 libssh2-1 12-SP4 1.4.3-20.3.1
+
+[rpm:os=12-SP5:]
+libssh2-1 1.4.3-20.14.1
+
+[rpm:os=12-SP4:arch=ppc64le]
+kernel-default 4.12.14-95.13.1
+
+[rpm:os=12-SP5:arch=ppc64le]
+kernel-default 4.12.14-122.17
 
 [grub]
 # /etc/default/grub GRUB_CMDLINE_LINUX_DEFAULT

--- a/ospackage/usr/share/saptune/notes/2578899
+++ b/ospackage/usr/share/saptune/notes/2578899
@@ -33,6 +33,23 @@ sysstat.service=start
 # chosen schedulers.
 IO_SCHEDULER=noop, none
 
+[block:os=15-SP2:arch=ppc64le]
+#
+# disk readahead
+# queue/read_ahead_kb
+#
+# Defines the maximum number of kilobytes that the operating system may read
+# ahead during a sequential read operation. As a result, the likely-needed
+# information is already present within the kernel page cache for the next
+# sequential read, which improves read I/O performance.
+# Device mappers often benefit from a high read_ahead_kb value.
+# Increasing the read_ahead_kb value might improve performance in environments
+# where sequential reading of large files takes place.
+#
+# When set, the value of read_ahead_kb for all block devices on the system will
+# be switched to the chosen value
+READ_AHEAD_KB=128
+
 [rpm]
 # dependencies handled by saptune package installation
 libopenssl1_0_0 15 1.0.2n-3.3.1
@@ -71,3 +88,7 @@ vm.dirty_bytes=629145600
 # vm.dirty_background_bytes should be set to 314572800 (see TID_7010287)
 #
 vm.dirty_background_bytes=314572800
+
+[sysctl:os=15-SP2:arch=ppc64le]
+kernel.sched_min_granularity_ns = 3000000
+kernel.sched_wakeup_granularity_ns = 4000000

--- a/sap/note/ini.go
+++ b/sap/note/ini.go
@@ -15,7 +15,7 @@ import (
 const OverrideTuningSheets = "/etc/saptune/override/"
 
 var pc = LinuxPagingImprovements{}
-var blck = param.BlockDeviceQueue{param.BlockDeviceSchedulers{SchedulerChoice: make(map[string]string)}, param.BlockDeviceNrRequests{NrRequests: make(map[string]int)}}
+var blck = param.BlockDeviceQueue{param.BlockDeviceSchedulers{SchedulerChoice: make(map[string]string)}, param.BlockDeviceNrRequests{NrRequests: make(map[string]int)}, param.BlockDeviceReadAheadKB{ReadAheadKB: make(map[string]int)}}
 var isLimitSoft = regexp.MustCompile(`LIMIT_.*_soft_memlock`)
 var isLimitHard = regexp.MustCompile(`LIMIT_.*_hard_memlock`)
 var flstates = ""
@@ -110,7 +110,7 @@ func (vend INISettings) Initialise() (Note, error) {
 	vend.OverrideParams = make(map[string]string)
 	vend.Inform = make(map[string]string)
 	pc = LinuxPagingImprovements{}
-	blck = param.BlockDeviceQueue{param.BlockDeviceSchedulers{SchedulerChoice: make(map[string]string)}, param.BlockDeviceNrRequests{NrRequests: make(map[string]int)}}
+	blck = param.BlockDeviceQueue{param.BlockDeviceSchedulers{SchedulerChoice: make(map[string]string)}, param.BlockDeviceNrRequests{NrRequests: make(map[string]int)}, param.BlockDeviceReadAheadKB{ReadAheadKB: make(map[string]int)}}
 
 	for _, param := range ini.AllValues {
 		if override && len(ow.KeyValue[param.Section]) != 0 {

--- a/sap/note/note.go
+++ b/sap/note/note.go
@@ -210,30 +210,30 @@ func CompareNoteFields(actualNote, expectedNote Note) (allMatch bool, comparison
 		}
 	}
 	if allMatch && grubAvail {
-		allMatch = chkGrubCompliance(comparisons, allMatch)
+		allMatch = ChkGrubCompliance(comparisons, allMatch)
 	}
 	return
 }
 
-// grub special - check compliance of alternative settings
+// ChkGrubCompliance grub special - check compliance of alternative settings
 // only if one of these alternatives are not compliant, modify the result of
 // the compare
-func chkGrubCompliance(comparisons map[string]FieldComparison, allMatch bool) bool {
+func ChkGrubCompliance(comparisons map[string]FieldComparison, allMatch bool) bool {
 	// grub:numa_balancing, kernel.numa_balancing
-	if !comparisons[fmt.Sprintf("%s[%s]", "SysctlParams", "grub:numa_balancing")].MatchExpectation {
-		if !comparisons[fmt.Sprintf("%s[%s]", "SysctlParams", "kernel.numa_balancing")].MatchExpectation && allMatch == true {
+	if comparisons["SysctlParams[grub:numa_balancing]"].ReflectMapKey == "grub:numa_balancing" && !comparisons["SysctlParams[grub:numa_balancing]"].MatchExpectation {
+		if comparisons["SysctlParams[kernel.numa_balancing]"].ReflectMapKey == "kernel.numa_balancing" && !comparisons["SysctlParams[kernel.numa_balancing]"].MatchExpectation && allMatch {
 			allMatch = false
 		}
 	}
 	// grub:transparent_hugepage, THP
-	if !comparisons[fmt.Sprintf("%s[%s]", "SysctlParams", "grub:transparent_hugepage")].MatchExpectation {
-		if !comparisons[fmt.Sprintf("%s[%s]", "SysctlParams", "THP")].MatchExpectation && allMatch == true {
+	if comparisons["SysctlParams[grub:transparent_hugepage]"].ReflectMapKey == "grub:transparent_hugepage" && !comparisons["SysctlParams[grub:transparent_hugepage]"].MatchExpectation {
+		if comparisons["SysctlParams[THP]"].ReflectMapKey == "THP" && !comparisons["SysctlParams[THP]"].MatchExpectation && allMatch {
 			allMatch = false
 		}
 	}
 	// grub:intel_idle.max_cstate, grub:processor.max_cstate, force_latency
-	if !comparisons[fmt.Sprintf("%s[%s]", "SysctlParams", "grub:intel_idle.max_cstate")].MatchExpectation || !comparisons[fmt.Sprintf("%s[%s]", "SysctlParams", "grub:processor.max_cstate")].MatchExpectation {
-		if (!comparisons[fmt.Sprintf("%s[%s]", "SysctlParams", "force_latency")].MatchExpectation && comparisons[fmt.Sprintf("%s[%s]", "SysctlParams", "force_latency")].ActualValue != "all:none") && allMatch == true {
+	if (comparisons["SysctlParams[grub:intel_idle.max_cstate]"].ReflectMapKey == "grub:intel_idle.max_cstate" && !comparisons["SysctlParams[grub:intel_idle.max_cstate]"].MatchExpectation) || (comparisons["SysctlParams[grub:processor.max_cstate]"].ReflectMapKey == "grub:processor.max_cstate" && !comparisons["SysctlParams[grub:processor.max_cstate]"].MatchExpectation) {
+		if (!comparisons["SysctlParams[force_latency]"].MatchExpectation && comparisons["SysctlParams[force_latency]"].ActualValue != "all:none") && allMatch {
 			allMatch = false
 		}
 	}

--- a/sap/note/note_test.go
+++ b/sap/note/note_test.go
@@ -132,6 +132,143 @@ func TestCmpFieldValue(t *testing.T) {
 	}
 }
 
+func TestChkGrubCompliance(t *testing.T) {
+	// grub:numa_balancing - false
+	comp1 := FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "grub:numa_balancing", ActualValue: "NA", ExpectedValue: "disable", ActualValueJS: "NA", ExpectedValueJS: "disable", MatchExpectation: false}
+	// kernel.numa_balancing - true
+	comp2 := FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "kernel.numa_balancing", ActualValue: "0", ExpectedValue: "0", ActualValueJS: "0", ExpectedValueJS: "0", MatchExpectation: true}
+	// kernel.numa_balancing - false
+	comp3 := FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "kernel.numa_balancing", ActualValue: "0", ExpectedValue: "0", ActualValueJS: "0", ExpectedValueJS: "0", MatchExpectation: false}
+	// grub:transparent_hugepage - false
+	comp4 := FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "grub:transparent_hugepage", ActualValue: "NA", ExpectedValue: "never", ActualValueJS: "NA", ExpectedValueJS: "never", MatchExpectation: false}
+	// THP - true
+	comp5 := FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "THP", ActualValue: "always", ExpectedValue: "never", ActualValueJS: "always", ExpectedValueJS: "never", MatchExpectation: true}
+	// THP - false
+	comp6 := FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "THP", ActualValue: "always", ExpectedValue: "never", ActualValueJS: "always", ExpectedValueJS: "never", MatchExpectation: false}
+	// grub:intel_idle.max_cstate - false
+	comp7 := FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "grub:intel_idle.max_cstate", ActualValue: "NA", ExpectedValue: "1", ActualValueJS: "NA", ExpectedValueJS: "1", MatchExpectation: false}
+	// grub:intel_idle.max_cstate - true
+	comp10 := FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "grub:intel_idle.max_cstate", ActualValue: "NA", ExpectedValue: "1", ActualValueJS: "NA", ExpectedValueJS: "1", MatchExpectation: true}
+	// grub:processor.max_cstate - true
+	comp8 := FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "grub:processor.max_cstate", ActualValue: "NA", ExpectedValue: "1", ActualValueJS: "NA", ExpectedValueJS: "1", MatchExpectation: true}
+	// grub:processor.max_cstate - false
+	comp11 := FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "grub:processor.max_cstate", ActualValue: "NA", ExpectedValue: "1", ActualValueJS: "NA", ExpectedValueJS: "1", MatchExpectation: false}
+	// force_latency - false and all:none
+	comp9 := FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "force_latency", ActualValue: "all:none", ExpectedValue: "70", ActualValueJS: "all:none", ExpectedValueJS: "70", MatchExpectation: false}
+	// force_latency - true and all:none
+	comp12 := FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "force_latency", ActualValue: "all:none", ExpectedValue: "70", ActualValueJS: "all:none", ExpectedValueJS: "70", MatchExpectation: true}
+	// force_latency - false and !all:none
+	comp13 := FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "force_latency", ActualValue: "33", ExpectedValue: "70", ActualValueJS: "33", ExpectedValueJS: "70", MatchExpectation: false}
+
+	// grub:numa_balancing - false, kernel.numa_balancing - true = true
+	t.Run("grub:numa_balancing - false, kernel.numa_balancing - true", func(t *testing.T) {
+		allMatch := true
+		comparison := make(map[string]FieldComparison)
+		comparison["SysctlParams[grub:numa_balancing]"] = comp1
+		comparison["SysctlParams[kernel.numa_balancing]"] = comp2
+
+		allMatch = ChkGrubCompliance(comparison, allMatch)
+		if !allMatch {
+			t.Errorf("grub:numa_balancing = false and kernel.numa_balancing = true should be true and NOT false")
+		}
+	})
+
+	// grub:numa_balancing - false, kernel.numa_balancing - false = false
+	t.Run("grub:numa_balancing - false, kernel.numa_balancing - false", func(t *testing.T) {
+		allMatch := true
+		comparison := make(map[string]FieldComparison)
+		comparison["SysctlParams[grub:numa_balancing]"] = comp1
+		comparison["SysctlParams[kernel.numa_balancing]"] = comp3
+
+		allMatch = ChkGrubCompliance(comparison, allMatch)
+		if allMatch {
+			t.Errorf("grub:numa_balancing = false and kernel.numa_balancing = false should be false and NOT true")
+		}
+	})
+
+	// grub:transparent_hugepage - false, THP - true = true
+	t.Run("grub:transparent_hugepage - false, THP - true", func(t *testing.T) {
+		allMatch := true
+		comparison := make(map[string]FieldComparison)
+		comparison["SysctlParams[grub:transparent_hugepage]"] = comp4
+		comparison["SysctlParams[THP]"] = comp5
+
+		allMatch = ChkGrubCompliance(comparison, allMatch)
+		if !allMatch {
+			t.Errorf("grub:transparent_hugepage = false and THP = true should be true and NOT false")
+		}
+	})
+
+	// grub:transparent_hugepage - false, THP - false = false
+	t.Run("grub:transparent_hugepage - false, THP - false", func(t *testing.T) {
+		allMatch := true
+		comparison := make(map[string]FieldComparison)
+		comparison["SysctlParams[grub:transparent_hugepage]"] = comp4
+		comparison["SysctlParams[THP]"] = comp6
+
+		allMatch = ChkGrubCompliance(comparison, allMatch)
+		if allMatch {
+			t.Errorf("grub:transparent_hugepage = false and THP = false should be false and NOT true")
+		}
+	})
+
+	// grub:intel_idle.max_cstate - false, grub:processor.max_cstate - true , force_latency - false and =all:none  = true
+	t.Run("grub:intel_idle.max_cstate - false, grub:processor.max_cstate - true , force_latency - false and =all:none", func(t *testing.T) {
+		allMatch := true
+		comparison := make(map[string]FieldComparison)
+		comparison["SysctlParams[grub:intel_idle.max_cstate]"] = comp7
+		comparison["SysctlParams[grub:processor.max_cstate]"] = comp8
+		comparison["SysctlParams[force_latency]"] = comp9
+
+		allMatch = ChkGrubCompliance(comparison, allMatch)
+		if !allMatch {
+			t.Errorf("grub:intel_idle.max_cstate = false, grub:processor.max_cstate = true, force_latency = false and force_latency.act_val = all:none should be true and NOT false")
+		}
+	})
+
+	// grub:intel_idle.max_cstate - true, grub:processor.max_cstate - false , force_latency - false and =all:none  = true
+	t.Run("grub:intel_idle.max_cstate - true, grub:processor.max_cstate - false , force_latency - false and =all:none", func(t *testing.T) {
+		allMatch := true
+		comparison := make(map[string]FieldComparison)
+		comparison["SysctlParams[grub:intel_idle.max_cstate]"] = comp10
+		comparison["SysctlParams[grub:processor.max_cstate]"] = comp11
+		comparison["SysctlParams[force_latency]"] = comp9
+
+		allMatch = ChkGrubCompliance(comparison, allMatch)
+		if !allMatch {
+			t.Errorf("grub:intel_idle.max_cstate = true, grub:processor.max_cstate = false, force_latency = false and force_latency.act_val = all:none should be true and NOT false")
+		}
+	})
+
+	// grub:intel_idle.max_cstate - false, grub:processor.max_cstate - false , force_latency - true and =all:none  = true
+	t.Run("grub:intel_idle.max_cstate - false, grub:processor.max_cstate - false , force_latency - true and =all:none", func(t *testing.T) {
+		allMatch := true
+		comparison := make(map[string]FieldComparison)
+		comparison["SysctlParams[grub:intel_idle.max_cstate]"] = comp7
+		comparison["SysctlParams[grub:processor.max_cstate]"] = comp11
+		comparison["SysctlParams[force_latency]"] = comp12
+
+		allMatch = ChkGrubCompliance(comparison, allMatch)
+		if !allMatch {
+			t.Errorf("grub:intel_idle.max_cstate = false, grub:processor.max_cstate = false, force_latency = true and force_latency.act_val = all:none should be true and NOT false")
+		}
+	})
+
+	// grub:intel_idle.max_cstate - true, grub:processor.max_cstate - false , force_latency - false and !=all:none  = false
+	t.Run("grub:intel_idle.max_cstate - true, grub:processor.max_cstate - false , force_latency - false and !=all:none", func(t *testing.T) {
+		allMatch := true
+		comparison := make(map[string]FieldComparison)
+		comparison["SysctlParams[grub:intel_idle.max_cstate]"] = comp10
+		comparison["SysctlParams[grub:processor.max_cstate]"] = comp11
+		comparison["SysctlParams[force_latency]"] = comp13
+
+		allMatch = ChkGrubCompliance(comparison, allMatch)
+		if allMatch {
+			t.Errorf("grub:intel_idle.max_cstate = true, grub:processor.max_cstate = false, force_latency = false and force_latency.act_val != all:none should be false and NOT true")
+		}
+	})
+}
+
 func TestGetTuningOptions(t *testing.T) {
 	allOpts := GetTuningOptions(OSNotesInGOPATH, "")
 	if sorted := allOpts.GetSortedIDs(); len(allOpts) != len(sorted) {

--- a/system/system.go
+++ b/system/system.go
@@ -64,6 +64,15 @@ func IsSLE15() bool {
 	return false
 }
 
+// IsSLE12 returns true, if System is running a SLE12 release
+func IsSLE12() bool {
+	var re = regexp.MustCompile(`12-SP\d+`)
+	if GetOsName() == "SLES" && (GetOsVers() == "12" || re.MatchString(GetOsVers())) {
+		return true
+	}
+	return false
+}
+
 // CheckForPattern returns true, if the file is available and
 // contains the expected string
 func CheckForPattern(file, pattern string) bool {

--- a/system/system.go
+++ b/system/system.go
@@ -146,3 +146,19 @@ func CopyFile(srcFile, destFile string) error {
 	}
 	return err
 }
+
+// BlockDeviceIsDisk checks, if a block device is a disk
+// /sys/block/*/device/type (TYPE_DISK / 0x00)
+// does not work for virtio block devices, needs workaround
+func BlockDeviceIsDisk(dev string) bool {
+	isVD := regexp.MustCompile(`^vd\w+$`)
+	fname := fmt.Sprintf("/sys/block/%s/device/type", dev)
+	dtype, err := ioutil.ReadFile(fname)
+	if err != nil || strings.TrimSpace(string(dtype)) != "0" {
+		if strings.Join(isVD.FindStringSubmatch(dev), "") == "" {
+			// unsupported device
+			return false
+		}
+	}
+	return true
+}

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -43,6 +43,14 @@ func TestIsSLE15(t *testing.T) {
 	}
 }
 
+func TestIsSLE12(t *testing.T) {
+	if IsSLE12() {
+		t.Logf("found SLE12 OS version\n")
+	} else {
+		t.Logf("OS version is '%s'\n", GetOsVers())
+	}
+}
+
 func TestCmdIsAvailable(t *testing.T) {
 	if !CmdIsAvailable("/usr/bin/go") {
 		t.Fatal("'/usr/bin/go' not found")
@@ -109,5 +117,16 @@ func TestCopyFile(t *testing.T) {
 	err = CopyFile(src, "/tmp/saptune_test/saptune_tstfile")
 	if err == nil {
 		t.Fatalf("copied from non existing file")
+	}
+}
+
+func TestBlockDeviceIsDisk(t *testing.T) {
+	devs := []string{"sda", "vda", "sr0"}
+	for _, bdev := range devs {
+		if !BlockDeviceIsDisk(bdev) {
+			t.Logf("device unsupported, '%s' is NOT a disk", bdev)
+		} else {
+			t.Logf("device supported, '%s' is a disk", bdev)
+		}
 	}
 }

--- a/testdata/ini_all_test.ini
+++ b/testdata/ini_all_test.ini
@@ -8,6 +8,7 @@
 [block]
 IO_SCHEDULER=NoOp,NoNE
 NRREQ=1022
+READ_AHEAD_KB=128
 
 [cpu]
 energy_perf_bias=powersave
@@ -30,6 +31,18 @@ VSZ_TMPFS_PERCENT=60
 glibc all 2.22-51.6
 tuned SLE12 2.8.0-4.3.1
 
+[rpm]
+glibc 2.22-51.6
+
+[rpm:os=15-SP1:arch=x86_64]
+tuned 2.10.0-11.3.2
+
+[rpm:os=15-*:arch=ppc64le]
+tuned 2.10.0-11.3.2
+
+[rpm:os=12-*:arch=x86_64]
+tuned 2.8.0-4.3.1
+
 [service]
 sysstat=stop
 uuidd.socket=start
@@ -46,6 +59,23 @@ KSM=1
 
 [unknownsection]
 unkown_parameter=unknownvalue
+
+[]
+# empty section
+
+[rpm:unknowntag=4711]
+# unknown tag
+
+[rpm:os=47=11]
+# wrong tag syntax
+
+[rpm:os=10-*]
+# unknown os version in tag os=
+
+[rpm]
+# wrong syntax for rpm checks
+glibc
+2.22-51.6
 
 [reminder]
 # Text to ignore for apply but to display.

--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -282,24 +282,12 @@ func ParseINI(input string) *INIFile {
 				system.WarningLog("[block] section detected: Traversing all block devices can take a considerable amount of time.")
 				blckCnt = blckCnt + 1
 			}
-			// identify virtio block devices
-			isVD := regexp.MustCompile(`^vd\w+$`)
 			_, sysDevs := system.ListDir("/sys/block", "the available block devices of the system")
 			for _, bdev := range sysDevs {
-				// /sys/block/*/device/type (TYPE_DISK / 0x00)
-				// does not work for virtio block devices
-				fname := fmt.Sprintf("/sys/block/%s/device/type", bdev)
-				dtype, err := ioutil.ReadFile(fname)
-				if err != nil || strings.TrimSpace(string(dtype)) != "0" {
-					if strings.Join(isVD.FindStringSubmatch(bdev), "") == "" {
-						// skip unsupported devices
-						continue
-					}
+				if !system.BlockDeviceIsDisk(bdev) {
+					// skip unsupported devices
+					continue
 				}
-				//if strings.Contains(bdev, "dm-") {
-				// skip unsupported devices
-				//	continue
-				//}
 				entry := INIEntry{
 					Section:  currentSection,
 					Key:      fmt.Sprintf("%s_%s", kov[1], bdev),


### PR DESCRIPTION
- To support system parameters only relevant for specific SLES
  releases, service packs and/or hardware architectures saptune
  now supports 'tagged' sections inside the Note definition files.
  (jsc#PM-1862)
- To support a special performance tuning for Power systems we add
  the handling for 'read_ahead_kb' setting for block devices and
  added additional sysctl parameters regarding to SAP-Note 2578899.
  (jsc#SLE-12416, bsc#1157811)
- new kernel requirement for Power added to SAP-Note 2205917
  SAP Note 2205917 updated to Version 58
  (bsc#1167416)
- add unit tests for the last changes