### PR TITLE
bsc#1194334 - 'saptune status' now reports the 'real' unit state.

### DIFF
--- a/actions/footnote.go
+++ b/actions/footnote.go
@@ -83,7 +83,7 @@ func setUsNa(actVal, compliant, comment string, footnote []string) (string, stri
 		compliant = compliant + " [1]"
 		comment = comment + " [1]"
 		footnote[0] = footnote1
-	case "NA":
+	case "NA", "":
 		compliant = compliant + " [2]"
 		comment = comment + " [2]"
 		footnote[1] = footnote2

--- a/actions/serviceacts.go
+++ b/actions/serviceacts.go
@@ -467,15 +467,11 @@ func printSapconfStatus(writer io.Writer) bool {
 		} else {
 			fmt.Fprintf(writer, "disabled/")
 		}
-		active, err := system.SystemctlIsRunning(SapconfService)
-		if err != nil {
+		active, err := system.SystemctlIsActive(SapconfService)
+		if active == "" {
 			system.ErrorExit("%v", err)
 		}
-		if active {
-			fmt.Fprintf(writer, "active\n")
-		} else {
-			fmt.Fprintf(writer, "stopped\n")
-		}
+		fmt.Fprintf(writer, "%s\n", active)
 	} else {
 		fmt.Fprintf(writer, "not available\n")
 	}
@@ -495,14 +491,14 @@ func printTunedStatus(writer io.Writer) {
 		} else {
 			fmt.Fprintf(writer, "disabled/")
 		}
-		active, err := system.SystemctlIsRunning(TunedService)
-		if err != nil {
+		active, err := system.SystemctlIsActive(TunedService)
+		if active == "" {
 			system.ErrorExit("%v", err)
 		}
-		if active {
-			fmt.Fprintf(writer, "running (profile: '%s')\n", system.GetTunedAdmProfile())
+		if active == "active" {
+			fmt.Fprintf(writer, "%s (profile: '%s')\n", active, system.GetTunedAdmProfile())
 		} else {
-			fmt.Fprintf(writer, "stopped\n")
+			fmt.Fprintf(writer, "%s\n", active)
 		}
 	} else {
 		fmt.Fprintf(writer, "not available\n")
@@ -586,16 +582,14 @@ func printSaptuneStatus(writer io.Writer) (bool, bool, bool) {
 		fmt.Fprintf(writer, "enabled/")
 		stenabled = true
 	}
-	active, err := system.SystemctlIsRunning(SaptuneService)
-	if err != nil {
+	active, err := system.SystemctlIsActive(SaptuneService)
+	if active == "" {
 		system.ErrorExit("%v", err)
 	}
-	if active {
-		fmt.Fprintf(writer, "active\n")
-	} else {
-		fmt.Fprintf(writer, "stopped\n")
+	if active != "active" {
 		saptuneStopped = true
 	}
+	fmt.Fprintf(writer, "%s\n", active)
 	return saptuneStopped, remember, stenabled
 }
 

--- a/actions/serviceacts_test.go
+++ b/actions/serviceacts_test.go
@@ -75,7 +75,7 @@ staging:                disabled
 staging area:           
 
 sapconf.service:        not available
-tuned.service:          disabled/running (profile: 'balanced')
+tuned.service:          disabled/active (profile: 'balanced')
 system state:           running
 
 Remember: if you wish to automatically activate the note's and solution's tuning options after a reboot, you must enable saptune.service by running:
@@ -203,7 +203,7 @@ staging:                disabled
 staging area:           
 
 sapconf.service:        not available
-tuned.service:          disabled/running (profile: 'balanced')
+tuned.service:          disabled/active (profile: 'balanced')
 system state:           running
 
 Remember: if you wish to automatically activate the note's and solution's tuning options after a reboot, you must enable saptune.service by running:

--- a/actions/table.go
+++ b/actions/table.go
@@ -22,6 +22,12 @@ func PrintNoteFields(writer io.Writer, header string, noteComparisons map[string
 	override := ""
 	comment := ""
 	hasDiff := false
+	// for sysctl and sys parameter not available on the system
+	// the actual value is empty, but for better/consolidated output
+	// set it to 'NA'. Because of many internal dependencies do not
+	// change the actual value during 'Initialize' (for now)
+	pAct := "NA"
+	pExp := ""
 
 	// sort output
 	sortkeys := sortNoteComparisonsOutput(noteComparisons)
@@ -58,12 +64,16 @@ func PrintNoteFields(writer io.Writer, header string, noteComparisons map[string
 		}
 
 		// print table body
+		if comparison.ActualValueJS != "" {
+			pAct = strings.Replace(comparison.ActualValueJS, "\t", " ", -1)
+		}
+		pExp = strings.Replace(comparison.ExpectedValueJS, "\t", " ", -1)
 		if printComparison {
 			// verify
-			fmt.Fprintf(writer, format, noteField, comparison.ReflectMapKey, strings.Replace(comparison.ExpectedValueJS, "\t", " ", -1), override, strings.Replace(comparison.ActualValueJS, "\t", " ", -1), compliant)
+			fmt.Fprintf(writer, format, noteField, comparison.ReflectMapKey, pExp, override, pAct, compliant)
 		} else {
 			// simulate
-			fmt.Fprintf(writer, format, comparison.ReflectMapKey, strings.Replace(comparison.ActualValueJS, "\t", " ", -1), strings.Replace(comparison.ExpectedValueJS, "\t", " ", -1), override, comment)
+			fmt.Fprintf(writer, format, comparison.ReflectMapKey, pAct, pExp, override, comment)
 		}
 	}
 	// print footer

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -111,7 +111,7 @@ If the action was successfully the exit code is 0, otherwise 1.
 Reports the following status information on stdout:
 .RS 5
 .IP \[bu] 2
-status of saptune.service (enabled/disabled, running/stopped)
+status of saptune.service (enabled/disabled, active/inactive/failed/...the other possible unit states...)
 .IP \[bu]
 saptune package version
 .IP \[bu]
@@ -139,15 +139,15 @@ state of staging
 .IP \[bu]
 all objects in staging area
 .IP \[bu]
-status of sapconf.service (enabled/disabled, running/stopped)
+status of sapconf.service (enabled/disabled, active/inactive/failed/...the other possible unit states...)
 .IP \[bu]
-status of tuned (enabled/disabled, running/stopped, profile)
+status of tuned (enabled/disabled, active/inactive/failed/...the other possible unit states..., profile)
 .IP \[bu]
 the overall systemd 'system' status, read from \fI'systemctl is-system-running'\fP (running, degraded, ....)
 
 This information is not logged, but only printed to stdout.
 
-If saptune.service is not running(stopped) the exit code is 1, if the system is '\fBnot tuned\fP' - which means no Note or Solution is enabled - the exit code is 3, otherwise the exit code is 0.
+If saptune.service is \fBnot\fP 'active' the exit code is 1, if the system is '\fBnot tuned\fP' - which means no Note or Solution is enabled - the exit code is 3, otherwise the exit code is 0.
 .SS
 .TP
 .B stop

--- a/sap/note/note.go
+++ b/sap/note/note.go
@@ -211,7 +211,7 @@ func CompareNoteFields(actualNote, expectedNote Note) (allMatch bool, comparison
 					// if this should change in the future use
 					// !strings.Contains(key.String(), "grub")
 					// instead of !isInternalGrub(key.String())
-					if actualValue.(string) != "all:none" && !isInternalGrub(key.String()) && !(system.IsXFSOption.MatchString(key.String()) && actualValue.(string) == "NA") && key.String() != "VSZ_TMPFS_PERCENT" {
+					if actualValue.(string) != "all:none" && !isInternalGrub(key.String()) && !(system.IsXFSOption.MatchString(key.String()) && actualValue.(string) == "NA") && actualValue.(string) != "" && key.String() != "VSZ_TMPFS_PERCENT" {
 						allMatch = false
 					}
 				}
@@ -298,6 +298,7 @@ func cmpMapValue(fieldName string, key reflect.Value, actVal, expVal interface{}
 		// so set match to true
 		match = true
 	}
+
 	if key.String() == "reminder" {
 		// a diff in the reminder section should not influence the
 		// compare result. So set macth to true

--- a/sap/note/sectSys.go
+++ b/sap/note/sectSys.go
@@ -19,9 +19,6 @@ func GetSysVal(key string) (string, string) {
 	if strings.ContainsAny(val, "[]") {
 		val, _ = system.GetSysChoice(key)
 	}
-	if val == "" {
-		val = "NA"
-	}
 	return val, info
 }
 

--- a/sap/note/sectSys_test.go
+++ b/sap/note/sectSys_test.go
@@ -21,8 +21,8 @@ func TestGetSysVal(t *testing.T) {
 		t.Errorf("expected '', got '%s'\n", inf)
 	}
 	val, inf = GetSysVal("kernel.mm.angi")
-	if val != "NA" {
-		t.Errorf("expected 'NA', got '%s'\n", val)
+	if val != "" {
+		t.Errorf("expected '', got '%s'\n", val)
 	}
 	if inf != "" {
 		t.Errorf("expected '', got '%s'\n", inf)

--- a/sap/note/sectSysctl.go
+++ b/sap/note/sectSysctl.go
@@ -13,7 +13,7 @@ import (
 func OptSysctlVal(operator txtparser.Operator, key, actval, cfgval string) string {
 	if actval == "" {
 		// sysctl parameter not available in system
-		return ""
+		return cfgval
 	}
 	if cfgval == "" {
 		// sysctl parameter should be leave untouched

--- a/sap/note/sectSysctl_test.go
+++ b/sap/note/sectSysctl_test.go
@@ -22,6 +22,10 @@ func TestOptSysctlVal(t *testing.T) {
 		t.Error(val)
 	}
 	val = OptSysctlVal(op, "TestParam", "", "100 330 180")
+	if val != "100 330 180" {
+		t.Error(val)
+	}
+	val = OptSysctlVal(op, "TestParam", "120 300 200", "")
 	if val != "" {
 		t.Error(val)
 	}

--- a/system/blockdev.go
+++ b/system/blockdev.go
@@ -119,7 +119,7 @@ func getValidBlockDevices() (valDevs []string) {
 		for _, edev := range excludedevs {
 			if bdev == edev {
 				// skip unsupported devices
-				InfoLog("skipping device '%s', md slaves unsupported", bdev)
+				InfoLog("skipping device '%s', dm slaves unsupported", bdev)
 				exclude = true
 				break
 			}

--- a/system/daemon.go
+++ b/system/daemon.go
@@ -168,6 +168,17 @@ func SystemctlIsRunning(thing string) (bool, error) {
 	return match, nil
 }
 
+// SystemctlIsActive return true only if systemctl suggests that the thing is
+// running.
+func SystemctlIsActive(thing string) (string, error) {
+	out, err := exec.Command(systemctlCmd, "is-active", thing).CombinedOutput()
+	DebugLog("SystemctlIsRunning - /usr/bin/systemctl is-active : '%+v %s'", err, string(out))
+	if len(out) == 0 && err != nil {
+		return "", ErrorLog("%v - Failed to call systemctl is-active", err)
+	}
+	return strings.TrimSpace(string(out)), err
+}
+
 // GetSystemState returns the output of 'systemctl is-system-running'
 func GetSystemState() (string, error) {
 	retval := ""

--- a/system/sys.go
+++ b/system/sys.go
@@ -51,7 +51,10 @@ func GetSysInt(parameter string) (int, error) {
 
 // SetSysString write a string /sys/ value.
 func SetSysString(parameter, value string) error {
-	if err := ioutil.WriteFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644); err != nil {
+	err := ioutil.WriteFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644)
+	if os.IsNotExist(err) {
+		WarningLog("sys key '%s' is not supported by os, skipping.", parameter)
+	} else if err != nil {
 		WarningLog("failed to set sys key '%s' to string '%s': %v", parameter, value, err)
 		return err
 	}


### PR DESCRIPTION
'saptune status' now reports the 'real' unit state. No mapping of not running (inactive) service to simply 'stopped' any more.
(bsc#1194334)

'saptune verify' will now report a non existing sysctl or sys parameter as 'not available on the system' (footnote) and this parameter will not affect the compliance state. But a warning is displayed to raise attention to may be typos in the parameter name.
Additional fix to support 'apply' and 'revert' without throwing an error, if only one, non existing sysctl or sys parameter is in the note definition file.