### PR TITLE
skip perf bias change if secure boot is enabled

### DIFF
--- a/system/cpu.go
+++ b/system/cpu.go
@@ -17,7 +17,7 @@ import (
 
 //constant definition
 const (
-	secBootoff   = "SecureBoot disabled"
+	secBootOff   = "SecureBoot disabled"
 	notSupported = "System does not support Intel's performance bias setting"
 	cpuDirSys    = "devices/system/cpu"
 )


### PR DESCRIPTION
When a system is in lockdown mode, i.e., Secure Boot is enabled, MSR cannot be altered in user-space. This patch checks if Secure Boot is enabled using the mokutil utility and skips setting the perf bias in case it is.