### PR TITLE
first changes for saptune v3.1 - inline comments, saptune check and detect virtualization

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -266,6 +266,8 @@ Revert all parameters tuned by the SAP notes or solutions:
   saptune revert all
 Remove the pending lock file from a former saptune call
   saptune lock remove
+Call external script '/usr/sbin/saptune_check'
+  saptune check
 Print current saptune status:
   saptune status
 Print current saptune version:

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -138,6 +138,8 @@ Revert all parameters tuned by the SAP notes or solutions:
   saptune revert all
 Remove the pending lock file from a former saptune call
   saptune lock remove
+Call external script '/usr/sbin/saptune_check'
+  saptune check
 Print current saptune status:
   saptune status
 Print current saptune version:
@@ -259,6 +261,8 @@ Revert all parameters tuned by the SAP notes or solutions:
   saptune revert all
 Remove the pending lock file from a former saptune call
   saptune lock remove
+Call external script '/usr/sbin/saptune_check'
+  saptune check
 Print current saptune status:
   saptune status
 Print current saptune version:

--- a/actions/serviceacts.go
+++ b/actions/serviceacts.go
@@ -207,6 +207,9 @@ func ServiceActionStatus(writer io.Writer, tuneApp *app.App, saptuneVersion stri
 	// check for system(d) state
 	infoTrigger["chkHint"] = printSystemStatus(writer)
 
+	// check for virtualization environment
+	printVirtStatus(writer)
+
 	printInfoBlock(writer, infoTrigger)
 
 	// order of exit codes important for yast2 module!
@@ -602,6 +605,13 @@ func printSystemStatus(writer io.Writer) bool {
 		chkHint = true
 	}
 	return chkHint
+}
+
+// printVirtStatus prints the virtualization environment
+func printVirtStatus(writer io.Writer) {
+	vtype := system.GetVirtStatus()
+	system.InfoLog("Following virtualized environment was detected: %s", vtype)
+	fmt.Fprintf(writer, "virtualization:         %s\n", vtype)
 }
 
 // printInfoBlock prints additional info for the status

--- a/actions/serviceacts_test.go
+++ b/actions/serviceacts_test.go
@@ -63,7 +63,7 @@ func TestDaemonActions(t *testing.T) {
 
 	// Test DaemonActionStatus
 	t.Run("DaemonActionStatus", func(t *testing.T) {
-		var daemonStatusMatchText = `
+		daemonStatusMatchText := fmt.Sprintf(`
 saptune.service:        disabled/active
 saptune package:        'undef'
 configured version:     '3'
@@ -75,13 +75,14 @@ staging:                disabled
 staging area:           
 
 sapconf.service:        not available
-tuned.service:          disabled/active (profile: 'balanced')
+tuned.service:          disabled/active (profile: '%s')
 system state:           running
+virtualization:         %s
 
 Remember: if you wish to automatically activate the note's and solution's tuning options after a reboot, you must enable saptune.service by running:
  'saptune service enable'.
 
-`
+`, system.GetTunedAdmProfile(), system.GetVirtStatus())
 		ServiceActionStart(false, sApp)
 
 		oldOSExit := system.OSExit
@@ -191,7 +192,7 @@ func TestServiceActions(t *testing.T) {
 
 	// Test ServiceActionStatus
 	t.Run("ServiceActionStatus", func(t *testing.T) {
-		var serviceStatusMatchText = `
+		serviceStatusMatchText := fmt.Sprintf(`
 saptune.service:        disabled/active
 saptune package:        'undef'
 configured version:     '3'
@@ -203,13 +204,14 @@ staging:                disabled
 staging area:           
 
 sapconf.service:        not available
-tuned.service:          disabled/active (profile: 'balanced')
+tuned.service:          disabled/active (profile: '%s')
 system state:           running
+virtualization:         %s
 
 Remember: if you wish to automatically activate the note's and solution's tuning options after a reboot, you must enable saptune.service by running:
  'saptune service enable'.
 
-`
+`, system.GetTunedAdmProfile(), system.GetVirtStatus())
 		ServiceActionStart(false, sApp)
 
 		oldOSExit := system.OSExit

--- a/actions/solutionacts_test.go
+++ b/actions/solutionacts_test.go
@@ -251,6 +251,8 @@ Revert all parameters tuned by the SAP notes or solutions:
   saptune revert all
 Remove the pending lock file from a former saptune call
   saptune lock remove
+Call external script '/usr/sbin/saptune_check'
+  saptune check
 Print current saptune status:
   saptune status
 Print current saptune version:
@@ -307,6 +309,8 @@ Revert all parameters tuned by the SAP notes or solutions:
   saptune revert all
 Remove the pending lock file from a former saptune call
   saptune lock remove
+Call external script '/usr/sbin/saptune_check'
+  saptune check
 Print current saptune status:
   saptune status
 Print current saptune version:
@@ -366,6 +370,8 @@ Revert all parameters tuned by the SAP notes or solutions:
   saptune revert all
 Remove the pending lock file from a former saptune call
   saptune lock remove
+Call external script '/usr/sbin/saptune_check'
+  saptune check
 Print current saptune status:
   saptune status
 Print current saptune version:

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"reflect"
 	"testing"
+	"time"
 )
 
 var OSPackageInGOPATH = path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/ospackage/")
@@ -136,14 +137,15 @@ func TestReadConfig(t *testing.T) {
 		t.Fatal(tuneApp)
 	}
 
+	time.Sleep(5 * time.Second)
 	// Read from testdata config 'testdata/etc/sysconfig/saptune'
-	tuneApp = InitialiseApp(TstFilesInGOPATH, "", AllTestNotes, AllTestSolutions)
+	tApp := InitialiseApp(TstFilesInGOPATH, "", AllTestNotes, AllTestSolutions)
 	matchTxt := `
 current order of enabled notes is: 2205917 2684254 1680803
 
 `
 	buffer := bytes.Buffer{}
-	tuneApp.PrintNoteApplyOrder(&buffer)
+	tApp.PrintNoteApplyOrder(&buffer)
 	txt := buffer.String()
 	if txt != matchTxt {
 		fmt.Println("==============")

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 // constant definitions
 const (
 	saptuneV1 = "/usr/sbin/saptune_v1"
+	saptcheck = "/usr/sbin/saptune_check"
 	logFile   = "/var/log/saptune/saptune.log"
 )
 
@@ -65,6 +66,7 @@ func main() {
 			actions.PrintHelpAndExit(os.Stdout, 0)
 		}
 	}
+	callSaptuneCheckScript(arg1)
 
 	// only one instance of saptune should run
 	// check and set saptune lock file
@@ -140,6 +142,25 @@ func checkForTuned() {
 	enabled, _ := system.SystemctlIsEnabled(actions.TunedService)
 	if enabled || active {
 		system.WarningLog("ATTENTION: tuned service is active, so we may encounter conflicting tuning values")
+	}
+}
+
+// callSaptuneCheckScript will simply call the saptune_check script
+// it's done before the saptune lock is set, but after the check for
+// running as root
+func callSaptuneCheckScript(arg string) {
+	if arg == "check" {
+		// call external scrip saptune_check
+		cmd := exec.Command(saptcheck)
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err := cmd.Run()
+		if err != nil {
+			system.ErrorExit("command '%+s' failed with error '%v'\n", saptcheck, err)
+		} else {
+			system.ErrorExit("", 0)
+		}
 	}
 }
 

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -1,5 +1,5 @@
 .\"/*
-.\" * Copyright (c) 2017-2021 SUSE LLC.
+.\" * Copyright (c) 2017-2022 SUSE LLC.
 .\" * All rights reserved
 .\" * Authors: Soeren Schmidt, Angela Briel
 .\" *
@@ -14,17 +14,15 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\"
-.TH saptune "8" "August 2021" "" "System Optimisation For SAP"
+.TH saptune "8" "March 2022" "" "System Optimisation For SAP"
 .SH NAME
 saptune \- Comprehensive system optimisation management for SAP solutions (\fBVersion 3\fP)
 
 ATTENTION: If you still use version \fB1\fP of saptune it's now time to migrate to saptune version \fB3\fP, so please refer to man page saptune-migrate(7).
 
 .SH SYNOPSIS
-ATTENTION: deprecated
-.br
 \fBsaptune daemon\fP
-[ start | status | stop ]
+[ start | status | stop ] \fBATTENTION: deprecated\fP
 
 \fBsaptune service\fP
 [ start | status | stop | restart | takeover | enable | disable | enablestart | disablestop ]
@@ -58,6 +56,8 @@ release [--force|--dry-run] [ NoteID... | SolutionID... | all ]
 
 \fBsaptune revert\fP
 all
+
+\fBsaptune check\fP
 
 \fBsaptune status\fP
 
@@ -598,6 +598,11 @@ Because the release is irreversible, the user has to confirm the action.
 .TP
 .B revert all
 Revert all optimisation settings recommended by the SAP solution and/or the Notes, and these settings will no longer be activated automatically upon system boot.
+
+.SH CHECK ACTIONS
+.TP
+.B check
+Will simply call the external script '/usr/sbin/saptune_check'.
 
 .SH STATUS ACTIONS
 .TP

--- a/ospackage/usr/share/saptune/deprecated/MAXDB.sol
+++ b/ospackage/usr/share/saptune/deprecated/MAXDB.sol
@@ -1,5 +1,0 @@
-[ArchX86]
-deprecated
-
-[ArchPPC64LE]
-deprecated

--- a/sap/note/sectLogin_test.go
+++ b/sap/note/sectLogin_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/SUSE/saptune/system"
 	"os"
 	"testing"
+	"time"
 )
 
 func TestGetLoginVal(t *testing.T) {
@@ -55,6 +56,8 @@ func TestSetLoginVal(t *testing.T) {
 	if !system.CheckForPattern(utmFile, val) {
 		t.Errorf("wrong value in file '%s'\n", utmFile)
 	}
+	// adding sleep to prevent 'service start-limit-hit'
+	time.Sleep(5 * time.Second)
 	val = "infinity"
 	err = SetLoginVal("UserTasksMax", val, false)
 	if err != nil {
@@ -66,6 +69,8 @@ func TestSetLoginVal(t *testing.T) {
 	if !system.CheckForPattern(utmFile, val) {
 		t.Errorf("wrong value in file '%s'\n", utmFile)
 	}
+	// adding sleep to prevent 'service start-limit-hit'
+	time.Sleep(10 * time.Second)
 	val = "10813"
 	err = SetLoginVal("UserTasksMax", val, true)
 	if err != nil {

--- a/system/cpu_test.go
+++ b/system/cpu_test.go
@@ -252,8 +252,10 @@ func TestCPUErrorCases(t *testing.T) {
 	if len(gval) != 0 {
 		t.Errorf("should return an empty value, but returns: %+v", gval)
 	}
-	if err := SetForceLatency("70", "cpu1:state0:0 cpu1:state1:0", "", false); err == nil {
-		t.Error("should return an error and not 'nil'")
+	if canSetForceLatency("70", "") {
+		if err := SetForceLatency("70", "cpu1:state0:0 cpu1:state1:0", "", false); err == nil {
+			t.Error("should return an error and not 'nil'")
+		}
 	}
 	cpuDir = oldCPUDir
 }

--- a/system/daemon.go
+++ b/system/daemon.go
@@ -53,7 +53,7 @@ func SystemctlRestart(thing string) error {
 		if err != nil {
 			return ErrorLog("%v - Failed to call systemctl restart on %s - %s", err, thing, string(out))
 		}
-		DebugLog("SystemctlRestart( - /usr/bin/systemctl restart '%s' : '%+v %s'", thing, err, string(out))
+		DebugLog("SystemctlRestart - /usr/bin/systemctl restart '%s' : '%+v %s'", thing, err, string(out))
 	}
 	return nil
 }
@@ -69,7 +69,23 @@ func SystemctlReloadTryRestart(thing string) error {
 		if err != nil {
 			return ErrorLog("%v - Failed to call systemctl reload-or-try-restart on %s - %s", err, thing, string(out))
 		}
-		DebugLog("SystemctlReloadTryRestart( - /usr/bin/systemctl reload-or-try-restart '%s' : '%+v %s'", thing, err, string(out))
+		DebugLog("SystemctlReloadTryRestart - /usr/bin/systemctl reload-or-try-restart '%s' : '%+v %s'", thing, err, string(out))
+	}
+	return nil
+}
+
+// SystemctlResetFailed call systemctl reset-failed.
+func SystemctlResetFailed() error {
+	running, err := IsSystemRunning()
+	if err != nil {
+		return ErrorLog("%v - Failed to call systemctl reset-failed", err)
+	}
+	if running {
+		out, err := exec.Command(systemctlCmd, "reset-failed").CombinedOutput()
+		if err != nil {
+			return ErrorLog("%v - Failed to call systemctl reset-failed - %s", err, string(out))
+		}
+		DebugLog("SystemctlResetFailed - /usr/bin/systemctl reset-failed : '%+v %s'", err, string(out))
 	}
 	return nil
 }
@@ -145,9 +161,9 @@ func SystemctlIsEnabled(thing string) (bool, error) {
 func SystemctlIsStarting() bool {
 	match := false
 	out, err := exec.Command(systemctlCmd, "is-system-running").CombinedOutput()
-	DebugLog("IsSystemRunning - /usr/bin/systemctl is-system-running : '%+v %s'", err, string(out))
+	DebugLog("SystemctlIsStarting - /usr/bin/systemctl is-system-running : '%+v %s'", err, string(out))
 	if strings.TrimSpace(string(out)) == "starting" {
-		DebugLog("IsSystemRunning - system is in state 'starting'")
+		DebugLog("SystemctlIsStarting - system is in state 'starting'")
 		match = true
 	}
 	return match
@@ -172,7 +188,7 @@ func SystemctlIsRunning(thing string) (bool, error) {
 // running.
 func SystemctlIsActive(thing string) (string, error) {
 	out, err := exec.Command(systemctlCmd, "is-active", thing).CombinedOutput()
-	DebugLog("SystemctlIsRunning - /usr/bin/systemctl is-active : '%+v %s'", err, string(out))
+	DebugLog("SystemctlIsActive - /usr/bin/systemctl is-active : '%+v %s'", err, string(out))
 	if len(out) == 0 && err != nil {
 		return "", ErrorLog("%v - Failed to call systemctl is-active", err)
 	}
@@ -183,7 +199,7 @@ func SystemctlIsActive(thing string) (string, error) {
 func GetSystemState() (string, error) {
 	retval := ""
 	out, err := exec.Command(systemctlCmd, "is-system-running").CombinedOutput()
-	DebugLog("IsSystemRunning - /usr/bin/systemctl is-system-running : '%+v %s'", err, string(out))
+	DebugLog("GetSystemState - /usr/bin/systemctl is-system-running : '%+v %s'", err, string(out))
 	if len(out) != 0 {
 		retval = strings.TrimSpace(string(out))
 	}

--- a/system/daemon_test.go
+++ b/system/daemon_test.go
@@ -1,7 +1,9 @@
 package system
 
 import (
+	"os"
 	"os/exec"
+	"path"
 	"testing"
 )
 
@@ -406,4 +408,105 @@ func TestDaemonErrorCases(t *testing.T) {
 		t.Log(err)
 	}
 	_ = SystemctlStart("tuned.service")
+}
+
+func TestSystemdDetectVirt(t *testing.T) {
+	opt := ""
+	oldSystemddvCmd := systemddvCmd
+	// test: virtualization found
+	systemddvCmd = path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/systemdDVOK")
+	exp := "kvm"
+	virt, vtype, err := SystemdDetectVirt("-v")
+	if !virt {
+		t.Error("virtualization should be true, but is false")
+	}
+	if vtype != exp {
+		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, vtype)
+	}
+	if err != nil {
+		t.Errorf("Test failed, returned error should be 'nil', but got: '%v'", err)
+	}
+
+	exp = "lxc"
+	virt, vtype, err = SystemdDetectVirt("-c")
+	if !virt {
+		t.Error("virtualization should be true, but is false")
+	}
+	if vtype != exp {
+		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, vtype)
+	}
+	if err != nil {
+		t.Errorf("Test failed, returned error should be 'nil', but got: '%v'", err)
+	}
+
+	exp = ""
+	virt, vtype, err = SystemdDetectVirt("-r")
+	if !virt {
+		t.Error("virtualization should be true, but is false")
+	}
+	if vtype != exp {
+		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, vtype)
+	}
+	if err != nil {
+		t.Errorf("Test failed, returned error should be 'nil', but got: '%v'", err)
+	}
+
+	exp = "none"
+	virt, vtype, err = SystemdDetectVirt(opt)
+	if !virt {
+		t.Error("virtualization should be true, but is false")
+	}
+	if vtype != exp {
+		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, vtype)
+	}
+	if err != nil {
+		t.Errorf("Test failed, returned error should be 'nil', but got: '%v'", err)
+	}
+
+	// test: virtualization NOT available
+	systemddvCmd = path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/systemdDVNOK")
+	exp = "none"
+	virt, vtype, err = SystemdDetectVirt("-v")
+	if virt {
+		t.Error("virtualization should be false, but is true")
+	}
+	if vtype != exp {
+		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, vtype)
+	}
+	if err == nil {
+		t.Errorf("Test failed, returned error should be NOT 'nil', but got: '%v'", err)
+	}
+	virt, vtype, err = SystemdDetectVirt("-c")
+	if virt {
+		t.Error("virtualization should be false, but is true")
+	}
+	if vtype != exp {
+		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, vtype)
+	}
+	if err == nil {
+		t.Errorf("Test failed, returned error should be NOT 'nil', but got: '%v'", err)
+	}
+	virt, vtype, err = SystemdDetectVirt(opt)
+	if virt {
+		t.Error("virtualization should be false, but is true")
+	}
+	if vtype != exp {
+		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, vtype)
+	}
+	if err == nil {
+		t.Errorf("Test failed, returned error should be NOT 'nil', but got: '%v'", err)
+	}
+	exp = ""
+	virt, vtype, err = SystemdDetectVirt("-r")
+	if virt {
+		t.Error("virtualization should be false, but is true")
+	}
+	if vtype != exp {
+		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, vtype)
+	}
+	if err == nil {
+		t.Errorf("Test failed, returned error should be NOT 'nil', but got: '%v'", err)
+	}
+
+	systemddvCmd = oldSystemddvCmd
 }

--- a/system/daemon_test.go
+++ b/system/daemon_test.go
@@ -103,6 +103,13 @@ func TestSystemctl(t *testing.T) {
 		t.Fatal("systemctl reports system is in state 'starting'")
 	}
 	sysState, err := GetSystemState()
+	if sysState == "degraded" {
+		err = SystemctlResetFailed()
+	}
+	if err != nil {
+		t.Error("systemctl reset-failed did not help")
+	}
+	sysState, err = GetSystemState()
 	if err != nil {
 		t.Fatal(err, sysState)
 	}

--- a/system/system.go
+++ b/system/system.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"unicode"
 )
 
 // SaptuneSectionDir defines saptunes saved state directory
@@ -329,6 +330,16 @@ func GetHWIdentity(info string) (string, error) {
 		InfoLog("failed to read %s - %v", fileName, err)
 	}
 	return ret, err
+}
+
+// StripComment will strip everything right from the given comment character
+// (including the comment character) and returns the resulting string
+// comment characters can be '#' or ';' or something else
+func StripComment(str, commentChars string) string {
+	if cut := strings.IndexAny(str, commentChars); cut >= 0 {
+		return strings.TrimRightFunc(str[:cut], unicode.IsSpace)
+	}
+	return str
 }
 
 // Watch prints the current time

--- a/system/system.go
+++ b/system/system.go
@@ -342,6 +342,43 @@ func StripComment(str, commentChars string) string {
 	return str
 }
 
+// GetVirtStatus gets the status of virtualization environment
+func GetVirtStatus() string {
+	vtype := ""
+	// first check vm (-v)
+	virt, vm, _ := SystemdDetectVirt("-v")
+	if virt {
+		// vm detected
+		vtype = vm
+	}
+	// next check container (-c)
+	virt, container, _ := SystemdDetectVirt("-c")
+	if virt {
+		// container detected
+		if vtype == "" {
+			vtype = container
+		} else {
+			vtype = vtype + " " + container
+		}
+	}
+	// last check for chroot (-r)
+	// be in mind, that the command will not deliver any output, but only
+	// return 0, if it found a chroot env or 1, if not
+	virt, _, _ = SystemdDetectVirt("-r")
+	if virt {
+		// chroot detected
+		if vtype == "" {
+			vtype = "chroot"
+		} else {
+			vtype = vtype + " chroot"
+		}
+	}
+	if vtype == "" {
+		vtype = "none"
+	}
+	return vtype
+}
+
 // Watch prints the current time
 func Watch() string {
 	t := time.Now()

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -485,3 +485,24 @@ func TestGetHWIdentity(t *testing.T) {
 	}
 	DmiID = "/sys/class/dmi/id"
 }
+
+func TestStripComments(t *testing.T) {
+	str := "Test string with # comment to strip"
+	exp := "Test string with "
+	res := StripComment(str, "#")
+	if res != exp {
+		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, res)
+	}
+	str = "Test string without comment to strip"
+	exp = "Test string with "
+	res = StripComment(str, "#")
+	if res != exp {
+		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, res)
+	}
+	str = "Test string with another; comment to strip"
+	exp = "Test string with another"
+	res = StripComment(str, ";")
+	if res != exp {
+		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, res)
+	}
+}

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -488,13 +488,13 @@ func TestGetHWIdentity(t *testing.T) {
 
 func TestStripComments(t *testing.T) {
 	str := "Test string with # comment to strip"
-	exp := "Test string with "
+	exp := "Test string with"
 	res := StripComment(str, "#")
 	if res != exp {
 		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, res)
 	}
 	str = "Test string without comment to strip"
-	exp = "Test string with "
+	exp = "Test string without comment to strip"
 	res = StripComment(str, "#")
 	if res != exp {
 		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, res)

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -506,3 +506,23 @@ func TestStripComments(t *testing.T) {
 		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, res)
 	}
 }
+
+func TestGetVirtStatus(t *testing.T) {
+	oldSystemddvCmd := systemddvCmd
+	// test: virtualization found
+	systemddvCmd = path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/systemdDVOK")
+	exp := "kvm lxc chroot"
+	vtype := GetVirtStatus()
+	if vtype != exp {
+		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, vtype)
+	}
+
+	// test: virtualization NOT available
+	systemddvCmd = path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/systemdDVNOK")
+	exp = "none"
+	vtype = GetVirtStatus()
+	if vtype != exp {
+		t.Errorf("Test failed, expected: '%s', got: '%s'", exp, vtype)
+	}
+	systemddvCmd = oldSystemddvCmd
+}

--- a/testdata/ini_all_test.ini
+++ b/testdata/ini_all_test.ini
@@ -45,6 +45,12 @@ tuned 2.10.0-11.3.2
 [rpm:os=12-*:arch=x86_64]
 tuned 2.8.0-4.3.1
 
+[rpm]
+tuned SLE12 2.8.0-4.3.1 # comment
+
+[rpm:os=15-*:arch=ppc64le]
+tuned 2.10.0-11.3.2	# comment
+
 [service]
 sysstat=stop
 uuidd.socket=start

--- a/testdata/systemdDVNOK
+++ b/testdata/systemdDVNOK
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# fake output of /usr/bin/systemd-detect-virt for unittests
+# use-case - no virtualization found
+
+# example
+# "-v" liefert - virt: true - vtype: microsoft - err: <nil>
+# "-c" liefert - virt: true - vtype: docker - err: <nil>
+# "-r" liefert - virt: false - vtype:  - err: exit status 1
+# "" liefert - virt: false - vtype: systemd-detect-virt takes no arguments. - err: exit status 1
+
+case "$1" in
+"-r")
+    echo ""
+    ;;
+"-c")
+    echo "none"
+    ;;
+"-v")
+    echo "none"
+    ;;
+*)
+    echo "none"
+    ;;
+esac
+exit 1

--- a/testdata/systemdDVOK
+++ b/testdata/systemdDVOK
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# fake output of /usr/bin/systemd-detect-virt for unittests
+# use-case - virtualization found
+
+# example
+# "-v" liefert - virt: true - vtype: microsoft - err: <nil>
+# "-c" liefert - virt: true - vtype: docker - err: <nil>
+# "-r" liefert - virt: false - vtype:  - err: exit status 1
+# "" liefert - virt: false - vtype: systemd-detect-virt takes no arguments. - err: exit status 1
+
+case "$1" in
+"-r")
+    echo ""
+    ;;
+"-c")
+    echo "lxc"
+    ;;
+"-v")
+    echo "kvm"
+    ;;
+*)
+    echo "none"
+    ;;
+esac
+exit 0

--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -260,6 +260,8 @@ func ParseINI(input string) *INIFile {
 			continue
 		}
 
+		// remove trailing comments from line
+		line = system.StripComment(line, "#")
 		// Break apart a line into key, operator, value.
 		kov := splitLineIntoKOV(currentSection, line)
 		if kov == nil {


### PR DESCRIPTION
- detect virtualization environment by 'systemd-detect-virt' and add the information to 'saptune status'.
  (jsc#SLE-23885)
- enhance saptune with the new action 'check' to directly call the external check script '/usr/sbin/saptune_check'.
  (jsc#SLE-23726)
- de-deprecate the MAXDB solution definition. It is still active supported by SAP.
  (jsc#SLE-23724)
- support inline comments in the Note definition files
  (jsc#23729)
