### PR TITLE
bugfixing saptune

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -170,7 +170,7 @@ func (app *App) NoteSanityCheck() error {
 		// bsc#1149205
 		// noteID available in apply order list, but no note definition
 		// file found. May be removed or renamed.
-		system.ErrorLog("the Note ID '%s' is not recognised by saptune, but is listed in the apply order list.\nMay be you removed or renamed the associated Note definition file on command line without reverting the Note first.\nWe will now remove the NoteID from the apply order list to prevent further confusion.", note)
+		system.ErrorLog("The Note ID '%s' is not recognized by saptune, but it is listed in the apply order list.\nMay be the associated Note definition file was removed or renamed via command line without previously reverting the Note.\nSaptune will now remove the NoteID from the apply order list to prevent further confusion.", note)
 		app.removeFromConfig(note)
 		if err := app.SaveConfig(); err != nil {
 			errs = append(errs, err)

--- a/app/state.go
+++ b/app/state.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/SUSE/saptune/sap/note"
 	"io/ioutil"
 	"os"
@@ -64,7 +65,7 @@ func (state *State) Retrieve(noteID string, dest interface{}) error {
 		return err
 	}
 	if len(content) == 0 {
-		return nil
+		return fmt.Errorf("empty state file")
 	}
 	return json.Unmarshal(content, dest)
 }

--- a/main.go
+++ b/main.go
@@ -172,6 +172,9 @@ func main() {
 	tuneApp = app.InitialiseApp("", "", tuningOptions, archSolutions)
 
 	checkUpdateLeftOvers()
+	if err := tuneApp.NoteSanityCheck(); err != nil {
+		errorExit("Error during NoteSanityCheck - '%v'\n", err)
+	}
 	selectAction()
 
 }
@@ -654,31 +657,16 @@ func NoteActionApply(writer io.Writer, noteID string, tuneApp *app.App) {
 	if noteID == "" {
 		PrintHelpAndExit(1)
 	}
+
 	// Do not apply the note, if it was applied before
 	// Otherwise, the state file (serialised parameters) will be
 	// overwritten, and it will no longer be possible to revert the
 	// note to the state before it was tuned.
-	sfile, err := os.Stat(tuneApp.State.GetPathToNote(noteID))
-	if err == nil {
-		// state file for note already exists
-		// check, if note is part of NOTE_APPLY_ORDER
-		if tuneApp.PositionInNoteApplyOrder(noteID) < 0 { // noteID not yet available
-			// bsc#1167618
-			// check, if state file is empty - seems to be a
-			// left-over of the update from saptune V1 to V2
-			if sfile.Size() == 0 {
-				// remove old, left-over state file and go
-				// forward to apply the note
-				os.Remove(tuneApp.State.GetPathToNote(noteID))
-			} else {
-				// data mismatch, do not apply the note
-				system.WarningLog("note '%s' is not listed in 'NOTE_APPLY_ORDER', but a non-empty state file exists. To prevent configuration mismatch, please revert note '%s' first and apply again.", noteID, noteID)
-				os.Exit(0)
-			}
-		} else {
+	if str, ok := tuneApp.IsNoteApplied(noteID); ok {
+		if str == "" {
 			system.InfoLog("note '%s' already applied. Nothing to do", noteID)
-			os.Exit(0)
 		}
+		os.Exit(0)
 	}
 	if err := tuneApp.TuneNote(noteID); err != nil {
 		errorExit("Failed to tune for note %s: %v", noteID, err)
@@ -792,8 +780,7 @@ func NoteActionCustomise(noteID string) {
 	if editor == "" {
 		editor = "/usr/bin/vim" // launch vim by default
 	}
-	i := tuneApp.PositionInNoteApplyOrder(noteID)
-	if i < 0 { // noteID not yet available
+	if _, ok := tuneApp.IsNoteApplied(noteID); !ok {
 		system.InfoLog("Do not forget to apply the just edited Note to get your changes to take effect\n")
 	} else { // noteID already applied
 		system.InfoLog("Your just edited Note is already applied. To get your changes to take effect, please 'revert' the Note and apply again.\n")
@@ -867,8 +854,7 @@ func NoteActionDelete(reader io.Reader, writer io.Writer, noteID, noteTuningShee
 	ovFileName, overrideNote := getovFile(noteID, ovTuningSheets)
 
 	// check, if note is active - applied
-	i := tuneApp.PositionInNoteApplyOrder(noteID)
-	if i >= 0 { // noteID already applied
+	if _, ok := tuneApp.IsNoteApplied(noteID); ok {
 		system.InfoLog("The Note definition file you want to delete is currently in use, which means it is already applied.")
 		system.InfoLog("So please 'revert' the Note first and then try deleting again.\n")
 		os.Exit(0)
@@ -918,8 +904,7 @@ func NoteActionRename(reader io.Reader, writer io.Writer, noteID, newNoteID, not
 	newovFileName := fmt.Sprintf("%s%s", ovTuningSheets, newNoteID)
 
 	// check, if note is active - applied
-	i := tuneApp.PositionInNoteApplyOrder(noteID)
-	if i >= 0 { // noteID already applied
+	if _, ok := tuneApp.IsNoteApplied(noteID); ok {
 		system.InfoLog("The Note definition file you want to rename is currently in use, which means it is already applied.")
 		system.InfoLog("So please 'revert' the Note first and then try renaming again.\n")
 		os.Exit(0)

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ const (
 	footnote4             = "[4] cpu idle state settings differ"
 	footnote5             = "[5] expected value does not contain a supported scheduler"
 	footnote6             = "[6] grub settings are mostly covered by other settings. See man page saptune-note(5) for details"
+	footnote7             = "[7] parameter value is untouched by default"
 )
 
 // PrintHelpAndExit Print the usage and exit
@@ -323,7 +324,7 @@ func PrintNoteFields(writer io.Writer, header string, noteComparisons map[string
 	compliant := "yes"
 	printHead := ""
 	noteField := ""
-	footnote := make([]string, 6, 6)
+	footnote := make([]string, 7, 7)
 	reminder := make(map[string]string)
 	override := ""
 	comment := ""
@@ -358,8 +359,12 @@ func PrintNoteFields(writer io.Writer, header string, noteComparisons map[string
 			continue
 		}
 		if !comparison.MatchExpectation {
-			hasDiff = true
-			compliant = "no "
+			if comparison.ExpectedValue.(string) == "" {
+				compliant = "yes"
+			} else {
+				hasDiff = true
+				compliant = "no "
+			}
 		} else {
 			compliant = "yes"
 		}
@@ -547,6 +552,11 @@ func prepareFootnote(comparison note.FieldComparison, compliant, comment, inform
 		compliant = compliant + " [6]"
 		comment = comment + " [6]"
 		footnote[5] = footnote6
+	}
+	if comparison.ExpectedValue == "" {
+		compliant = compliant + " [7]"
+		comment = comment + " [7]"
+		footnote[6] = footnote7
 	}
 	return compliant, comment, footnote
 }

--- a/main.go
+++ b/main.go
@@ -359,12 +359,8 @@ func PrintNoteFields(writer io.Writer, header string, noteComparisons map[string
 			continue
 		}
 		if !comparison.MatchExpectation {
-			if comparison.ExpectedValue.(string) == "" {
-				compliant = "yes"
-			} else {
-				hasDiff = true
-				compliant = "no "
-			}
+			hasDiff = true
+			compliant = "no "
 		} else {
 			compliant = "yes"
 		}

--- a/main.go
+++ b/main.go
@@ -992,8 +992,8 @@ func SolutionActionApply(writer io.Writer, solName string, tuneApp *app.App) {
 	if len(tuneApp.TuneForSolutions) > 0 {
 		// already one solution applied.
 		// do not apply another solution. Does not make sense
-		system.InfoLog("There is already one solution applied. Applying another solution is NOT supported.")
-		os.Exit(0)
+		system.ErrorLog("There is already one solution applied. Applying another solution is NOT supported.")
+		os.Exit(1)
 	}
 	removedAdditionalNotes, err := tuneApp.TuneSolution(solName)
 	if err != nil {

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -15,7 +15,7 @@
 .\" */
 .\" 
 
-.TH "saptune-note" "5" "February 2020" "" "saptune note file format description"
+.TH "saptune-note" "5" "June 2020" "" "saptune note file format description"
 .SH NAME
 saptune\-note - Note definition files for saptune version \fB2\fP
 .SH DESCRIPTION
@@ -302,6 +302,8 @@ To remove the override, set the parameter to empty string.
 The section "[reminder]" contains important information and all settings of a SAP Note, which can not set by saptune. 
 
 This section is displayed at the end of the saptune options 'verify', 'simulate' and 'apply'. It will be highlighted with red color to get the attention of the customer.
+
+Sometimes this section may include lines with parameter settings commented out as the SAP Note only contains rough estimations as the settings are highly customer environment and workload dependend. Please be aware that these parameter settings can't be activated by an override file. If you need to set such parameters you need to create a 'custom' note containing these settings by using 'saptune note create'
 \" section rpm
 .SH "[rpm]"
 The section "[rpm]" is checking rpm versions on the system.

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -21,7 +21,7 @@ saptune \- Comprehensive system optimisation management for SAP solutions
 .SH DESCRIPTION
 saptune has been improved to much more better adapt the needs of an SAP environment. So at the moment we will support 2 versions of saptune.
 
-We now have our good old version 1 of saptune, which is now deprecated and will be removed with SLE15SP2, but will be kept in SLE12. It's available for compatibility reasons and to give the admin the ability to smoothly migrate his SAP system tunings to the new settings demanded by SAP. saptune version 1 will ONLY get bug fixing, but NO new notes, parameters or value changes.
+We now have our good old version 1 of saptune, which is now deprecated and will be removed with SLE15SP3, but will be kept in SLE12. It's available for compatibility reasons and to give the admin the ability to smoothly migrate his SAP system tunings to the new settings demanded by SAP. saptune version 1 will ONLY get bug fixing, but NO new notes, parameters or value changes.
 .br
 To get the man page for the version 1 of saptune please use saptune_v1(8).
 .br

--- a/ospackage/usr/share/saptune/notes/2382421
+++ b/ospackage/usr/share/saptune/notes/2382421
@@ -1,8 +1,8 @@
 # 2382421 - Optimizing the Network Configuration on HANA- and OS-Level
-# Version 36 from 16.01.2020 in English
+# Version 37 from 24.04.2020 in English
 
 [version]
-# SAP-NOTE=2382421 CATEGORY=HANA VERSION=36 DATE=16.01.2020 NAME="Optimizing the Network Configuration on HANA- and OS-Level"
+# SAP-NOTE=2382421 CATEGORY=HANA VERSION=37 DATE=24.04.2020 NAME="Optimizing the Network Configuration on HANA- and OS-Level"
 
 [sysctl]
 # This parameter limits the size of the accept backlog of a listening socket.
@@ -22,16 +22,32 @@ net.core.somaxconn = 4096
 # log, the size of the SYN backlog should be set to a reasonably high value.
 net.ipv4.tcp_max_syn_backlog = 8192
 
-# This setting adds the timestamp field to the TCP header.
-# It should already be active on most systems and is a prerequisite for
-# net.ipv4.tcp_tw_reuse and net.ipv4.tcp_tw_recycle.
-# If you are running on Microsoft Azure depending on your scenario the setting
-# of this OS parameter might not be supported. Please refer to the documentation
-# provided by Microsoft for details. In this case please adjust the OS
-# parameters as recommended by Microsoft. Moreover, please keep in mind that
-# also the two parameters net.ipv4.tcp_tw_reuse and net.ipv4.tcp_tw_recycle
-# must not be enabled in such a case.
-net.ipv4.tcp_timestamps = 1
+# net.ipv4.ip_local_port_range
+# As HANA uses a considerable number of connections for the internal
+# communication, it makes sense to have as many client ports available as
+# possible for this purpose.
+# At the same time, you need to ensure that you explicitly exclude the ports
+# used by processes and applications which bind to specific ports by adjusting
+# parameter net.ipv4.ip_local_reserved_ports accordingly.
+# If configured correctly, the SAP Host Agent takes care of adjusting this
+# parameter and setting it manually is neither recommended nor required.
+#
+# The SAP Host Agent typically increases the port range typically to 9000-65499.
+# If your port range is significantly different, for example when your lower
+# port range starts with port 40000, please check the SAP Host Agent section
+net.ipv4.ip_local_port_range =
+
+# net.ipv4.ip_local_reserved_ports
+# This parameter specifies the ports which are reserved for known applications.
+# You especially also have to specify the standard ports that are used by the
+# SAP HANA. To find out which standard ports are used by your SAP HANA please
+# refer to SAP Note 2477204.
+# Ports listed in this parameter will not be used by automatic port assignment,
+# while explicit port allocation behavior is unchanged. 
+# If configured correctly, the SAP Host Agent takes care of the standard ports
+# used by SAP HANA if the instance numbers are provided accordingly. Setting
+# this configuration manually is neither recommended nor required.
+net.ipv4.ip_local_reserved_ports =
 
 # net.ipv4.tcp_slow_start_after_idle
 # If enabled (=1), provide RFC 2861 behavior and time out the congestion
@@ -50,52 +66,6 @@ net.ipv4.tcp_timestamps = 1
 #
 net.ipv4.tcp_slow_start_after_idle = 0
 
-# net.ipv4.tcp_window_scaling
-# This setting enables the TCP window scaling.
-# On most systems it already should be active. Moreover, it is a prerequisite
-# for net.ipv4.tcp_wmem and net.ipv4.tcp_rmem.
-#
-net.ipv4.tcp_window_scaling = 1
-
-# On SAP HANA 1 Revisions <= 122.14 and on all SAP HANA 2 Revisions
-# of SPS00 you additionally need to set the following parameter:
-# net.ipv4.tcp_syn_retries
-# The default value for this parameter is 5, which translates to a timeout of
-# about 24 seconds.
-# If the system is under load, a timeout of 24 seconds can be too short and
-# lead to avoidable errors.
-# It also prevents processes to set a longer timeout. The recommended value is
-# 8, which translates into a timeout of 190 seconds.
-net.ipv4.tcp_syn_retries = 8
-
-[reminder]
-# SAP HANA Parameters - all '.ini' file changes - not handled by saptune
-#
-# net.ipv4.ip_local_port_range
-# As HANA uses a considerable number of connections for the internal
-# communication, it makes sense to have as many client ports available as
-# possible for this purpose.
-# At the same time, you need to ensure that you explicitly exclude the ports
-# used by processes and applications which bind to specific ports by adjusting
-# parameter net.ipv4.ip_local_reserved_ports accordingly.
-# If configured correctly, the SAP Host Agent takes care of adjusting this
-# parameter and setting it manually is neither recommended nor required.
-#
-# The SAP Host Agent typically increases the port range typically to 9000-65499.
-# If your port range is significantly different, for example when your lower
-# port range starts with port 40000, please check the SAP Host Agent section
-#
-# net.ipv4.ip_local_reserved_ports
-# This parameter specifies the ports which are reserved for known applications.
-# You especially also have to specify the standard ports that are used by the
-# SAP HANA. To find out which standard ports are used by your SAP HANA please
-# refer to SAP Note 2477204.
-# Ports listed in this parameter will not be used by automatic port assignment,
-# while explicit port allocation behavior is unchanged. 
-# If configured correctly, the SAP Host Agent takes care of the standard ports
-# used by SAP HANA if the instance numbers are provided accordingly. Setting
-# this configuration manually is neither recommended nor required.
-#
 # net.ipv4.tcp_wmem and net.ipv4.tcp_rmem
 # These parameters specify the minimum, default and maximum size of the TCP
 # send and receive buffer.
@@ -120,16 +90,39 @@ net.ipv4.tcp_syn_retries = 8
 #   required maximum is 1 GBit/s * 100 ms = 12.5 Mbyte, so in this case the
 #   setting should be adjusted to at least 12.5 MByte.
 #   The minimum and the default buffer size do not need to be adjusted.
-#
+net.ipv4.tcp_wmem =
+net.ipv4.tcp_rmem =
+
 # net.core.wmem_max and net.core.rmem_max
 # These settings define the maximum socket send and receive buffer size.
 # To ensure complete functionality it must be ensured that the wmem_max and
 # rmem_max values are at least the same as the respective maximum value of the
 # parameters net.ipv4.tcp_wmem and net.ipv4.tcp_rmem.
+net.core.wmem_max =
+net.core.rmem_max =
+
+# net.ipv4.tcp_window_scaling
+# This setting enables the TCP window scaling.
+# On most systems it already should be active. Moreover, it is a prerequisite
+# for net.ipv4.tcp_wmem and net.ipv4.tcp_rmem.
 #
+net.ipv4.tcp_window_scaling = 1
+
 # In landscapes where TCP timestamps are enabled please carefully evaluate if
 # the following OS settings can be applied:
 #
+# net.ipv4.tcp_timestamps
+# This setting adds the timestamp field to the TCP header.
+# It should already be active on most systems and is a prerequisite for
+# net.ipv4.tcp_tw_reuse and net.ipv4.tcp_tw_recycle.
+# If you are running on Microsoft Azure depending on your scenario the setting
+# of this OS parameter might not be supported. Please refer to the documentation
+# provided by Microsoft for details. In this case please adjust the OS
+# parameters as recommended by Microsoft. Moreover, please keep in mind that
+# also the two parameters net.ipv4.tcp_tw_reuse and net.ipv4.tcp_tw_recycle
+# must not be enabled in such a case.
+net.ipv4.tcp_timestamps = 1
+
 # net.ipv4.tcp_tw_reuse
 # This setting allows HANA to reuse a client port immediately after the
 # connection has been closed, even though the connection is still in TIME_WAIT
@@ -140,8 +133,26 @@ net.ipv4.tcp_syn_retries = 8
 # not be applied if not all hosts that use a TCP connection to communicate with
 # the HANA node have TCP timestamps enabled. Otherwise you might encounter TCP
 # connection issues after applying this configuration parameter.
+# As of SLES 15 SP2 the new option "2" is available which is also the default
+# one. In single node systems this new default value is sufficient. If you are
+# therefore running on a high enough OS version you should only consider setting
+# net.ipv4.tcp_tw_reuse = 1 in case you are running SAP HANA in a scale-out
+# setup.
 #net.ipv4.tcp_tw_reuse = 1
-#
+net.ipv4.tcp_tw_reuse =
+
+# On SAP HANA 1 Revisions <= 122.14 and on all SAP HANA 2 Revisions
+# of SPS00 you additionally need to set the following parameter:
+# net.ipv4.tcp_syn_retries
+# The default value for this parameter is 5, which translates to a timeout of
+# about 24 seconds.
+# If the system is under load, a timeout of 24 seconds can be too short and
+# lead to avoidable errors.
+# It also prevents processes to set a longer timeout. The recommended value is
+# 8, which translates into a timeout of 190 seconds.
+net.ipv4.tcp_syn_retries = 8
+
+[sysctl:os=12-SP3]
 # net.ipv4.tcp_tw_recycle
 # This setting reduces the time a connection spends in the TIME_WAIT state.
 # One precondition for it to take effect is that TCP timestamps are enabled,
@@ -155,7 +166,34 @@ net.ipv4.tcp_syn_retries = 8
 # In case you are running ABAP Application Server instances on Windows, please
 # refer to SAP Note 2789262 for further details on possible connection issues.
 #
-# Starting from SUSE Linux Enterprise Server (SLES) 12 SP4 and SLES 15 GA this
-# configuration is removed without substitution.
+# As of Linux kernel version 4.12, this configuration parameter is removed
+# without substitution. You can therefore not set it anymore for OS versions
+# running on kernel versions >= 4.12.
+# This applies as of SUSE Linux Enterprise Server (SLES) 12 SP4 and SLES 15 GA.
 #net.ipv4.tcp_tw_recycle = 1
+net.ipv4.tcp_tw_recycle =
+
+[sysctl:os=12-SP2]
+# net.ipv4.tcp_tw_recycle
+# This setting reduces the time a connection spends in the TIME_WAIT state.
+# One precondition for it to take effect is that TCP timestamps are enabled,
+# i.e. net.ipv4.tcp_timestamps = 1, which is the default on most modern systems.
+# Please note that this setting must not be applied if the HANA node has to
+# communicate with hosts behind a NAT firewall. Moreover, it must not be
+# applied if not all hosts that use a TCP connection to communicate with the
+# HANA node have TCP timestamps enabled. Otherwise you might encounter TCP
+# connection issues after applying this configuration parameter.
+#
+# In case you are running ABAP Application Server instances on Windows, please
+# refer to SAP Note 2789262 for further details on possible connection issues.
+#
+# As of Linux kernel version 4.12, this configuration parameter is removed
+# without substitution. You can therefore not set it anymore for OS versions
+# running on kernel versions >= 4.12.
+# This applies as of SUSE Linux Enterprise Server (SLES) 12 SP4 and SLES 15 GA.
+#net.ipv4.tcp_tw_recycle = 1
+net.ipv4.tcp_tw_recycle =
+
+[reminder]
+# SAP HANA Parameters - all '.ini' file changes - not handled by saptune
 #

--- a/ospackage/usr/share/saptune/scripts/upd_helper
+++ b/ospackage/usr/share/saptune/scripts/upd_helper
@@ -29,7 +29,7 @@ PARAMETERSTATEDIR=/var/lib/saptune/parameter
 
 NOTEDIR=/usr/share/saptune/notes
 NOTES2CHANGE_12to15="1984787,2578899 2205917,2684254"
-NOTES2DELETE_15="1557506"
+NOTES2DELETE_15="1557506 1275776"
 
 set_sysconfig_version() {
     # add or change SAPTUNE_VERSION string in /etc/sysconfig/saptune to "1"

--- a/sap/note/ini_sections.go
+++ b/sap/note/ini_sections.go
@@ -48,6 +48,10 @@ func OptSysctlVal(operator txtparser.Operator, key, actval, cfgval string) strin
 		// sysctl parameter not available in system
 		return ""
 	}
+	if cfgval == "" {
+		// sysctl parameter should be leave untouched
+		return ""
+	}
 	allFieldsC := strings.Fields(actval)
 	allFieldsE := strings.Fields(cfgval)
 	allFieldsS := ""

--- a/sap/note/note.go
+++ b/sap/note/note.go
@@ -191,12 +191,17 @@ func CompareNoteFields(actualNote, expectedNote Note) (allMatch bool, comparison
 					valApplyList = append(valApplyList, comparisons[ckey].ReflectMapKey)
 				}
 				if !comparisons[ckey].MatchExpectation {
+					// if the expected value is empty, the
+					// parameter value will be untouched
+					// this case should not influence the
+					// compare result
+					//
 					// a parameter, which is not supported
 					// by the system ("all:none") should not
 					// influence the compare result
 					// and grub compliance will be handled
 					// at the end of the compare
-					if actualValue.(string) != "all:none" && !strings.Contains(key.String(), "grub") {
+					if expectedValue.(string) != "" && actualValue.(string) != "all:none" && !strings.Contains(key.String(), "grub") {
 						allMatch = false
 					}
 				}

--- a/sap/note/note.go
+++ b/sap/note/note.go
@@ -223,6 +223,8 @@ func CompareNoteFields(actualNote, expectedNote Note) (allMatch bool, comparison
 // ChkGrubCompliance grub special - check compliance of alternative settings
 // only if one of these alternatives are not compliant, modify the result of
 // the compare
+// restricted to grub parameter shipped with saptune integrated notes
+// grub parameter and 'alternative' setting have to be within the same note
 func ChkGrubCompliance(comparisons map[string]FieldComparison, allMatch bool) bool {
 	// grub:numa_balancing, kernel.numa_balancing
 	if comparisons["SysctlParams[grub:numa_balancing]"].ReflectMapKey == "grub:numa_balancing" && !comparisons["SysctlParams[grub:numa_balancing]"].MatchExpectation {

--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -85,7 +85,6 @@ func GetINIFileVersionSectionEntry(fileName, entryName string) string {
 
 // chkSecTags checks, if the tags of a section are valid
 func chkSecTags(secFields []string) bool {
-	osWild := regexp.MustCompile(`(.*)-(\*)`)
 	ret := true
 	cnt := 0
 	for _, secTag := range secFields {
@@ -105,46 +104,61 @@ func chkSecTags(secFields []string) bool {
 		}
 		switch tagField[0] {
 		case "os":
-			osw := osWild.FindStringSubmatch(tagField[1])
-			if len(osw) != 3 {
-				if tagField[1] != system.GetOsVers() {
-					// os version does not match
-					system.WarningLog("os version '%s' in section definition '%v' does not match running os version '%s'. Skipping whole section with all lines till next valid section definition", tagField[1], secFields, system.GetOsVers())
-					ret = false
-				}
-			} else if osw[2] == "*" {
-				// wildcard
-				switch osw[1] {
-				case "15":
-					if !system.IsSLE15() {
-						system.WarningLog("os version '%s' in section definition '%v' does not match running os version '%s'. Skipping whole section with all lines till next valid section definition", tagField[1], secFields, system.GetOsVers())
-						ret = false
-					}
-				case "12":
-					if !system.IsSLE12() {
-						system.WarningLog("os version '%s' in section definition '%v' does not match running os version '%s'. Skipping whole section with all lines till next valid section definition", tagField[1], secFields, system.GetOsVers())
-						ret = false
-					}
-				default:
-					system.WarningLog("unsupported os version '%s' in section definition '%v'. Skipping whole section with all lines till next valid section definition", tagField[1], secFields)
-					ret = false
-				}
-			}
+			ret = chkOsTags(tagField[1], secFields)
 		case "arch":
-			chkArch := runtime.GOARCH
-			if chkArch == "amd64" {
-				// map architecture to 'uname -i' output
-				chkArch = "x86_64"
-			}
-			if tagField[1] != chkArch {
-				// arch does not match
-				system.WarningLog("system architecture '%s' in section definition '%v' does not match the architecture of the running system '%s'. Skipping whole section with all lines till next valid section definition", tagField[1], secFields, chkArch)
-				ret = false
-			}
+			ret = chkArchTags(tagField[1], secFields)
 		default:
 			system.WarningLog("skip unkown section tag '%v'.", secTag)
 			ret = false
 		}
+	}
+	return ret
+}
+
+// chkOsTags checks if the os section tag is valid or not
+func chkOsTags(tagField string, secFields []string) bool {
+	ret := true
+	osWild := regexp.MustCompile(`(.*)-(\*)`)
+	osw := osWild.FindStringSubmatch(tagField)
+	if len(osw) != 3 {
+		if tagField != system.GetOsVers() {
+			// os version does not match
+			system.WarningLog("os version '%s' in section definition '%v' does not match running os version '%s'. Skipping whole section with all lines till next valid section definition", tagField, secFields, system.GetOsVers())
+			ret = false
+		}
+	} else if osw[2] == "*" {
+		// wildcard
+		switch osw[1] {
+		case "15":
+			if !system.IsSLE15() {
+				system.WarningLog("os version '%s' in section definition '%v' does not match running os version '%s'. Skipping whole section with all lines till next valid section definition", tagField, secFields, system.GetOsVers())
+				ret = false
+			}
+		case "12":
+			if !system.IsSLE12() {
+				system.WarningLog("os version '%s' in section definition '%v' does not match running os version '%s'. Skipping whole section with all lines till next valid section definition", tagField, secFields, system.GetOsVers())
+				ret = false
+			}
+		default:
+			system.WarningLog("unsupported os version '%s' in section definition '%v'. Skipping whole section with all lines till next valid section definition", tagField, secFields)
+			ret = false
+		}
+	}
+	return ret
+}
+
+// chkArchTags checks if the os section tag is valid or not
+func chkArchTags(tagField string, secFields []string) bool {
+	ret := true
+	chkArch := runtime.GOARCH
+	if chkArch == "amd64" {
+		// map architecture to 'uname -i' output
+		chkArch = "x86_64"
+	}
+	if tagField != chkArch {
+		// arch does not match
+		system.WarningLog("system architecture '%s' in section definition '%v' does not match the architecture of the running system '%s'. Skipping whole section with all lines till next valid section definition", tagField, secFields, chkArch)
+		ret = false
 	}
 	return ret
 }


### PR DESCRIPTION
add a sanity check to detect Note definition files which do not exist anymore, because they were renamed or deleted, but without reverting them before.
saptune will now print an error message, remove the Note from the tracking variables in /etc/sysconfig/saptune and try to revert the related parameter settings.
(bsc#1149205)

check, if json input file is empty and handle some left-over files from the migration from saptune v1 to saptune v2
(bsc#1167618)

To support system parameters only relevant for specific SLES releases, service packs and/or hardware architectures saptune now supports 'tagged' sections inside the Note definition files.
(jsc#PM-1862)

new kernel requirement for Power added to SAP-Note 2205917, updated to Version 58
(bsc#1167416)

SAP Note 2382421 updated to Version 37
and move all 'not-well-defined' parameters from the 'reminder' section into the 'sysctl' section, but with 'empty' values.
Now it's possible to use an override file instead of an 'extra' file to adapt the values to the customers needs
(bsc#1170672)

support empty parameter values in the Note definition files and not only in the override file.
This is needed for the support of SAP Notes like 2382421, so that the customer is able to simply use an override file to define some special parameters instead of using a customer specific Note definition file.
needed for bsc#1170672

report an 'error' instead of 'info' and set the exit code to '1', if we reject the apply of a solution
(bsc#1167213)
