### PR TITLE
fix bsc#1182009 for VSZ_TMPFS_PERCENT

### DIFF
--- a/actions/footnote.go
+++ b/actions/footnote.go
@@ -28,6 +28,7 @@ const (
 	footnote12   = "[12] option FSOPT"
 	footnote13   = "[13] The SAP recommendation for nr_request does not work in the context of multiqueue block framework (scheduler=none).\n      Maximal supported value by the hardware is MAXVAL"
 	footnote14   = "[14] the parameter value exceeds the maximum possible number of open files. Check and increase fs.nr_open if really needed."
+	footnote15   = "[15] the parameter is only used to calculate the size of tmpfs (/dev/shm)"
 )
 
 // set 'unsupported' footnote regarding the architecture
@@ -70,6 +71,8 @@ func prepareFootnote(comparison note.FieldComparison, compliant, comment, inform
 	compliant, comment, footnote = setUnNRR(comparison.ReflectMapKey, compliant, comment, inform, footnote)
 	// set footnote for unsupported nofile limit value [14]
 	compliant, comment, footnote = setNofile(comparison.ReflectMapKey, compliant, comment, inform, footnote)
+	// set footnote for VSZ_TMPFS_PERCENT parameter from mem section
+	compliant, comment, footnote = setMem(comparison.ReflectMapKey, compliant, comment, footnote)
 	return compliant, comment, footnote
 }
 
@@ -232,6 +235,16 @@ func setNofile(mapKey, compliant, comment, info string, footnote []string) (stri
 		compliant = compliant + " [14]"
 		comment = comment + " [14]"
 		footnote[13] = footnote14
+	}
+	return compliant, comment, footnote
+}
+
+// setMem sets footnote for VSZ_TMPFS_PERCENT parameter from mem section
+func setMem(mapKey, compliant, comment string, footnote []string) (string, string, []string) {
+	if mapKey == "VSZ_TMPFS_PERCENT" {
+		compliant = " -  [15]"
+		comment = comment + " [15]"
+		footnote[14] = footnote15
 	}
 	return compliant, comment, footnote
 }

--- a/actions/noteacts.go
+++ b/actions/noteacts.go
@@ -282,9 +282,7 @@ func NoteActionDelete(reader io.Reader, writer io.Writer, noteID string, tuneApp
 
 	// check, if note is active - applied
 	if _, ok := tuneApp.IsNoteApplied(noteID); ok {
-		system.NoticeLog("The Note definition file you want to delete is currently in use, which means it is already applied.")
-		system.NoticeLog("So please 'revert' the Note first and then try deleting again.\n")
-		system.ErrorExit("", 0)
+		system.ErrorExit("The Note definition file you want to delete is currently in use, which means it is already applied.\nSo please 'revert' the Note first and then try deleting again.")
 	}
 
 	if !extraNote && !overrideNote {
@@ -338,9 +336,7 @@ func NoteActionRename(reader io.Reader, writer io.Writer, noteID, newNoteID stri
 
 	// check, if note is active - applied
 	if _, ok := tuneApp.IsNoteApplied(noteID); ok {
-		system.NoticeLog("The Note definition file you want to rename is currently in use, which means it is already applied.")
-		system.NoticeLog("So please 'revert' the Note first and then try renaming again.\n")
-		system.ErrorExit("", 0)
+		system.ErrorExit("The Note definition file you want to rename is currently in use, which means it is already applied.\nSo please 'revert' the Note first and then try renaming again.")
 	}
 
 	if extraNote && overrideNote {

--- a/actions/noteacts_test.go
+++ b/actions/noteacts_test.go
@@ -20,11 +20,13 @@ func TestNoteActions(t *testing.T) {
 	t.Run("NoteActionList", func(t *testing.T) {
 		var listMatchText = `
 All notes (+ denotes manually enabled notes, * denotes notes enabled by solutions, - denotes notes enabled by solutions but reverted manually later, O denotes override file exists for note, C denotes custom note):
+	NEWSOL2NOTE	
 	extraNote	Configuration drop in for extra tests
 			Version 0 from 04.06.2019 
 	oldFile		Name_syntax
 	simpleNote	Configuration drop in for simple tests
 			Version 1 from 09.07.2019 
+	wrongFileNamesyntax	
 
 Remember: if you wish to automatically activate the solution's tuning options after a reboot, you must enable and start saptune.service by running:
     saptune service enablestart

--- a/actions/solutionacts.go
+++ b/actions/solutionacts.go
@@ -359,9 +359,7 @@ func SolutionActionDelete(reader io.Reader, writer io.Writer, solName string, tu
 
 	// check, if solution is active - applied
 	if i := sort.SearchStrings(tuneApp.TuneForSolutions, solName); i < len(tuneApp.TuneForSolutions) && tuneApp.TuneForSolutions[i] == solName {
-		system.NoticeLog("The Solution file you want to delete is currently in use, which means the Solution is already applied.")
-		system.NoticeLog("So please 'revert' the Solution first and then try deleting again.\n")
-		system.ErrorExit("", 0)
+		system.ErrorExit("The Solution file you want to delete is currently in use, which means the Solution is already applied.\nSo please 'revert' the Solution first and then try deleting again.")
 	}
 
 	if !extraSol && !overrideSol {
@@ -418,9 +416,7 @@ func SolutionActionRename(reader io.Reader, writer io.Writer, solName, newSolNam
 
 	// check, if solution is active - applied
 	if i := sort.SearchStrings(tuneApp.TuneForSolutions, solName); i < len(tuneApp.TuneForSolutions) && tuneApp.TuneForSolutions[i] == solName {
-		system.NoticeLog("The Solution definition file you want to rename is currently in use, which means the Solution is already applied.")
-		system.NoticeLog("So please 'revert' the Solution first and then try renaming it again.\n")
-		system.ErrorExit("", 0)
+		system.ErrorExit("The Solution definition file you want to rename is currently in use, which means the Solution is already applied.\nSo please 'revert' the Solution first and then try renaming again.")
 	}
 
 	if extraSol && overrideSol {

--- a/actions/table.go
+++ b/actions/table.go
@@ -17,7 +17,7 @@ func PrintNoteFields(writer io.Writer, header string, noteComparisons map[string
 	compliant := "yes"
 	printHead := ""
 	noteField := ""
-	footnote := make([]string, 14, 14)
+	footnote := make([]string, 15, 15)
 	reminder := make(map[string]string)
 	override := ""
 	comment := ""

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 	system.LogInit(logFile, logSwitch)
 	// now system.ErrorExit can write to log and os.Stderr. No longer extra
 	// care is needed.
-	system.InfoLog("saptune started with '%s'", strings.Join(os.Args, " "))
+	system.InfoLog("saptune (%s) started with '%s'", actions.RPMVersion, strings.Join(os.Args, " "))
 
 	if arg1 == "lock" {
 		if arg2 := system.CliArg(2); arg2 == "remove" {

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -15,7 +15,7 @@
 .\" */
 .\" 
 
-.TH "saptune-note" "5" "July 2021" "" "saptune note file format description"
+.TH "saptune-note" "5" "September 2021" "" "saptune note file format description"
 .SH NAME
 saptune\-note - Note definition files for saptune version \fB3\fP
 .SH DESCRIPTION
@@ -413,6 +413,8 @@ Size of tmpfs mounted on \fI/dev/shm\fP in percent of the virtual memory.
 Depending on the size of the virtual memory (physical+swap) the value is calculated by (RAM + SWAP) * VSZ_TMPFS_PERCENT/100
 .br
 If VSZ_TMPFS_PERCENT is set to '\fB0\fP', the value is calculated by (RAM + SWAP) * 75/100, as the default is 75.
+
+As this parameter is only used to calculate the value of \fIShmFileSystemSizeMB\fP it will not be checked and compared during the saptune operation 'verify'. A footnote is pointing this out.
 \" section pagecache
 .SH "[pagecache]"
 The section "[pagecache]" is dealing with the pagecache limit feature as described in SAP Note 1557506, which is only available on SLE12.

--- a/sap/note/note.go
+++ b/sap/note/note.go
@@ -211,12 +211,8 @@ func CompareNoteFields(actualNote, expectedNote Note) (allMatch bool, comparison
 					// if this should change in the future use
 					// !strings.Contains(key.String(), "grub")
 					// instead of !isInternalGrub(key.String())
-					if actualValue.(string) != "all:none" && !isInternalGrub(key.String()) {
+					if actualValue.(string) != "all:none" && !isInternalGrub(key.String()) && !(system.IsXFSOption.MatchString(key.String()) && actualValue.(string) == "NA") && key.String() != "VSZ_TMPFS_PERCENT" {
 						allMatch = false
-					}
-					// handle filesystem options separately
-					if system.IsXFSOption.MatchString(key.String()) && actualValue.(string) == "NA" {
-						allMatch = true
 					}
 				}
 			}

--- a/sap/param/io.go
+++ b/sap/param/io.go
@@ -18,7 +18,6 @@ type BlockDeviceQueue struct {
 }
 
 var blkDev *system.BlockDev
-var schedWarn = map[string]string{}
 
 // BlockDeviceSchedulers changes IO elevators on all IO devices
 type BlockDeviceSchedulers struct {
@@ -307,21 +306,8 @@ func IsValidScheduler(blockdev, scheduler string) bool {
 			}
 		}
 	}
-	printSchedWarning(scheduler, blockdev)
+	system.InfoLog("'%s' is not a valid scheduler for device '%s', skipping.", scheduler, blockdev)
 	return false
-}
-
-// printSchedWarning checks, if we need to print a scheduler warning
-func printSchedWarning(scheduler, blockdev string) {
-	warn := false
-	if _, ok := schedWarn[blockdev]; !ok {
-		warn = true
-	}
-	if warn {
-		// print warning
-		system.WarningLog("'%s' is not a valid scheduler for device '%s', skipping.", scheduler, blockdev)
-		schedWarn[blockdev] = scheduler
-	}
 }
 
 // IsValidforNrRequests checks, if the nr_requests value is supported by the system


### PR DESCRIPTION
fix bsc#1182009 by excluding VSZ_TMPFS_PERCENT from being checked and compared during the 'verify' operation of saptune
fix an issue with xfs_options and 'verify'
fix some log messages and exit codes
adapt unit test to the last change regarding note definition files with wrong 'name' field syntax in the header. That will influence the number of notes listed on 'saptune note list' action, but gives the customer the possibility to use 'saptune note edit' to correct the wrong note content.