### PR TITLE
remove usage of tuned from saptune (jsc#SLE-6457)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -127,9 +127,9 @@ func (app *App) removeFromConfig(noteID string) {
 func (app *App) IsNoteApplied(noteID string) (string, bool) {
 	rval := ""
 	ret := false
-	// ANGI TODO - is check against state file still ok or should
-	// the check switched to first check NOTE_APPLY_ORDER and later
-	// the state file
+	// check against state file first is still ok, don't change
+	// because of TuneAll/RevertAll to cover system reboot
+	// NoteApplyOrder is filled, but state files are removed
 	sfile, err := os.Stat(app.State.GetPathToNote(noteID))
 	if err == nil {
 		// state file for note already exists
@@ -183,7 +183,7 @@ func (app *App) NoteSanityCheck() error {
 		fileName := fmt.Sprintf("/var/lib/saptune/sections/%s.sections", note)
 		// check, if empty state file exists
 		if content, err := ioutil.ReadFile(app.State.GetPathToNote(note)); err == nil && len(content) == 0 {
-			 // remove empty state file
+			// remove empty state file
 			_ = app.State.Remove(note)
 			if _, err := os.Stat(fileName); err == nil {
 				// section file exists, remove
@@ -362,6 +362,10 @@ func (app *App) TuneSolution(solName string) (removedExplicitNotes []string, err
 // TuneAll tune for all currently enabled solutions and notes.
 func (app *App) TuneAll() error {
 	for _, noteID := range app.NoteApplyOrder {
+		if _, err := os.Stat(app.State.GetPathToNote(noteID)); err == nil {
+			// state file for note already exists
+			continue
+		}
 		if _, err := app.GetNoteByID(noteID); err != nil {
 			_ = system.ErrorLog(err.Error())
 			continue
@@ -467,7 +471,7 @@ func (app *App) RevertSolution(solName string) error {
 }
 
 // RevertAll revert all tuned parameters (both solutions and additional notes),
-// and clear stored states.
+// and clear stored states, but NOT NoteApplyOrder.
 func (app *App) RevertAll(permanent bool) error {
 	allErrs := make([]error, 0, 0)
 

--- a/development.md
+++ b/development.md
@@ -42,3 +42,29 @@ clean up when finished with your tests
 	docker stop travis-st-ci
 	docker rm travis-st-ci
 
+## build the saptune package:
+saptune is build on ibs (and not obs, as saptune is not available on Factory)
+
+branch from a maintained project (see https://maintenance.suse.de/maintained)
+	osc -A https://api.suse.de bco -M SUSE:SLE-12-SP2:Update saptune
+
+build the source archive from the github repository (something like 'tar -czvf ../saptune-\<release\>.tgz .') and move it to your obs directory
+Or - if the new version is already created in github -
+copy the archive from https://github.com/SUSE/saptune/releases to your obs directory
+
+change the saptune.spec file, at least the version field
+
+change the saptune.changes file.
+	first line should be '- update version of saptune v2 to \<new version\>'
+	Add a description of the changes and do not forget to add the bsc# or jsc# reference to these changes.
+	And don't forget the line length restriction :-)
+	Important - changes of SAP Notes need to be mentioned in the changes file
+
+change the \_service file and add the new version number
+
+change the \_servicedata and add the commit id
+
+commit the changes to the obs sub project and check the build
+
+test the resulting package (initial install and update installations) before submitting a maintenance request.
+

--- a/main.go
+++ b/main.go
@@ -100,8 +100,14 @@ var footnote1 = footnote1X86                     // set 'unsupported' footnote r
 var debugSwitch = os.Getenv("SAPTUNE_DEBUG")     // Switch Debug on ("1") or off ("0" - default)
 var verboseSwitch = os.Getenv("SAPTUNE_VERBOSE") // Switch verbose mode on ("on" - default) or off ("off")
 var solutionSelector = runtime.GOARCH
+
+// SaptuneVersion is the saptune version from /etc/sysconfig/saptune
 var SaptuneVersion = ""
+
+// RPMVersion is the package version from package build process
 var RPMVersion = "undef"
+
+// RPMDate is the date of package build
 var RPMDate = "undef"
 
 func main() {
@@ -351,10 +357,10 @@ func ServiceActionStatus(writer io.Writer, tuneApp *app.App) {
 	if len(tuneApp.TuneForSolutions) > 0 || len(tuneApp.TuneForNotes) > 0 {
 		fmt.Fprintf(writer, "The system has been tuned for the following solutions and notes:")
 		for _, sol := range tuneApp.TuneForSolutions {
-			fmt.Fprintf(writer, "\t" + sol)
+			fmt.Fprintf(writer, "\t"+sol)
 		}
 		for _, noteID := range tuneApp.TuneForNotes {
-			fmt.Fprintf(writer, "\t" + noteID)
+			fmt.Fprintf(writer, "\t"+noteID)
 		}
 		// list order of enabled notes
 		tuneApp.PrintNoteApplyOrder(writer)

--- a/ospackage/etc/sysconfig/saptune
+++ b/ospackage/etc/sysconfig/saptune
@@ -1,6 +1,6 @@
 ## Path:           SAP/System Tuning/General
 ## Description:    Global settings for saptune - the comprehensive optimisation management utility for SAP solutions
-## ServiceRestart: tuned
+## ServiceRestart: saptune
 
 ## Type:    string
 ## Default: ""
@@ -28,7 +28,7 @@ TUNE_FOR_NOTES=""
 NOTE_APPLY_ORDER=""
 
 ## Type:    string
-## Default: "2"
+## Default: "3"
 #
 # Version of saptune
-SAPTUNE_VERSION="2"
+SAPTUNE_VERSION="3"

--- a/ospackage/logrotate/saptune
+++ b/ospackage/logrotate/saptune
@@ -1,0 +1,9 @@
+/var/log/saptune/saptune.log {
+    compress
+    copytruncate
+    dateext
+    rotate 99
+    size +4096k
+    notifempty
+    missingok
+}

--- a/ospackage/man/saptune-migrate.7
+++ b/ospackage/man/saptune-migrate.7
@@ -1,5 +1,5 @@
 .\"/*
-.\" * Copyright (c) 2017-2019 SUSE LLC.
+.\" * Copyright (c) 2017-2020 SUSE LLC.
 .\" * All rights reserved
 .\" * Authors: Sören Schmidt, Angela Briel
 .\" *
@@ -15,9 +15,9 @@
 .\" */
 .\"
 
-.TH "saptune-migrate" "7" "June 2019" "" "migration from saptune version 1 to saptune version 2"
+.TH "saptune-migrate" "7" "July 2020" "" "migration from saptune version 1 to saptune version 2/3"
 .SH NAME
-saptune\-migration \- migration of saptune version 1 to saptune version 2
+saptune\-migration \- migration of saptune version 1 to saptune version 2/3
 
 .SH DESCRIPTION
 As there are too many logical and structural changes between the saptune versions 1 and 2 the migration has to be planned carefully and performed manually.
@@ -28,7 +28,7 @@ The section MIGRATION will guide you through it step by step. The sections SOLUT
 
 .SH FILES TO REMOVE AFTER MIGRATION
 
-The package update from version 1 to version 2 creates or copies some files during post install to allows this smooth migration. But after finishing the migration these files should be removed manually.
+The package update from version 1 to version 2/3 creates or copies some files during post install to allows this smooth migration. But after finishing the migration these files should be removed manually.
 
 .BI /etc/saptune/extra/SAP_BOBJ-SAP_Business_OBJects.conf
 .PP
@@ -42,7 +42,7 @@ and the directory
 
 .SH IMPORTANT
 
-\fBOnly a migration from version 1 to version 2 is supported!\fP
+\fBOnly a migration from version 1 to version 2/3 is supported!\fP
 
 .SH SOLUTIONS
 
@@ -51,7 +51,7 @@ The following solutions are shipped:
 tab(:) box;
 c | l | l
 l | l | l.
-SOLUTION:Version 1:Version 2
+SOLUTION:Version 1:Version 2/3
 _
 BOBJ:T{
 1275776* 1557506** 1984787 SAP_BOBJ
@@ -100,9 +100,9 @@ T}:T{
 T}
 .TE
 
-*   SAP Note \fB1275776\fP has been rewritten and therefore removed in version 2.
+*   SAP Note \fB1275776\fP has been rewritten and therefore removed in version 2/3.
 .HP 4
-** SAP Note \fB1557506\fP has been removed from the solutions in version 2 because it is only required in a few workload specific use cases.
+** SAP Note \fB1557506\fP has been removed from the solutions in version 2/3 because it is only required in a few workload specific use cases.
 .PP
 Note: In version 1 the solutions BOBJ and SAP-ASE were not available on ppc64 little-endian.
 
@@ -131,13 +131,13 @@ l | l | l | l.
 SAP Note:v1:v2:comment
 _
 941735:no:yes:T{
-newly introduced in version 2
+newly introduced in version 2/3
 T}
 _
 1275776:yes*:no:T{
 This SAP Note has been rewritten and no longer contains any settings.
 .br
-recommendations and therefore has been removed from version 2.
+recommendations and therefore has been removed from version 2/3.
 .br
 The SAP Note is still part of version 1 with the former recommendations.
 T}
@@ -166,7 +166,7 @@ To replace 1275776, you can use:
 T}
 _
 1410736:no:yes:T{
-newly introduced in version 2
+newly introduced in version 2/3
 T}
 _
 1557506:yes:yes:T{
@@ -174,19 +174,19 @@ In version 2 only the HANA formula is used.
 T}
 _
 1680803:no:yes:T{
-newly introduced in version 2
+newly introduced in version 2/3
 T}
 _
 1771258:no:yes:T{
-newly introduced in version 2
+newly introduced in version 2/3
 T}
 _
 1805750:no:yes:T{
-newly introduced in version 2
+newly introduced in version 2/3
 T}
 _
 1980196:no:yes:T{
-newly introduced in version 2
+newly introduced in version 2/3
 T}
 _
 1984787:yes**:yes:T{
@@ -201,19 +201,19 @@ _
 2205917:yes*:yes:T{
 In version 1 the configuration was partially hard coded and partially done by tuned (always enabled regardless if note was active or not!)
 .br
-In version 2 this done by saptune itself.
+In version 2/3 this done by saptune itself.
 T}
 _
 2382421:no:yes:T{
-newly introduced in version 2
+newly introduced in version 2/3
 T}
 _
 2534844:no:yes:T{
-newly introduced in version 2
+newly introduced in version 2/3
 T}
 _
 SAP_ASE:yes:no:T{
-Has been replaced by \fB1680803\fP in version 2. The same defaults, but 1680803 also covers
+Has been replaced by \fB1680803\fP in version 2/3. The same defaults, but 1680803 also covers
 .br
 net.ipv4.tcp_keepalive_intvl and
 .br
@@ -241,7 +241,7 @@ In version 1 part of configuration was hard coded or configurable via /etc/sysco
 .br
 Due to tuned CPU tuning (see SAP Note 2205917) was always active.
 
-In version 2 everything can be configured via an override file in /etc/saptune/override/.
+In version 2/3 everything can be configured via an override file in /etc/saptune/override/.
 .br
 For details and defaults read the configuration in the corresponding Note definition files in /usr/share/saptune/notes/.
 
@@ -297,23 +297,23 @@ Version 1 of saptune uses the following configurations:
 
 .SS Migration Planning:
 
-Before starting the migration, familiarize yourself with saptune version 2.
+Before starting the migration, familiarize yourself with saptune version 2/3.
 Please read the man pages of saptune_v2(8) and saptune-note(5).
 .br
 
-Solutions of version 2 can encompass more SAP Notes then in version 1.
+Solutions of version 2/3 can encompass more SAP Notes then in version 1.
 .br
 Please check section SOLUTIONS for details. You might want to deselect some SAP Notes, change or disable parameters.
 
-SAP notes are more comprehensive in version 2.
+SAP notes are more comprehensive in version 2/3.
 .br
 Please check section SAP NOTES for details. You might want to change or disable parameters.
 
-Some SAP notes have been removed in version 2.
+Some SAP notes have been removed in version 2/3.
 .br
 Please check section SAP NOTES for details. You might want to add your own configuration file.
 
-In version 1 multiple solutions can be applied, in saptune version 2 only one at the same time.
+In version 1 multiple solutions can be applied, in saptune version 2/3 only one at the same time.
 .br
 If you had multiple solutions in the past, choose the most suitable one and add additional notes.
 
@@ -324,11 +324,11 @@ Version 2 will set the parameter always to the configured value, no matter the c
 
 .SS Migration Steps:
 
-The following steps describe the easisest way to migrate from version 1 to version 2.
+The following steps describe the easisest way to migrate from version 1 to version 2/3.
 
 .nr step 1 1
 .IP \n[step]. 4
-Determine current solutions and SAP Notes for version 1 and plan the ones for version 2.
+Determine current solutions and SAP Notes for version 1 and plan the ones for version 2/3.
 
     Use these commands to get a list of selected solutions and notes.
 
@@ -336,11 +336,11 @@ Determine current solutions and SAP Notes for version 1 and plan the ones for ve
         saptune note list
 
     Use the sections SOLUTIONS and SAP NOTES above to familiarize yourself with the changes and create a list
-    of the solution and SAP Notes you are going to use with version 2.
+    of the solution and SAP Notes you are going to use with version 2/3.
 .IP \n+[step].
 (Skip, if saptune defaults are acceptable) Check each chosen SAP Note and former configuration.
 
-    Verify that the shipped defaults of version 2 meet your requirements.
+    Verify that the shipped defaults of version 2/3 meet your requirements.
 
     \fBSince saptune is running in version 1 prior to migration you cannot use 'saptune note show' yet. Please check the files in /usr/share/saptune/notes/ directly.\fP
 
@@ -368,11 +368,11 @@ Change saptune version variable to "2".
 Remove the configuration directory /etc/tuned/saptune/.
 
     During the package upgrade a comatibility configuration /etc/tuned/saptune/ was created, which
-    has to be removed to run version 2 properly.
+    has to be removed to run version 2/3 properly.
 
     It is possible that it was created manually in the past to alter the configuration.
     In this case verify the configuration and extend your future saptune configuration (step 2).
-    Saptune version 2 performs all tuning settings itself and no longer uses tuned for tuning.
+    Saptune version 2/3 performs all tuning settings itself and no longer uses tuned for tuning.
 
     The line "#stv1tov2#" is in inidicator that the configuration file was created by the update process
     and not manually.

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -15,7 +15,7 @@
 .\" */
 .\" 
 
-.TH "saptune-note" "5" "June 2020" "" "saptune note file format description"
+.TH "saptune-note" "5" "July 2020" "" "saptune note file format description"
 .SH NAME
 saptune\-note - Note definition files for saptune version \fB2\fP
 .SH DESCRIPTION
@@ -374,7 +374,7 @@ Concerning \fBsysstat.service\fP please be in mind: A running sysstat service ca
 .br
 See sar(1), sa2(8), sa1(8) for more information
 
-If a service is enabled or disabled by default or admin choice, saptune will NOT disable or enable this service. It will only start/stop the service. If such a service is started by systemd during a system reboot \fBafter\fP the start of tuned.service it will be possible that a service is stopped/running even if it was started/stopped by saptune.
+If a service is enabled or disabled by default or admin choice, saptune will NOT disable or enable this service. It will only start/stop the service. If such a service is started by systemd during a system reboot \fBafter\fP the start of saptune.service it will be possible that a service is stopped/running even if it was started/stopped by saptune.
 \" section sysctl
 .SH "[sysctl]"
 The section "[sysctl]" can be used to modify kernel parameters. The parameters available are those listed under /proc/sys/.
@@ -406,7 +406,7 @@ But please do not change the files located here. You will lose all your changes 
 
 .SH "SEE ALSO"
 .LP
-saptune-migrate(7) saptune(8) saptune_v1(8) saptune_v2(8) tuned(8) tuned-adm(8)
+saptune-migrate(7) saptune(8) saptune_v1(8) saptune_v2(8)
 
 .SH AUTHOR
 .NF

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -1,5 +1,5 @@
 .\"/*
-.\" * Copyright (c) 2017-2019 SUSE LLC.
+.\" * Copyright (c) 2017-2020 SUSE LLC.
 .\" * All rights reserved
 .\" * Authors: Soeren Schmidt, Angela Briel
 .\" *
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\"
-.TH saptune "8" "June 2019" "" "System Optimisation For SAP"
+.TH saptune "8" "July 2020" "" "System Optimisation For SAP"
 .SH NAME
 saptune \- Comprehensive system optimisation management for SAP solutions
 
@@ -25,13 +25,13 @@ We now have our good old version 1 of saptune, which is now deprecated and will 
 .br
 To get the man page for the version 1 of saptune please use saptune_v1(8).
 .br
-To get more information about the migration path from saptune version 1 to saptune version 2 please see saptune-migrate(7)
+To get more information about the migration path from saptune version 1 to saptune version 3 please see saptune-migrate(7)
 
-Our new improved saptune version 2 and the new configuration possibilities and syntax are described in saptune_v2(8).
+Our new improved saptune version 3 and the new configuration possibilities and syntax are described in saptune_v2(8).
 
 .SH SEE ALSO
 .NF
-saptune-note(5) saptune-migrate(7) saptune_v1(8) saptune_v2(8) tuned(8) tuned-adm(8)
+saptune-note(5) saptune-migrate(7) saptune_v1(8) saptune_v2(8)
 
 .SH AUTHOR
 .NF

--- a/ospackage/man/saptune_v2.8
+++ b/ospackage/man/saptune_v2.8
@@ -14,15 +14,20 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\"
-.TH saptune "8" "January 2020" "" "System Optimisation For SAP"
+.TH saptune "8" "July 2020" "" "System Optimisation For SAP"
 .SH NAME
-saptune \- Comprehensive system optimisation management for SAP solutions (\fBVersion 2\fP)
+saptune \- Comprehensive system optimisation management for SAP solutions (\fBVersion 2 and 3\fP)
 
 ATTENTION: If you still use version \fB1\fP of saptune please refer to man page  saptune_v1(8) instead.
 
 .SH SYNOPSIS
+ATTENTION: deprecated
+.br
 \fBsaptune daemon\fP
 [ start | status | stop ]
+
+\fBsaptune service\fP
+[ start | status | stop | enable | disable | enablestart | stopdisable ]
 
 \fBsaptune note\fP
 [ list | verify | enabled ]
@@ -58,21 +63,44 @@ saptune does not only set kernel values (like sysctl does), but also values like
 .PP
 /proc/sys/, /proc/sys/vm/, /proc/sys/kernel, /proc/sys/fs, /sys/block/*/queue/scheduler and /sys/block/*/queue/nr_requests, /sys/devices/system/cpu/*/cpufreq/scaling_governor, /sys/devices/system/cpu/*/cpuidle/state*/latency, /sys/devices/system/cpu/*/cpuidle/state*/disable, /dev/shm, /etc/security/limits.d/, /etc/systemd/logind.conf.d/ and some others.
 
-saptune fully integrates with tuned(8), the tuned-profile name associated with this utility is "saptune".
+saptune does no longer use tuned(8) to restart after a system reboot. It is using it's own systemd service named "saptune.service".
 
 We decided to have only ONE solution applied, but multiple Notes. Each Note is applied exactly once.
 
-.SH DAEMON ACTIONS
+.SH DAEMON ACTIONS - ATTENTION: deprecated
 .SS
 .TP
 .B start
-Start tuned(8) daemon, set tuning profile to "saptune", and apply a set of optimisations to the system, if solutions or notes were selected during a previous call of saptune. The daemon will be automatically activated upon system boot.
+As saptune no longer uses tuned, this action is internally linked to 'saptune service start'. See description below
 .TP
 .B status
-Report the status of tuned(8) daemon and whether it is using the correct profile.
+As saptune no longer uses tuned, this action is internally linked to 'saptune service status'. See description below
 .TP
 .B stop
-Stop tuned(8) daemon, and revert all optimisations that were previously applied by saptune. The daemon will no longer automatically activate upon boot.
+As saptune no longer uses tuned, this action is internally linked to 'saptune service stop'. See description below
+
+.SH SERVICE ACTIONS
+.SS
+.TP
+.B start
+Start saptune service and apply a set of optimisations to the system, if solutions or notes were selected during a previous call of saptune. If the service is enabled, the tuning will be automatically activated upon system boot.
+.TP
+.B status
+Report the status of saptune service, the saptune version from \fI/etc/sysconfig/saptune\fP and the rpm version and build date from the current installed saptune package.
+.TP
+.B stop
+Stop saptune service and revert all optimisations that were previously applied by saptune. If the service is disabled, the tuning will no longer automatically activate upon boot.
+.B enable
+Enables the saptune service. To activate the tuning, the saptune service needs to be started. But as the service is now enabled, the tuning will automatically activated upon system boot.
+.TP
+.B disable
+Disable the saptune service. To revert all optimisations that were previously applied by saptune, the saptune service needs to be stopped. But as the service is now disabled, the tuning will no longer automatically activated upon system boot.
+.TP
+.B enablestart
+Enables and start the saptune service and apply a set of optimisations to the system, if solutions or notes were selected during a previous call of saptune. As the service is now enabled, the tuning will automatically activated upon system boot.
+.TP
+.B stopdisable
+Stop and disable the saptune service and revert all optimisations that were previously applied by saptune. As the service is now disabled, the tuning will no longer automatically activated upon system boot.
 
 .SH NOTE ACTIONS
 Note denotes either a SAP Note, a vendor specific tuning definition or SUSE recommendation article.
@@ -224,7 +252,6 @@ Note definition files shipped by the saptune package - so called \fIinternal\fP 
 ATTENTION:
 .br
 If the Note is already applied, the command will be terminated with the information, that the Note first needs to be reverted before it can be deleted.
-.TP
 
 .SH SOLUTION ACTIONS
 A solution is a collection of one or more Notes. Activation of a solution will activate all associated Notes.
@@ -370,7 +397,7 @@ saptune now sets the values read from the Note definition files irrespective of 
 
 .SH SEE ALSO
 .NF
-saptune-note(5) saptune-migrate(7) saptune(8) saptune_v1(8) tuned(8) tuned-adm(8)
+saptune-note(5) saptune-migrate(7) saptune(8) saptune_v1(8)
 
 .SH AUTHOR
 .NF

--- a/ospackage/svc/saptune.service
+++ b/ospackage/svc/saptune.service
@@ -1,16 +1,12 @@
 [Unit]
-Description=Optimise system for running SAP workloads (daemon)
-After=syslog.target systemd-sysctl.service network.target
+Description=Optimise system for running SAP workloads
+After=syslog.target systemd-sysctl.service network.target tuned.service
 
 [Service]
-Type=simple
-ExecStart=/usr/sbin/saptune daemon
-User=root
-Group=root
-WorkingDirectory=/
-PrivateTmp=true
-RestartSec=5
-Restart=on-abort
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/sbin/saptune service apply
+ExecStop=/usr/sbin/saptune service revert
 
 [Install]
 WantedBy=multi-user.target

--- a/ospackage/usr/share/bash-completion/completions/saptune.completion
+++ b/ospackage/usr/share/bash-completion/completions/saptune.completion
@@ -1,6 +1,7 @@
-# v1.3
+# v1.4
 #
 #   saptune daemon [ start | status | stop ]
+#   saptune service [ start | status | stop | enable | disable | enablestart | stopdisable ]
 #   saptune note [ list | verify | enabled ]
 #   saptune note [ apply | simulate | verify | customise | revert | create | show | delete ] NoteID
 #   saptune note rename NoteID NoteID
@@ -20,11 +21,13 @@ _saptune() {
     
     case ${COMP_CWORD} in 
 
-        1)  opts="daemon solution note revert version --version help"
+        1)  opts="daemon service solution note revert version --version help"
             ;;
         
         2)  case "${prev}" in
                 daemon)     opts="start status stop"
+                            ;;
+                service)    opts="start status stop enable disable enablestart stopdisable"
                             ;;
                 solution)   opts="list verify apply simulate revert enabled"
                             ;;

--- a/ospackage/usr/share/saptune/notes/1984787
+++ b/ospackage/usr/share/saptune/notes/1984787
@@ -61,8 +61,6 @@ util-linux-systemd 12-SP1 2.25-22.1
 # specified at a time. When one sysctl is written it is immediately taken into
 # account to evaluate the dirty memory limits and the other appears as 0 when
 # read.
-# Note: when changing the tuned profile or switching off tuned, both values
-# will be set back to their previous settings.
 # Note: the minimum value allowed for dirty_bytes is two pages (in bytes); any
 # value lower than this limit will be ignored and the old configuration will be
 # retained.
@@ -78,8 +76,6 @@ vm.dirty_bytes=629145600
 # Only one of them may be specified at a time. When one sysctl is written it is
 # immediately taken into account to evaluate the dirty memory limits and the
 # other appears as 0 when read.
-# Note: when changing the tuned profile or switching off tuned, both values
-# will be set back to their previous settings.
 #
 # vm.dirty_background_bytes should be set to 314572800 (see TID_7010287)
 #

--- a/ospackage/usr/share/saptune/notes/2382421
+++ b/ospackage/usr/share/saptune/notes/2382421
@@ -1,8 +1,8 @@
 # 2382421 - Optimizing the Network Configuration on HANA- and OS-Level
-# Version 37 from 24.04.2020 in English
+# Version 38 from 29.06.2020 in English
 
 [version]
-# SAP-NOTE=2382421 CATEGORY=HANA VERSION=37 DATE=24.04.2020 NAME="Optimizing the Network Configuration on HANA- and OS-Level"
+# SAP-NOTE=2382421 CATEGORY=HANA VERSION=38 DATE=29.06.2020 NAME="Optimizing the Network Configuration on HANA- and OS-Level"
 
 [sysctl]
 # This parameter limits the size of the accept backlog of a listening socket.
@@ -13,6 +13,7 @@
 # tcp_backlog, tcp_backlog will be silently truncated to the value set for
 # net.core.somaxconn. Therefore, you need to ensure that net.core.somaxconn
 # is always set to a value equal to or greater than tcp_backlog.
+# net.core.somaxconn >= 4096
 net.core.somaxconn = 4096
 
 # This is the size of the SYN backlog.
@@ -20,6 +21,7 @@ net.core.somaxconn = 4096
 # connection requests are sent in a short timeframe and to prevent a
 # corresponding warning about a potential SYN flooding attack in the system
 # log, the size of the SYN backlog should be set to a reasonably high value.
+# net.ipv4.tcp_max_syn_backlog >= 8192
 net.ipv4.tcp_max_syn_backlog = 8192
 
 # net.ipv4.ip_local_port_range

--- a/ospackage/usr/share/saptune/notes/2578899
+++ b/ospackage/usr/share/saptune/notes/2578899
@@ -48,8 +48,6 @@ tcsh 15-SP1 6.20.00-4.9.1
 # specified at a time. When one sysctl is written it is immediately taken into
 # account to evaluate the dirty memory limits and the other appears as 0 when
 # read.
-# Note: when changing the tuned profile or switching off tuned, both values
-# will be set back to their previous settings.
 # Note: the minimum value allowed for dirty_bytes is two pages (in bytes); any
 # value lower than this limit will be ignored and the old configuration will be
 # retained.
@@ -65,8 +63,6 @@ vm.dirty_bytes=629145600
 # Only one of them may be specified at a time. When one sysctl is written it is
 # immediately taken into account to evaluate the dirty memory limits and the
 # other appears as 0 when read.
-# Note: when changing the tuned profile or switching off tuned, both values
-# will be set back to their previous settings.
 #
 # vm.dirty_background_bytes should be set to 314572800 (see TID_7010287)
 #

--- a/ospackage/usr/share/saptune/scripts/upd_helper
+++ b/ospackage/usr/share/saptune/scripts/upd_helper
@@ -26,6 +26,7 @@ CUSTOM_TUNED_CONF=/etc/tuned/saptune/tuned.conf
 OVERRIDEDIR=/etc/saptune/override
 SAVEDSTATEDIR=/var/lib/saptune/saved_state
 PARAMETERSTATEDIR=/var/lib/saptune/parameter
+SECTIONSTATEDIR=/var/lib/saptune/sections
 
 NOTEDIR=/usr/share/saptune/notes
 NOTES2CHANGE_12to15="1984787,2578899 2205917,2684254"
@@ -34,10 +35,10 @@ NOTES2DELETE_15="1557506 1275776"
 set_sysconfig_version() {
     # add or change SAPTUNE_VERSION string in /etc/sysconfig/saptune to "1"
     if (grep "SAPTUNE_VERSION[[:space:]]*=" $SAPTUNE_SYSCONFIG >/dev/null 2>&1); then
-        sed -i 's/SAPTUNE_VERSION="2"/SAPTUNE_VERSION="1"/' $SAPTUNE_SYSCONFIG
+        sed -i 's/SAPTUNE_VERSION="[23]"/SAPTUNE_VERSION="1"/' $SAPTUNE_SYSCONFIG
     else
         echo "missing SAPTUNE_VERSION string in /etc/sysconfig/saptune. Appending ..."
-        echo -e "## Type:    string\n## Default: \"2\"\n#\n# Version of saptune\nSAPTUNE_VERSION=\"1\"\n" >> $SAPTUNE_SYSCONFIG
+        echo -e "## Type:    string\n## Default: \"3\"\n#\n# Version of saptune\nSAPTUNE_VERSION=\"1\"\n" >> $SAPTUNE_SYSCONFIG
     fi
 }
 
@@ -54,7 +55,10 @@ create_tuned_conf() {
 #\
 # for compatibility support of saptune version 1 the tuned config script\
 # /usr/lib/tuned/saptune/tuned.conf is copied to /etc/tuned/saptune/tuned.conf\
-# during the saptune package update from version 1 to version 2\
+# during the saptune package update from rpm version 1* to version 3*\
+# ATTENTION: saptune version 3 (SAPTUNE_VERSION=3 in /etc/sysconfig/saptune)\
+# does not use tuned service any longer\
+# Please migrate to saptune version 3 as soon as possible\
 #\
 ' $CUSTOM_TUNED_CONF
         # add cpu section
@@ -150,6 +154,12 @@ change_note_names() {
                     sed -i "s/$srch_pat/$new_pat/g" "$pfile"
                 fi
             done
+
+            # 5. check existence of section state file and change name
+            if [ -f ${SECTIONSTATEDIR}/"$oldNote".sections ]; then
+                echo "### mv old section state file to the new name"
+                mv ${SECTIONSTATEDIR}/"$oldNote".sections ${SECTIONSTATEDIR}/"$newNote".sections
+            fi
         #else
             # if both note files are available - not possible, rpm should cover
             # if both note files NOT available - not possible, rpm should cover
@@ -198,9 +208,16 @@ delete_notes() {
 
             # 3. check existence of saved_state file and remove file
             # normally shouldn't be available
-            if [ -f ${SAVEDSTATEDIR}/"$oldNote" ]; then
+            if [ -f ${SAVEDSTATEDIR}/"$delnote" ]; then
                 echo "WARNING: old saved state file '${SAVEDSTATEDIR}/$delnote' found, removing superfluous file."
                 rm ${SAVEDSTATEDIR}/"$delnote"
+            fi
+
+            # 4. check existence of sections state file and remove file
+            # normally shouldn't be available
+            if [ -f ${SECTIONSTATEDIR}/"$delnote".sections ]; then
+                echo "WARNING: old sections state file '${SECTIONSTATEDIR}/${delnote}.sections' found, removing superfluous file."
+                rm ${SECTIONSTATEDIR}/"$delnote".sections
             fi
         fi
     done
@@ -220,18 +237,18 @@ cleanup_savestates() {
 case "$upd_opt" in
 v1tov2pi)
     # called from the postinstall script of saptune, if installation was an
-    # update from saptune version 1 to version 2
+    # update from saptune version 1 to version 2/3
     set_sysconfig_version
     create_tuned_conf
     ;;
 v1tov2pt)
     # called from the posttrans script of saptune, if installation was an
-    # update from saptune version 1 to version 2
+    # update from saptune version 1 to version 2/3
     get_back_extra_ASE_BOBJ
     ;;
 sle12to15pt)
     # called from the posttrans script of saptune, if installation was an
-    # update from saptune version 2 to version 2
+    # update from saptune version 2/3 to version 2/3
     change_note_names
     delete_notes
     ;;

--- a/run_travis_tst.sh
+++ b/run_travis_tst.sh
@@ -5,14 +5,6 @@ echo "zypper in ..."
 # additional libs needed to get 'tuned' working
 zypper -n --gpg-auto-import-keys ref && zypper -n --gpg-auto-import-keys in glib2 glib2-tools libgio-2_0-0 libglib-2_0-0 libgmodule-2_0-0 libgobject-2_0-0 go1.10 go rpcbind cpupower uuidd polkit tuned sysstat
 
-# setup saptune service
-cp /app/ospackage/svc/saptune.service /usr/lib/systemd/system
-if [ ! -f /usr/sbin/rcsaptune ]; then
-	ln -s /usr/sbin/service /usr/sbin/rcsaptune
-fi
-cp /app/saptune /usr/sbin/saptune
-mkdir /var/log/saptune
-
 # dbus can not be started directly, only by dependency - so start 'tuned' instead
 /bin/systemctl start tuned
 systemctl --no-pager status

--- a/run_travis_tst.sh
+++ b/run_travis_tst.sh
@@ -5,6 +5,14 @@ echo "zypper in ..."
 # additional libs needed to get 'tuned' working
 zypper -n --gpg-auto-import-keys ref && zypper -n --gpg-auto-import-keys in glib2 glib2-tools libgio-2_0-0 libglib-2_0-0 libgmodule-2_0-0 libgobject-2_0-0 go1.10 go rpcbind cpupower uuidd polkit tuned sysstat
 
+# setup saptune service
+cp /app/ospackage/svc/saptune.service /usr/lib/systemd/system
+if [ ! -f /usr/sbin/rcsaptune ]; then
+	ln -s /usr/sbin/service /usr/sbin/rcsaptune
+fi
+cp /app/saptune /usr/sbin/saptune
+mkdir /var/log/saptune
+
 # dbus can not be started directly, only by dependency - so start 'tuned' instead
 /bin/systemctl start tuned
 systemctl --no-pager status
@@ -17,14 +25,18 @@ echo "PATH is $PATH, GOPATH is $GOPATH, TRAVIS_HOME is $TRAVIS_HOME"
 export TRAVIS_HOME=/home/travis
 mkdir -p ${TRAVIS_HOME}/gopath/src/github.com/SUSE
 cd ${TRAVIS_HOME}/gopath/src/github.com/SUSE
-ln -s /app saptune
+if [ ! -f saptune ]; then
+	ln -s /app saptune
+fi
 export GOPATH=${TRAVIS_HOME}/gopath
 export PATH=${TRAVIS_HOME}/gopath/bin:$PATH
 export TRAVIS_BUILD_DIR=${TRAVIS_HOME}/gopath/src/github.com/SUSE/saptune
 
 mkdir -p /etc/saptune/override
 mkdir -p /usr/share/saptune
-ln -s /app/testdata/saptune-test-solutions /usr/share/saptune/solutions
+if [ ! -f /usr/share/saptune/solutions ]; then
+	ln -s /app/testdata/saptune-test-solutions /usr/share/saptune/solutions
+fi
 
 echo "go environment:"
 go env

--- a/sap/solution/solution.go
+++ b/sap/solution/solution.go
@@ -2,8 +2,6 @@ package solution
 
 /*
 Solutions are collections of relevant SAP notes, all of which are applicable to specific SAP products.
-
-A system can be tuned for more than one solutions at a time.
 */
 
 import (

--- a/system/daemon.go
+++ b/system/daemon.go
@@ -83,6 +83,15 @@ func SystemctlDisableStop(thing string) error {
 	return err
 }
 
+// SystemctlIsEnabled return true only if systemctl suggests that the thing is
+// enabled.
+func SystemctlIsEnabled(thing string) bool {
+	if _, err := exec.Command("systemctl", "is-enabled", thing).CombinedOutput(); err == nil {
+		return true
+	}
+	return false
+}
+
 // SystemctlIsRunning return true only if systemctl suggests that the thing is
 // running.
 func SystemctlIsRunning(thing string) bool {

--- a/system/daemon_test.go
+++ b/system/daemon_test.go
@@ -83,6 +83,26 @@ func TestSystemctl(t *testing.T) {
 	}
 }
 
+func TestSystemctlIsEnabled(t *testing.T) {
+	testService := "rpcbind.service"
+	if SystemctlIsEnabled(testService) {
+		t.Errorf("service '%s' is detected as enabled, but should be disabled", testService)
+	}
+	if err := SystemctlEnableStart(testService); err != nil {
+		t.Errorf("Error enable and start '%s': '%v'\n", testService, err)
+	}
+	if !SystemctlIsEnabled(testService) {
+		t.Errorf("service '%s' is detected as disabled, but should be enabled", testService)
+	}
+	if err := SystemctlDisableStop(testService); err != nil {
+		t.Errorf("Error disable and stop '%s': '%v'\n", testService, err)
+	}
+
+	if SystemctlIsEnabled("UnkownService") {
+		t.Errorf("service 'UnkownService' is detected as enabled, which is not possible")
+	}
+}
+
 func TestSystemctlIsRunning(t *testing.T) {
 	// check, if command is available
 	if !CmdIsAvailable("/usr/bin/systemctl") {

--- a/testdata/etc/sysconfig/saptune
+++ b/testdata/etc/sysconfig/saptune
@@ -1,6 +1,6 @@
 ## Path:           SAP/System Tuning/General
 ## Description:    Global settings for saptune - the comprehensive optimisation management utility for SAP solutions
-## ServiceRestart: tuned
+## ServiceRestart: saptune
 
 ## Type:    string
 ## Default: ""
@@ -28,7 +28,7 @@ TUNE_FOR_NOTES="1680803 2205917 2684254"
 NOTE_APPLY_ORDER="2205917 2684254 1680803"
 
 ## Type:    string
-## Default: "2"
+## Default: "3"
 #
 # Version of saptune
-SAPTUNE_VERSION="2"
+SAPTUNE_VERSION="3"

--- a/testdata/saptune_sysconfig
+++ b/testdata/saptune_sysconfig
@@ -1,6 +1,6 @@
 ## Path:           SAP/System Tuning/General
 ## Description:    Global settings for saptune - the comprehensive optimisation management utility for SAP solutions
-## ServiceRestart: tuned
+## ServiceRestart: saptune
 
 ## Type:    string
 ## Default: ""
@@ -28,7 +28,7 @@ TUNE_FOR_NOTES="1680803 2205917 2684254"
 NOTE_APPLY_ORDER="2205917 2684254 1680803"
 
 ## Type:    string
-## Default: "2"
+## Default: "3"
 #
 # Version of saptune
-SAPTUNE_VERSION="2"
+SAPTUNE_VERSION="3"

--- a/testdata/sysconfig-sample
+++ b/testdata/sysconfig-sample
@@ -1,6 +1,6 @@
 ## Path:        Productivity/Other
 ## Description: Limits for system tuning profile "sap-netweaver".
-## ServiceRestart: tuned
+## ServiceRestart: saptune
 
 ## Type:        integer
 ## Default:     8388608

--- a/txtparser/sysconfig_test.go
+++ b/txtparser/sysconfig_test.go
@@ -10,7 +10,7 @@ import (
 
 var sysconfSampleText = `## Path:        Productivity/Other
 ## Description: Limits for system tuning profile "sap-netweaver".
-## ServiceRestart: tuned
+## ServiceRestart: saptune
 
 ## Type:        integer
 ## Default:     8388608
@@ -39,7 +39,7 @@ INTARY_TEST=" 12 34 abc 56 "
 
 var sysconfigMatchText = `## Path:        Productivity/Other
 ## Description: Limits for system tuning profile "sap-netweaver".
-## ServiceRestart: tuned
+## ServiceRestart: saptune
 
 ## Type:        integer
 ## Default:     8388608


### PR DESCRIPTION
remove usage of tuned from saptune, but keep saptune version 1 compatibility in case of update
Add an own systemd service file for saptune to start/stop tuning of parameter values during a reboot of the system.
Add a new saptune action 'service' to handle the saptune.service supporting start/stop/enable/disable/status a.s.m.
The saptune action 'daemon', which handled tuned.service in the past, is now flagged as 'deprecated' and internally linked to the new action 'service'
