### PR TITLE
fix the scheduler settings for multi path devices (bsc#1192460)

### DIFF
--- a/ospackage/usr/share/saptune/scripts/upd_helper
+++ b/ospackage/usr/share/saptune/scripts/upd_helper
@@ -472,7 +472,7 @@ adjust_workingarea() {
 
 cleanup_savestates() {
     # cleanup older, no longer handled savedState files
-    param_filelist="/var/lib/saptune/parameter/IO_SCHEDULER_sr* /var/lib/saptune/parameter/IO_SCHEDULER_dm-*"
+    param_filelist="/var/lib/saptune/parameter/IO_SCHEDULER_sr*"
     for i in $param_filelist ; do
         [ -f "$i" ] && rm -f "$i"
     done

--- a/sap/note/sectBlock.go
+++ b/sap/note/sectBlock.go
@@ -72,17 +72,19 @@ func OptBlkVal(key, cfgval string, cur *param.BlockDeviceQueue, bOK map[string][
 		// all devices with same scheduler (oval="all none")
 		oval := ""
 		sfound := false
-		dname := regexp.MustCompile(`^IO_SCHEDULER_(\w+)$`)
+		dname := regexp.MustCompile(`^IO_SCHEDULER_(\w+\-?\d*)$`)
 		bdev := dname.FindStringSubmatch(key)
-		for _, sched := range strings.Split(cfgval, ",") {
-			sval = strings.ToLower(strings.TrimSpace(sched))
-			if !param.IsValidScheduler(bdev[1], sval) {
-				continue
-			} else {
-				sfound = true
-				oval = bdev[1] + " " + sval
-				bOK[sval] = append(bOK[sval], bdev[1])
-				break
+		if len(bdev) > 0 {
+			for _, sched := range strings.Split(cfgval, ",") {
+				sval = strings.ToLower(strings.TrimSpace(sched))
+				if !param.IsValidScheduler(bdev[1], sval) {
+					continue
+				} else {
+					sfound = true
+					oval = bdev[1] + " " + sval
+					bOK[sval] = append(bOK[sval], bdev[1])
+					break
+				}
 			}
 		}
 		if !sfound {

--- a/sap/param/io.go
+++ b/sap/param/io.go
@@ -38,6 +38,8 @@ func (ioe BlockDeviceSchedulers) Inspect() (Parameter, error) {
 		elev := blkDev.BlockAttributes[entry]["IO_SCHEDULER"]
 		if elev != "" {
 			newIOE.SchedulerChoice[entry] = elev
+		} else {
+			newIOE.SchedulerChoice[entry] = "NA"
 		}
 	}
 	return newIOE, nil

--- a/system/blockdev.go
+++ b/system/blockdev.go
@@ -18,7 +18,7 @@ type BlockDev struct {
 }
 
 // IsSched matches block device scheduler tag
-var IsSched = regexp.MustCompile(`^IO_SCHEDULER_\w+$`)
+var IsSched = regexp.MustCompile(`^IO_SCHEDULER_\w+\-?\d*$`)
 
 // IsNrreq matches block device nrreq tag
 var IsNrreq = regexp.MustCompile(`^NRREQ_\w+$`)
@@ -147,6 +147,9 @@ func CollectBlockDeviceInfo() []string {
 
 		// Remember, GetSysChoice does not accept the leading /sys/
 		elev, _ := GetSysChoice(path.Join("block", bdev, "queue", "scheduler"))
+		if elev == "" {
+			elev, _ = GetSysString(path.Join("block", bdev, "queue", "scheduler"))
+		}
 		blockMap["IO_SCHEDULER"] = elev
 		val, err := ioutil.ReadFile(path.Join("/sys/block/", bdev, "/queue/scheduler"))
 		sched := ""


### PR DESCRIPTION
and supress unnecessary warnings regarding vendor and model information of block devices