### PR TITLE
fix block device settings (e.g. NRREQ) for multipath devices (bsc#1193576)

### DIFF
--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -15,7 +15,7 @@
 .\" */
 .\" 
 
-.TH "saptune-note" "5" "September 2021" "" "saptune note file format description"
+.TH "saptune-note" "5" "December 2021" "" "saptune note file format description"
 .SH NAME
 saptune\-note - Note definition files for saptune version \fB3\fP
 .SH DESCRIPTION
@@ -37,6 +37,7 @@ Tags are separated by ':' and can appear in any order. Unsupported tags are cons
 .br
 For some tags the value of the tag is treated as a string and used as a regular expression to match the content of the respective source. This is mentioned in the description of the possible tags below. As a reference https://golang.org/pkg/regexp/#MatchString can be used to see, what additional expressions may be possible inside the tag value. But attention, only some basic ones are really supprted (like 'sd[ab]' for block devices).
 
+Attention: as the IBM Power platform (hardware architecture 'ppc64le') does not support files in \fI/sys/class/dmi\fP (the directory is not available on this hardware architecture) some of the tags listed below are not usable on Power systems for now.
 
 The \fBsyntax\fP for such sections is:
 
@@ -68,6 +69,8 @@ to define a special \fIsystem hardware vendor\fP
 Valid values for \fBvendor=\fP are the values found in \fB/sys/class/dmi/id/board_vendor\fP or parts of the string available in this file.
 .br
 The value of the vendor tag is used as a regular expression '\fB.*<value>.*\fP' to match the content of the vendor file.
+
+Attention: not usable on IBM Power platform (hardware architecture 'ppc64le')
 .TP
 .BI model= <hardware model>
 to define a special \fIsystem hardware model\fP
@@ -75,6 +78,8 @@ to define a special \fIsystem hardware model\fP
 Valid values for \fBmodel=\fP are the values found in \fB/sys/class/dmi/id/product_name\fP or parts of the string available in this file.
 .br
 The value of the model tag is used as a regular expression '\fB.*<value>.*\fP' to match the content of the model file.
+
+Attention: not usable on IBM Power platform (hardware architecture 'ppc64le')
 
 .RS 4
 Example:
@@ -102,6 +107,8 @@ This way it's possible to restrict a section to a special hardware vendor or har
 The value of the DMI interface tag is used as a regular expression '\fB.*<value>.*\fP' to match the content of the file in \fI/sys/class/dmi/id/<filename>\fP.
 
 Attention: if the pattern does not match any filename in \fI/sys/class/dmi/id\fP, the section will be skipped as unknown.
+
+Attention: not usable on IBM Power platform (hardware architecture 'ppc64le')
 
 .RS 4
 Example:

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -117,11 +117,23 @@ saptune package version
 .IP \[bu]
 configured saptune major version (from \fI/etc/sysconfig/saptune\fP)
 .IP \[bu]
-configured Solution and Notes
+configured Solution
+.br
+The entry 'configured Solution' shows the Solution, which was manually applied by '\fIsaptune solution apply <solution name>\fP'.
+.IP \[bu]
+configured Notes
+.br
+The entry 'configured Notes' shows all Notes, which were manually applied by '\fIsaptune note apply <note name>\fP'. They are \fBone\fP part of the list of notes in the entry 'applied Notes' and 'order of enabled Notes'.
 .IP \[bu]
 all selected Notes in applied order
+.br
+The list of 'order of enabled Notes' includes all Notes from 'configured Notes' and additional all the Notes related to the 'configured Solution' too. The list shows the order in which these Notes were applied and will be re-applied after a system reboot, if the \fBsaptune.service\fP is enabled.
 .IP \[bu]
 all currently applied Notes, sorted lexicographically
+.br
+The list of 'applied Notes' includes the \fBmanually\fP applied Notes. Additional it includes all the Notes related to the 'configured Solution' too. These Notes get applied when using '\fIsaptune solution apply\fP'. The solutions and their related notes can be listed by '\fIsaptune solution list\fP'.
+
+And additional 'applied Notes' shows you, if your system is '\fBactively\fP' tuned at the moment. If the list is empty, your system is \fBnot\fP tuned. If the list is \fBnot\fP empty, your system \fBis\fP tuned.
 .IP \[bu]
 state of staging
 .IP \[bu]
@@ -131,7 +143,7 @@ status of sapconf.service (enabled/disabled, running/stopped)
 .IP \[bu]
 status of tuned (enabled/disabled, running/stopped, profile)
 .IP \[bu]
-systemd status
+the overall systemd 'system' status, read from \fI'systemctl is-system-running'\fP (running, degraded, ....)
 
 This information is not logged, but only printed to stdout.
 

--- a/sap/note/sectBlock.go
+++ b/sap/note/sectBlock.go
@@ -165,7 +165,7 @@ func SetBlkVal(key, value string, cur *param.BlockDeviceQueue, revert bool) erro
 func chkMaxHWsector(key, val string) (int, string, string) {
 	info := ""
 	ival, _ := strconv.Atoi(val)
-	dname := regexp.MustCompile(`^MAX_SECTORS_KB_(\w+)$`)
+	dname := regexp.MustCompile(`^MAX_SECTORS_KB_(\w+\-?\d*)$`)
 	bdev := dname.FindStringSubmatch(key)
 	maxHWsector, _ := system.GetSysInt(path.Join("block", bdev[1], "queue", "max_hw_sectors_kb"))
 	if ival > maxHWsector {

--- a/system/blockdev.go
+++ b/system/blockdev.go
@@ -21,13 +21,13 @@ type BlockDev struct {
 var IsSched = regexp.MustCompile(`^IO_SCHEDULER_\w+\-?\d*$`)
 
 // IsNrreq matches block device nrreq tag
-var IsNrreq = regexp.MustCompile(`^NRREQ_\w+$`)
+var IsNrreq = regexp.MustCompile(`^NRREQ_\w+\-?\d*$`)
 
 // IsRahead matches block device read_ahead_kb tag
-var IsRahead = regexp.MustCompile(`^READ_AHEAD_KB_\w+$`)
+var IsRahead = regexp.MustCompile(`^READ_AHEAD_KB_\w+\-?\d*$`)
 
 // IsMsect matches block device max_sectors_kb tag
-var IsMsect = regexp.MustCompile(`^MAX_SECTORS_KB_\w+$`)
+var IsMsect = regexp.MustCompile(`^MAX_SECTORS_KB_\w+\-?\d*$`)
 
 var isVD = regexp.MustCompile(`^vd\w+$`)
 

--- a/system/csp.go
+++ b/system/csp.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"io/ioutil"
+	"os"
 	"regexp"
 )
 
@@ -24,6 +25,8 @@ const (
 	CSPAlibaba     = "alibaba"
 	CSPAlibabaLong = "Alibaba Cloud"
 )
+
+var dmiDir = "/sys/class/dmi"
 
 // dmidecode key files
 // /usr/sbin/dmidecode -s chassis-asset-tag
@@ -63,6 +66,10 @@ var isAlibaba = regexp.MustCompile(`.*[aA]libaba.*`)
 func GetCSP() string {
 	csp := ""
 
+	if _, err := os.Stat(dmiDir); os.IsNotExist(err) {
+		InfoLog("directory '%s' does not exist", dmiDir)
+		return csp
+	}
 	// check for Azure
 	if content, err := ioutil.ReadFile(dmiChassisAssetTag); err == nil {
 		matches := isAzureCat.FindStringSubmatch(string(content))

--- a/system/sys.go
+++ b/system/sys.go
@@ -147,7 +147,7 @@ func GetNrTags(key string) (int, string, string) {
 	nrtags := 0
 	elev := ""
 	disk := ""
-	dname := regexp.MustCompile(`^NRREQ_(\w+)$`)
+	dname := regexp.MustCompile(`^NRREQ_(\w+\-?\d*)$`)
 	bdev := dname.FindStringSubmatch(key)
 	if len(bdev) > 0 {
 		nrTagsFile := path.Join("block", bdev[1], "mq", "0", "nr_tags")

--- a/system/system.go
+++ b/system/system.go
@@ -301,6 +301,8 @@ func GetDmiID(file string) (string, error) {
 	fileName := fmt.Sprintf("%s/%s", DmiID, file)
 	if content, err = ioutil.ReadFile(fileName); err == nil {
 		ret = strings.TrimSpace(string(content))
+	} else {
+		InfoLog("failed to read %s - %v", fileName, err)
 	}
 	return ret, err
 }
@@ -323,6 +325,8 @@ func GetHWIdentity(info string) (string, error) {
 	}
 	if content, err = ioutil.ReadFile(fileName); err == nil {
 		ret = strings.TrimSpace(string(content))
+	} else {
+		InfoLog("failed to read %s - %v", fileName, err)
 	}
 	return ret, err
 }


### PR DESCRIPTION
enhance man page 'saptune.8'. Add entry 'configured Note' and some more descriptions of the entries from 'saptune service status'  (bsc#1192697)
