### PR TITLE
revert changes for jsc#SLE-12416, bsc#1157811 for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,8 @@ With each new version of saptune we implement many of them, but the journey will
 
 
 Enjoy the new saptune!
+
+---
+
+[Hints for development](development.md)
+

--- a/app/state.go
+++ b/app/state.go
@@ -63,6 +63,9 @@ func (state *State) Retrieve(noteID string, dest interface{}) error {
 	if err != nil {
 		return err
 	}
+	if len(content) == 0 {
+		return nil
+	}
 	return json.Unmarshal(content, dest)
 }
 

--- a/development.md
+++ b/development.md
@@ -1,0 +1,44 @@
+# some hints for development
+
+the sources should be available at $GOPATH/src/github.com/SUSE/saptune
+
+## build saptune v2
+	cd $GOPATH/src/github.com/SUSE/saptune
+	go build
+
+## lint and format checks for the sources before committing changes
+
+	gofmt -d *
+	golint ./...
+	go vet -composites=false ./...
+
+and run the unit tests (in a docker container)
+
+## unit tests for saptune:
+after committing the changes to git travis is used for automatic testing
+
+But before committing the sources, run the tests locally by using docker and the same workflow as on travis
+
+	su -
+	systemctl start docker
+	cd $GOPATH/src/github.com/SUSE/saptune
+	docker run --name travis-st-ci --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -td -v "$(pwd):/app" shap/crmsh
+	docker exec -t travis-st-ci /bin/sh -c "cd /app; ./run_travis_tst.sh;"
+
+in $GOPATH/src/github.com/SUSE/saptune
+
+	go tool cover -html=c.out -o coverage.html
+
+and check the file 'coverage.html' in your Browser to see the coverage
+
+make changes to the source files
+
+and run the tests again
+
+	docker exec -t travis-st-ci /bin/sh -c "cd /app; ./run_travis_tst.sh;"
+
+clean up when finished with your tests
+
+	docker stop travis-st-ci
+	docker rm travis-st-ci
+

--- a/main.go
+++ b/main.go
@@ -649,12 +649,27 @@ func NoteActionApply(writer io.Writer, noteID string, tuneApp *app.App) {
 	// Otherwise, the state file (serialised parameters) will be
 	// overwritten, and it will no longer be possible to revert the
 	// note to the state before it was tuned.
-	_, err := os.Stat(tuneApp.State.GetPathToNote(noteID))
+	sfile, err := os.Stat(tuneApp.State.GetPathToNote(noteID))
 	if err == nil {
 		// state file for note already exists
-		// do not apply the note again
-		system.InfoLog("note '%s' already applied. Nothing to do", noteID)
-		os.Exit(0)
+		// check, if note is part of NOTE_APPLY_ORDER
+		if tuneApp.PositionInNoteApplyOrder(noteID) < 0 { // noteID not yet available
+			// bsc#1167618
+			// check, if state file is empty - seems to be a
+			// left-over of the update from saptune V1 to V2
+			if sfile.Size() == 0 {
+				// remove old, left-over state file and go
+				// forward to apply the note
+				os.Remove(tuneApp.State.GetPathToNote(noteID))
+			} else {
+				// data mismatch, do not apply the note
+				system.WarningLog("note '%s' is not listed in 'NOTE_APPLY_ORDER', but a non-empty state file exists. To prevent configuration mismatch, please revert note '%s' first and apply again.", noteID, noteID)
+				os.Exit(0)
+			}
+		} else {
+			system.InfoLog("note '%s' already applied. Nothing to do", noteID)
+			os.Exit(0)
+		}
 	}
 	if err := tuneApp.TuneNote(noteID); err != nil {
 		errorExit("Failed to tune for note %s: %v", noteID, err)

--- a/main.go
+++ b/main.go
@@ -134,6 +134,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	// cleanup runtime file
+	note.CleanUpRun()
+
 	// activate logging
 	system.LogInit(logFile, debugSwitch, verboseSwitch)
 

--- a/ospackage/usr/share/saptune/notes/2205917
+++ b/ospackage/usr/share/saptune/notes/2205917
@@ -118,7 +118,7 @@ sapinit-systemd-compat 12 1.0-2.1
 sapinit-systemd-compat 12-SP1 1.0-2.1
 libssh2-1 12-SP4 1.4.3-20.3.1
 
-[rpm:os=12-SP5:]
+[rpm:os=12-SP5]
 libssh2-1 1.4.3-20.14.1
 
 [rpm:os=12-SP4:arch=ppc64le]

--- a/ospackage/usr/share/saptune/notes/2578899
+++ b/ospackage/usr/share/saptune/notes/2578899
@@ -33,23 +33,6 @@ sysstat.service=start
 # chosen schedulers.
 IO_SCHEDULER=noop, none
 
-[block:os=15-SP2:arch=ppc64le]
-#
-# disk readahead
-# queue/read_ahead_kb
-#
-# Defines the maximum number of kilobytes that the operating system may read
-# ahead during a sequential read operation. As a result, the likely-needed
-# information is already present within the kernel page cache for the next
-# sequential read, which improves read I/O performance.
-# Device mappers often benefit from a high read_ahead_kb value.
-# Increasing the read_ahead_kb value might improve performance in environments
-# where sequential reading of large files takes place.
-#
-# When set, the value of read_ahead_kb for all block devices on the system will
-# be switched to the chosen value
-READ_AHEAD_KB=128
-
 [rpm]
 # dependencies handled by saptune package installation
 libopenssl1_0_0 15 1.0.2n-3.3.1
@@ -88,7 +71,3 @@ vm.dirty_bytes=629145600
 # vm.dirty_background_bytes should be set to 314572800 (see TID_7010287)
 #
 vm.dirty_background_bytes=314572800
-
-[sysctl:os=15-SP2:arch=ppc64le]
-kernel.sched_min_granularity_ns = 3000000
-kernel.sched_wakeup_granularity_ns = 4000000

--- a/sap/note/ini_test.go
+++ b/sap/note/ini_test.go
@@ -16,6 +16,9 @@ func cleanUp() {
 	var parameterStateDir = "/var/lib/saptune/parameter"
 	os.RemoveAll(parameterStateDir)
 	defer os.RemoveAll(parameterStateDir)
+	var saptuneSectionDir = "/var/lib/saptune/sections"
+	os.RemoveAll(saptuneSectionDir)
+	defer os.RemoveAll(saptuneSectionDir)
 }
 
 func TestCalculateOptimumValue(t *testing.T) {
@@ -79,7 +82,7 @@ func TestCalculateOptimumValue(t *testing.T) {
 func TestVendorSettings(t *testing.T) {
 	cleanUp()
 	iniPath := path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/ini_test.ini")
-	ini := INISettings{ConfFilePath: iniPath}
+	ini := INISettings{ConfFilePath: iniPath, ID: "471147"}
 
 	if ini.Name() == "" {
 		t.Fatal(ini.Name())
@@ -453,6 +456,8 @@ func TestOverrideAllSettings(t *testing.T) {
 	if optimisedINI.SysctlParams["reminder"] != txt2chk {
 		t.Fatal(optimisedINI.SysctlParams)
 	}
+	// cleanup
+	CleanUpRun()
 }
 
 func TestPageCacheSettings(t *testing.T) {

--- a/sap/note/parameter.go
+++ b/sap/note/parameter.go
@@ -115,7 +115,9 @@ func GetSavedParameterNotes(param string) ParameterNotes {
 	if err != nil {
 		return pEntries
 	}
-	err = json.Unmarshal(content, &pEntries)
+	if len(content) != 0 {
+		err = json.Unmarshal(content, &pEntries)
+	}
 	return pEntries
 }
 

--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -89,6 +89,10 @@ func chkSecTags(secFields []string) bool {
 	ret := true
 	cnt := 0
 	for _, secTag := range secFields {
+		if secTag == "" {
+			// support empty tags
+			continue
+		}
 		if cnt == 0 {
 			// skip section name
 			cnt = cnt + 1
@@ -234,6 +238,8 @@ func ParseINI(input string) *INIFile {
 				// to be compatible to old section definitions without 'tags' we need to check fields[1] for os matching
 				if fields[1] == "all" || fields[1] == system.GetOsVers() {
 					kov = []string{"rpm", "rpm:" + fields[0], "", fields[2]}
+				} else {
+					system.WarningLog("in rpm section '%v' the line '%v' contains a non-matching os version '%s'. Skipping line", currentSection, fields, fields[1])
 				}
 			} else if len(fields) == 2 {
 				// new syntax - rpm to check | expected package version


### PR DESCRIPTION
revert changes for jsc#SLE-12416, bsc#1157811 for now, as our internal performance tests do not show any advantage of these settings at the moment
correct a typo and add some checks for the rpm section handling (bsc#1167416)
check, if json input file is empty (bsc#1167618)