### PR TITLE
add system sysctl config file checks

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -31,6 +31,7 @@ const (
 	footnote8          = " [8] cannot set Perf Bias because SecureBoot is enabled"
 	footnote9          = " [9] expected value limited to 'max_hw_sectors_kb'"
 	footnote10         = "[10] parameter is defined twice, see section SECT"
+	footnote11         = "[11] parameter is additional defined in SYSCTLLIST"
 )
 
 // PackageArea is the package area with all notes and solutions shiped by

--- a/actions/table.go
+++ b/actions/table.go
@@ -21,7 +21,7 @@ func PrintNoteFields(writer io.Writer, header string, noteComparisons map[string
 	compliant := "yes"
 	printHead := ""
 	noteField := ""
-	footnote := make([]string, 10, 10)
+	footnote := make([]string, 11, 11)
 	reminder := make(map[string]string)
 	override := ""
 	comment := ""
@@ -278,6 +278,14 @@ func chkInfo(mapKey, compliant, comment, info string, footnote []string) (string
 		compliant = compliant + " [10]"
 		comment = comment + " [10]"
 		footnote[9] = writeFN(footnote[9], footnote10, info, "SECT")
+	}
+	// check if the sysctl parameter is additional set in a sysctl system
+	// configuration file
+	if strings.HasPrefix(info, "sysctl config file ") {
+		// sysctl info
+		compliant = compliant + " [11]"
+		comment = comment + " [11]"
+		footnote[10] = writeFN(footnote[10], footnote11, info, "SYSCTLLIST")
 	}
 	return compliant, comment, footnote
 }

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -428,6 +428,8 @@ Add one line for each SLE version a package should be checked for, even if the p
 .br
 The SLE version has to be noted in the same format as the '\fBVERSION=\fP' entry in \fI/etc/os-release\fP.
 
+To address all SLE versions and service packs the keyword '\fBall\fP' can be used instead of a dedicated SLE version.
+
 e.g
 .br
 systemd 12-SP2 228-142.1
@@ -437,6 +439,8 @@ sapinit-systemd-compat 12 1.0-2.1
 sapinit-systemd-compat 12-SP1 1.0-2.1
 .br
 util-linux 12-SP1 2.25-22.1
+.br
+bzip2 all 1.0.8
 
 Only the lines where the SLE version is matching the running system OS are checked and displayed during the 'verify' and 'simulate' option.
 .br

--- a/run_travis_tst.sh
+++ b/run_travis_tst.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# this tests do not need any HA/cluster stuff, so remove the repo
+echo "zypper remove unneeded repo"
+zypper rr network:ha-clustering:Factory
+
 echo "zypper in ..."
 #/bin/systemctl start dbus -> does not work any longer
 # additional libs needed to get 'tuned' working
@@ -20,6 +24,7 @@ cd ${TRAVIS_HOME}/gopath/src/github.com/SUSE
 if [ ! -f saptune ]; then
 	ln -s /app saptune
 fi
+export GO111MODULE="off"
 export GOPATH=${TRAVIS_HOME}/gopath
 export PATH=${TRAVIS_HOME}/gopath/bin:$PATH
 export TRAVIS_BUILD_DIR=${TRAVIS_HOME}/gopath/src/github.com/SUSE/saptune

--- a/run_travis_tst.sh
+++ b/run_travis_tst.sh
@@ -53,6 +53,10 @@ loginctl --no-pager
 echo "exchange /etc/os-release"
 cp /etc/os-release /etc/os-release_OrG
 
+# for some sysctl tests
+echo "vm.pagecache_limit_ignore_dirty = 1" > /etc/sysctl.d/saptune_test.conf
+echo "vm.pagecache_limit_ignore_dirty = 1" > /etc/sysctl.d/saptune_test2.conf
+
 echo "run go tests"
 go test -v -coverprofile=c.out -cover ./...
 exitErr=$?

--- a/sap/note/ini.go
+++ b/sap/note/ini.go
@@ -145,6 +145,7 @@ func (vend INISettings) Initialise() (Note, error) {
 
 		switch param.Section {
 		case INISectionSysctl:
+			vend.Inform[param.Key] = ""
 			vend.SysctlParams[param.Key], _ = system.GetSysctlString(param.Key)
 		case INISectionSys:
 			vend.SysctlParams[param.Key], vend.Inform[param.Key] = GetSysVal(param.Key)
@@ -237,6 +238,7 @@ func (vend INISettings) Optimise() (Note, error) {
 		case INISectionSysctl:
 			//optimisedValue, err := CalculateOptimumValue(param.Operator, vend.SysctlParams[param.Key], param.Value)
 			//vend.SysctlParams[param.Key] = optimisedValue
+			vend.Inform[param.Key] = system.ChkForSysctlDoubles(param.Key)
 			vend.SysctlParams[param.Key] = OptSysctlVal(param.Operator, param.Key, vend.SysctlParams[param.Key], param.Value)
 		case INISectionSys:
 			vend.Inform[param.Key] = vend.chkDoubles(param.Key, vend.Inform[param.Key])
@@ -645,10 +647,6 @@ func (vend INISettings) chkDoubles(key, info string) string {
 func getSysSearchParam(syskey string) (string, string) {
 	searchParam := ""
 	sect := ""
-	// THP
-	thp := "sys:kernel.mm.transparent_hugepage.enabled"
-	// KSM
-	ksm := "sys:kernel.mm.ksm.run"
 	// blkdev
 	sched := regexp.MustCompile(`block.*queue\.scheduler$`)
 	nrreq := regexp.MustCompile(`block.*queue\.nr_requests$`)
@@ -669,15 +667,15 @@ func getSysSearchParam(syskey string) (string, string) {
 
 	switch {
 	case syskey == "THP":
-		searchParam = thp
+		searchParam = "sys:" + system.SysKernelTHPEnabled
 		sect = "sys"
-	case syskey == thp:
+	case syskey == "sys:"+system.SysKernelTHPEnabled:
 		searchParam = "THP"
 		sect = "vm"
 	case syskey == "KSM":
-		searchParam = ksm
+		searchParam = "sys:" + system.SysKSMRun
 		sect = "sys"
-	case syskey == ksm:
+	case syskey == "sys:"+system.SysKSMRun:
 		searchParam = "KSM"
 		sect = "vm"
 	case system.IsSched.MatchString(syskey):

--- a/sap/note/ini_sections.go
+++ b/sap/note/ini_sections.go
@@ -30,8 +30,6 @@ const (
 	INISectionRpm       = "rpm"
 	INISectionGrub      = "grub"
 	INISectionReminder  = "reminder"
-	SysKernelTHPEnabled = "kernel/mm/transparent_hugepage/enabled"
-	SysKSMRun           = "kernel/mm/ksm/run"
 
 	// LoginConfDir is the path to systemd's logind configuration directory under /etc.
 	LogindConfDir = "/etc/systemd/logind.conf.d"
@@ -373,9 +371,9 @@ func GetVMVal(key string) (string, string) {
 	info := ""
 	switch key {
 	case "THP":
-		val, _ = system.GetSysChoice(SysKernelTHPEnabled)
+		val, _ = system.GetSysChoice(system.SysKernelTHPEnabled)
 	case "KSM":
-		ksmval, _ := system.GetSysInt(SysKSMRun)
+		ksmval, _ := system.GetSysInt(system.SysKSMRun)
 		val = strconv.Itoa(ksmval)
 	}
 	return val, info
@@ -405,10 +403,10 @@ func SetVMVal(key, value string) error {
 	var err error
 	switch key {
 	case "THP":
-		err = system.SetSysString(SysKernelTHPEnabled, value)
+		err = system.SetSysString(system.SysKernelTHPEnabled, value)
 	case "KSM":
 		ksmval, _ := strconv.Atoi(value)
-		err = system.SetSysInt(SysKSMRun, ksmval)
+		err = system.SetSysInt(system.SysKSMRun, ksmval)
 	}
 	return err
 }

--- a/system/cpu.go
+++ b/system/cpu.go
@@ -359,11 +359,11 @@ func SetForceLatency(value, savedStates, info string, revert bool) error {
 						// apply
 						oldState, _ = GetSysString(path.Join(cpuDirSys, entry.Name(), "cpuidle", centry.Name(), "disable"))
 						// save old latency states for 'revert'
-						if lat >= flval {
+						if lat > flval {
 							// set new latency states
 							err = SetSysString(path.Join(cpuDirSys, entry.Name(), "cpuidle", centry.Name(), "disable"), "1")
 						}
-						if lat < flval && oldState == "1" {
+						if lat <= flval && oldState == "1" {
 							// reset previous set latency state
 							err = SetSysString(path.Join(cpuDirSys, entry.Name(), "cpuidle", centry.Name(), "disable"), "0")
 						}

--- a/system/sysctl_test.go
+++ b/system/sysctl_test.go
@@ -101,3 +101,23 @@ func TestIsPagecacheAvailable(t *testing.T) {
 		t.Log("pagecache setting NOT available")
 	}
 }
+
+func TestGlobalSysctls(t *testing.T) {
+	//var sysctlParms = sysctlDefined{}
+	expTxt := "sysctl config file /etc/sysctl.d/saptune_test.conf(1), /etc/sysctl.d/saptune_test2.conf(1)"
+	expTxt2 := "sysctl config file /etc/sysctl.d/saptune_test2.conf(1), /etc/sysctl.d/saptune_test.conf(1)"
+	CollectGlobalSysctls()
+	info := ChkForSysctlDoubles("vm.nr_hugepages")
+	if info != "" {
+		t.Errorf("got '%s' instead of expected empty string\n", info)
+	}
+	info = ChkForSysctlDoubles("vm.pagecache_limit_ignore_dirty")
+	if info == "" {
+		t.Error("got empty string instead of expected text")
+	}
+	// as the order of the sysctl files are not predictive and not important
+	// for the code use 2 text pattern for the comparison
+	if info != expTxt && info != expTxt2 {
+		t.Errorf("got '%s' instead of expected text '%s'\n", info, expTxt)
+	}
+}

--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -34,6 +34,9 @@ var blckCnt = 0
 
 var blockDev = make([]string, 0, 10)
 
+// counter to control the [sysctl] section
+var sysctlCnt = 0
+
 // INIEntry contains a single key-value pair in INI file.
 type INIEntry struct {
 	Section  string
@@ -211,6 +214,11 @@ func ParseINI(input string) *INIFile {
 			}
 			sectionFields := strings.Split(currentSection, ":")
 
+			// collect system wide sysctl settings
+			if sectionFields[0] == "sysctl" && sysctlCnt == 0 {
+				sysctlCnt = sysctlCnt + 1
+				system.CollectGlobalSysctls()
+			}
 			// moved block device colletion so that the info can be
 			// used inside the 'tag' checks
 			if sectionFields[0] == "block" && blckCnt == 0 {


### PR DESCRIPTION
- fixed wrong comparison used for setting FORCE_LATENCY
  (bsc#1185702)
- add keyword 'all' to the 'rpm' section description in the man page saptune-note(5)
  (bsc#1182287)
- check system sysctl config files as mentioned in the comments of /etc/sysctl.conf and in man page sysctl.conf(5) for sysctl parameters currently set by saptune notes. Print a warning and a footnote for 'verify' and 'customize'.
  (jsc#TEAM-1696)