### PR TITLE
Fixes for TEAM-3342, TEAM-2675 and bsc#11179275

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -18,18 +18,19 @@ const (
 	TunedService       = "tuned.service"
 	exitSaptuneStopped = 1
 	exitNotTuned       = 3
-	footnote1X86       = "[1] setting is not supported by the system"
-	footnote1IBM       = "[1] setting is not relevant for the system"
-	footnote1AZR       = "[1] setting is not available on Azure instances (see SAP Note 2993054)."
-	footnote1AWS       = "[1] setting is not available on AWS instances (see SAP Note 1656250)."
-	footnote2          = "[2] setting is not available on the system"
-	footnote3          = "[3] value is only checked, but NOT set"
-	footnote4          = "[4] cpu idle state settings differ"
-	footnote5          = "[5] expected value does not contain a supported scheduler"
-	footnote6          = "[6] grub settings are mostly covered by other settings. See man page saptune-note(5) for details"
-	footnote7          = "[7] parameter value is untouched by default"
-	footnote8          = "[8] cannot set Perf Bias because SecureBoot is enabled"
-	footnote9          = "[9] expected value limited to 'max_hw_sectors_kb'"
+	footnote1X86       = " [1] setting is not supported by the system"
+	footnote1IBM       = " [1] setting is not relevant for the system"
+	footnote1AZR       = " [1] setting is not available on Azure instances (see SAP Note 2993054)."
+	footnote1AWS       = " [1] setting is not available on AWS instances (see SAP Note 1656250)."
+	footnote2          = " [2] setting is not available on the system"
+	footnote3          = " [3] value is only checked, but NOT set"
+	footnote4          = " [4] cpu idle state settings differ"
+	footnote5          = " [5] expected value does not contain a supported scheduler"
+	footnote6          = " [6] grub settings are mostly covered by other settings. See man page saptune-note(5) for details"
+	footnote7          = " [7] parameter value is untouched by default"
+	footnote8          = " [8] cannot set Perf Bias because SecureBoot is enabled"
+	footnote9          = " [9] expected value limited to 'max_hw_sectors_kb'"
+	footnote10         = "[10] parameter is defined twice, see section SECT"
 )
 
 // PackageArea is the package area with all notes and solutions shiped by

--- a/actions/noteacts_test.go
+++ b/actions/noteacts_test.go
@@ -93,7 +93,8 @@ Remember: if you wish to automatically activate the solution's tuning options af
 
 	// Test VerifyAllParameters
 	t.Run("VerifyAllParameters", func(t *testing.T) {
-		var verifyMatchText = `   SAPNote, Version | Parameter                    | Expected    | Override  | Actual      | Compliant
+		var verifyMatchText = `
+   SAPNote, Version | Parameter                    | Expected    | Override  | Actual      | Compliant
 --------------------+------------------------------+-------------+-----------+-------------+-----------
    simpleNote, 1    | net.ipv4.ip_local_port_range | 31768 61999 |           | 31768 61999 | yes
 

--- a/actions/solutionacts_test.go
+++ b/actions/solutionacts_test.go
@@ -57,6 +57,7 @@ Remember: if you wish to automatically activate the solution's tuning options af
 	// Test SolutionActionSimulate
 	t.Run("SolutionActionSimulate", func(t *testing.T) {
 		var simulateMatchText = `If you run ` + "`saptune solution apply sol1`" + `, the following changes will be applied to your system:
+
    Parameter                    | Value set   | Value expected  | Override  | Comment
 --------------------------------+-------------+-----------------+-----------+--------------
    net.ipv4.ip_local_port_range | 32768 60999 | 31768 61999     |           |   
@@ -95,7 +96,8 @@ Remember: if you wish to automatically activate the solution's tuning options af
 	// Test SolutionActionVerify
 	// need to run after 'Test SolutionActionApply'
 	t.Run("SolutionActionVerify", func(t *testing.T) {
-		var verifyMatchText = `   SAPNote, Version | Parameter                    | Expected    | Override  | Actual      | Compliant
+		var verifyMatchText = `
+   SAPNote, Version | Parameter                    | Expected    | Override  | Actual      | Compliant
 --------------------+------------------------------+-------------+-----------+-------------+-----------
    simpleNote, 1    | net.ipv4.ip_local_port_range | 31768 61999 |           | 31768 61999 | yes
 

--- a/actions/table_test.go
+++ b/actions/table_test.go
@@ -59,21 +59,23 @@ func TestPrintNoteFields(t *testing.T) {
 
    SAPNote, Version | Parameter                  | Expected             | Override  | Actual               | Compliant
 --------------------+----------------------------+----------------------+-----------+----------------------+-----------
-   941735, 1        | IO_SCHEDULER_sdb           |                      |           | all:none             |  -  [1] [5] [7]
+   941735, 1        | IO_SCHEDULER_sdb           |                      |           | all:none             |  -  [1] [7] [5]
    941735, 1        | IO_SCHEDULER_sdc           |                      |           | bfq                  | no  [7]
+   941735, 1        | IO_SCHEDULER_sdd           |                      |           | bfq                  | no  [7] [10]
    941735, 1        | IO_SCHEDULER_vda           | noop                 |           | all:none             |  -  [1] [5]
    941735, 1        | ShmFileSystemSizeMB        | 1714                 |           | 488                  | no 
    941735, 1        | force_latency              | 70                   |           | all:none             | no  [4]
    941735, 1        | grub:intel_idle.max_cstate | 1                    |           | NA                   | no  [2] [3] [6]
    941735, 1        | kernel.shmmax              | 18446744073709551615 |           | 18446744073709551615 | yes
 
- [1] setting is not supported by the system
- [2] setting is not available on the system
- [3] value is only checked, but NOT set
- [4] cpu idle state settings differ
- [5] expected value does not contain a supported scheduler
- [6] grub settings are mostly covered by other settings. See man page saptune-note(5) for details
- [7] parameter value is untouched by default
+  [1] setting is not supported by the system
+  [2] setting is not available on the system
+  [3] value is only checked, but NOT set
+  [4] cpu idle state settings differ
+  [5] expected value does not contain a supported scheduler
+  [6] grub settings are mostly covered by other settings. See man page saptune-note(5) for details
+  [7] parameter value is untouched by default
+ [10] parameter is defined twice, see section [sys] 'sys:block.sdd.queue.scheduler' from the other applied notes
 
 `
 	var printMatchText2 = `
@@ -82,59 +84,67 @@ func TestPrintNoteFields(t *testing.T) {
 
    Parameter                  | Value set            | Value expected       | Override  | Comment
 ------------------------------+----------------------+----------------------+-----------+--------------
-   IO_SCHEDULER_sdb           | all:none             |                      |           |  [1] [5] [7]
+   IO_SCHEDULER_sdb           | all:none             |                      |           |  [1] [7] [5]
    IO_SCHEDULER_sdc           | bfq                  |                      |           |  [7]
+   IO_SCHEDULER_sdd           | bfq                  |                      |           |  [7] [10]
    IO_SCHEDULER_vda           | all:none             | noop                 |           |  [1] [5]
    ShmFileSystemSizeMB        | 488                  | 1714                 |           |   
    force_latency              | all:none             | 70                   |           |  [1] [4]
    grub:intel_idle.max_cstate | NA                   | 1                    |           |  [2] [3] [6]
    kernel.shmmax              | 18446744073709551615 | 18446744073709551615 |           |   
 
- [1] setting is not supported by the system
- [2] setting is not available on the system
- [3] value is only checked, but NOT set
- [4] cpu idle state settings differ
- [5] expected value does not contain a supported scheduler
- [6] grub settings are mostly covered by other settings. See man page saptune-note(5) for details
- [7] parameter value is untouched by default
+  [1] setting is not supported by the system
+  [2] setting is not available on the system
+  [3] value is only checked, but NOT set
+  [4] cpu idle state settings differ
+  [5] expected value does not contain a supported scheduler
+  [6] grub settings are mostly covered by other settings. See man page saptune-note(5) for details
+  [7] parameter value is untouched by default
+ [10] parameter is defined twice, see section [sys] 'sys:block.sdd.queue.scheduler' from the other applied notes
 
 `
-	var printMatchText3 = `   SAPNote, Version | Parameter                  | Expected             | Override  | Actual               | Compliant
+	var printMatchText3 = `
+   SAPNote, Version | Parameter                  | Expected             | Override  | Actual               | Compliant
 --------------------+----------------------------+----------------------+-----------+----------------------+-----------
-   941735, 1        | IO_SCHEDULER_sdb           |                      |           | all:none             |  -  [1] [5] [7]
+   941735, 1        | IO_SCHEDULER_sdb           |                      |           | all:none             |  -  [1] [7] [5]
    941735, 1        | IO_SCHEDULER_sdc           |                      |           | bfq                  | no  [7]
+   941735, 1        | IO_SCHEDULER_sdd           |                      |           | bfq                  | no  [7] [10]
    941735, 1        | IO_SCHEDULER_vda           | noop                 |           | all:none             |  -  [1] [5]
    941735, 1        | ShmFileSystemSizeMB        | 1714                 |           | 488                  | no 
    941735, 1        | force_latency              | 70                   |           | all:none             | no  [4]
    941735, 1        | grub:intel_idle.max_cstate | 1                    |           | NA                   | no  [2] [3] [6]
    941735, 1        | kernel.shmmax              | 18446744073709551615 |           | 18446744073709551615 | yes
 
- [1] setting is not supported by the system
- [2] setting is not available on the system
- [3] value is only checked, but NOT set
- [4] cpu idle state settings differ
- [5] expected value does not contain a supported scheduler
- [6] grub settings are mostly covered by other settings. See man page saptune-note(5) for details
- [7] parameter value is untouched by default
+  [1] setting is not supported by the system
+  [2] setting is not available on the system
+  [3] value is only checked, but NOT set
+  [4] cpu idle state settings differ
+  [5] expected value does not contain a supported scheduler
+  [6] grub settings are mostly covered by other settings. See man page saptune-note(5) for details
+  [7] parameter value is untouched by default
+ [10] parameter is defined twice, see section [sys] 'sys:block.sdd.queue.scheduler' from the other applied notes
 
 `
-	var printMatchText4 = `   Parameter                  | Value set            | Value expected       | Override  | Comment
+	var printMatchText4 = `
+   Parameter                  | Value set            | Value expected       | Override  | Comment
 ------------------------------+----------------------+----------------------+-----------+--------------
-   IO_SCHEDULER_sdb           | all:none             |                      |           |  [1] [5] [7]
+   IO_SCHEDULER_sdb           | all:none             |                      |           |  [1] [7] [5]
    IO_SCHEDULER_sdc           | bfq                  |                      |           |  [7]
+   IO_SCHEDULER_sdd           | bfq                  |                      |           |  [7] [10]
    IO_SCHEDULER_vda           | all:none             | noop                 |           |  [1] [5]
    ShmFileSystemSizeMB        | 488                  | 1714                 |           |   
    force_latency              | all:none             | 70                   |           |  [1] [4]
    grub:intel_idle.max_cstate | NA                   | 1                    |           |  [2] [3] [6]
    kernel.shmmax              | 18446744073709551615 | 18446744073709551615 |           |   
 
- [1] setting is not supported by the system
- [2] setting is not available on the system
- [3] value is only checked, but NOT set
- [4] cpu idle state settings differ
- [5] expected value does not contain a supported scheduler
- [6] grub settings are mostly covered by other settings. See man page saptune-note(5) for details
- [7] parameter value is untouched by default
+  [1] setting is not supported by the system
+  [2] setting is not available on the system
+  [3] value is only checked, but NOT set
+  [4] cpu idle state settings differ
+  [5] expected value does not contain a supported scheduler
+  [6] grub settings are mostly covered by other settings. See man page saptune-note(5) for details
+  [7] parameter value is untouched by default
+ [10] parameter is defined twice, see section [sys] 'sys:block.sdd.queue.scheduler' from the other applied notes
 
 `
 	checkCorrectMessage := func(t *testing.T, got, want string) {
@@ -165,8 +175,10 @@ func TestPrintNoteFields(t *testing.T) {
 	fcomp12 := note.FieldComparison{ReflectFieldName: "Inform", ReflectMapKey: "IO_SCHEDULER_sdb", ActualValue: "NA", ExpectedValue: "", ActualValueJS: "NA", ExpectedValueJS: "", MatchExpectation: false}
 	fcomp13 := note.FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "IO_SCHEDULER_sdc", ActualValue: "bfq", ExpectedValue: "", ActualValueJS: "bfq", ExpectedValueJS: "", MatchExpectation: false}
 	fcomp14 := note.FieldComparison{ReflectFieldName: "Inform", ReflectMapKey: "IO_SCHEDULER_sdc", ActualValue: "", ExpectedValue: "bfq", ActualValueJS: "", ExpectedValueJS: "bfq", MatchExpectation: false}
+	fcomp15 := note.FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "IO_SCHEDULER_sdd", ActualValue: "bfq", ExpectedValue: "", ActualValueJS: "bfq", ExpectedValueJS: "", MatchExpectation: false}
+	fcomp16 := note.FieldComparison{ReflectFieldName: "Inform", ReflectMapKey: "IO_SCHEDULER_sdd", ActualValue: "", ExpectedValue: "[sys] 'sys:block.sdd.queue.scheduler' from the other applied notes", ActualValueJS: "", ExpectedValueJS: "[sys] 'sys:block.sdd.queue.scheduler' from the other applied notes", MatchExpectation: false}
 
-	map941735 := map[string]note.FieldComparison{"ConfFilePath": fcomp1, "ID": fcomp2, "DescriptiveName": fcomp3, "SysctlParams[ShmFileSystemSizeMB]": fcomp4, "SysctlParams[kernel.shmmax]": fcomp5, "SysctlParams[IO_SCHEDULER_vda]": fcomp6, "SysctlParams[grub:intel_idle.max_cstate]": fcomp7, "SysctlParams[force_latency]": fcomp8, "Inform[force_latency]": fcomp9, "Inform[IO_SCHEDULER_vda]": fcomp10, "SysctlParams[IO_SCHEDULER_sdb]": fcomp11, "Inform[IO_SCHEDULER_sdb]": fcomp12, "SysctlParams[IO_SCHEDULER_sdc]": fcomp13, "Inform[IO_SCHEDULER_sdc]": fcomp14}
+	map941735 := map[string]note.FieldComparison{"ConfFilePath": fcomp1, "ID": fcomp2, "DescriptiveName": fcomp3, "SysctlParams[ShmFileSystemSizeMB]": fcomp4, "SysctlParams[kernel.shmmax]": fcomp5, "SysctlParams[IO_SCHEDULER_vda]": fcomp6, "SysctlParams[grub:intel_idle.max_cstate]": fcomp7, "SysctlParams[force_latency]": fcomp8, "Inform[force_latency]": fcomp9, "Inform[IO_SCHEDULER_vda]": fcomp10, "SysctlParams[IO_SCHEDULER_sdb]": fcomp11, "Inform[IO_SCHEDULER_sdb]": fcomp12, "SysctlParams[IO_SCHEDULER_sdc]": fcomp13, "Inform[IO_SCHEDULER_sdc]": fcomp14, "SysctlParams[IO_SCHEDULER_sdd]": fcomp15, "Inform[IO_SCHEDULER_sdd]": fcomp16}
 	noteComp := map[string]map[string]note.FieldComparison{"941735": map941735}
 
 	t.Run("verify with header", func(t *testing.T) {

--- a/sap/note/ini_sections_test.go
+++ b/sap/note/ini_sections_test.go
@@ -203,11 +203,11 @@ func TestOptLimitsVal(t *testing.T) {
 //SetLimitsVal apply and revert
 
 func TestGetVMVal(t *testing.T) {
-	val := GetVMVal("THP")
+	val, _ := GetVMVal("THP")
 	if val != "always" && val != "madvise" && val != "never" {
 		t.Errorf("wrong value '%+v' for THP.\n", val)
 	}
-	val = GetVMVal("KSM")
+	val, _ = GetVMVal("KSM")
 	if val != "1" && val != "0" {
 		t.Errorf("wrong value '%+v' for KSM.\n", val)
 	}
@@ -238,7 +238,7 @@ func TestOptVMVal(t *testing.T) {
 
 func TestSetVMVal(t *testing.T) {
 	newval := ""
-	oldval := GetVMVal("THP")
+	oldval, _ := GetVMVal("THP")
 	if oldval == "never" {
 		newval = "always"
 	} else {
@@ -248,7 +248,7 @@ func TestSetVMVal(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	val := GetVMVal("THP")
+	val, _ := GetVMVal("THP")
 	if val != newval {
 		t.Error(val)
 	}
@@ -258,7 +258,7 @@ func TestSetVMVal(t *testing.T) {
 		t.Error(err)
 	}
 
-	oldval = GetVMVal("KSM")
+	oldval, _ = GetVMVal("KSM")
 	if oldval == "0" {
 		newval = "1"
 	} else {
@@ -268,7 +268,7 @@ func TestSetVMVal(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	val = GetVMVal("KSM")
+	val, _ = GetVMVal("KSM")
 	if val != newval {
 		t.Error(val)
 	}

--- a/sap/note/note.go
+++ b/sap/note/note.go
@@ -22,6 +22,11 @@ import (
 	"strings"
 )
 
+// SaptuneParameterStateDir defines the directory where to store the
+// parameter state files
+// separated from the note state file directory
+const SaptuneParameterStateDir = "/var/lib/saptune/parameter"
+
 // Note defines the structure and actions for a SAP Note
 // An SAP note consisting of a series of tunable parameters that can be
 // applied and reverted.

--- a/sap/note/parameter.go
+++ b/sap/note/parameter.go
@@ -22,11 +22,6 @@ type ParameterNotes struct {
 	AllNotes []ParameterNoteEntry
 }
 
-// SaptuneParameterStateDir defines the directory where to store the
-// parameter state files
-// separated from the note state file directory
-const SaptuneParameterStateDir = "/var/lib/saptune/parameter"
-
 // GetPathToParameter returns path to the serialised parameter state file.
 func GetPathToParameter(param string) string {
 	return path.Join(SaptuneParameterStateDir, param)

--- a/system/blockdev.go
+++ b/system/blockdev.go
@@ -17,6 +17,18 @@ type BlockDev struct {
 	BlockAttributes map[string]map[string]string
 }
 
+// IsSched matches block device scheduler tag
+var IsSched = regexp.MustCompile(`^IO_SCHEDULER_\w+$`)
+
+// IsNrreq matches block device nrreq tag
+var IsNrreq = regexp.MustCompile(`^NRREQ_\w+$`)
+
+// IsRahead matches block device read_ahead_kb tag
+var IsRahead = regexp.MustCompile(`^READ_AHEAD_KB_\w+$`)
+
+// IsMsect matches block device max_sectors_kb tag
+var IsMsect = regexp.MustCompile(`^MAX_SECTORS_KB_\w+$`)
+
 var isVD = regexp.MustCompile(`^vd\w+$`)
 
 // devices like /dev/nvme0n1 are the NVME storage namespaces: the devices you

--- a/system/system.go
+++ b/system/system.go
@@ -459,6 +459,22 @@ func GetHWIdentity(info string) (string, error) {
 	return ret, err
 }
 
+// GetFiles returns the files from a directory as map
+// skip directories
+func GetFiles(dir string) map[string]string {
+	files := make(map[string]string)
+	entries, err := ioutil.ReadDir(dir)
+	if err != nil {
+		WarningLog("failed to read %s - %v", dir, err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			files[entry.Name()] = entry.Name()
+		}
+	}
+	return files
+}
+
 // Watch prints the current time
 func Watch() string {
 	t := time.Now()


### PR DESCRIPTION
add support for [sys] section and handle double configurations for parameters defined in the [sys] section (jsc#TEAM-3342)
add NVMe support to the block device handling to support AWS  (jsc#TEAM-2675)
change block device handling to handle multipath devices correctly. Only the DM multipath devices will be used for the settings, but not its paths. (bsc#11179275)
