### PR TITLE
saptune v3.1 - colorized and filtered output for 'verify'

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -55,6 +55,9 @@ var RPMDate = "undef"
 // solutionSelector used in solutionacts and statgingacts
 var solutionSelector = system.GetSolutionSelector()
 
+// saptune configuration file
+var saptuneSysconfig = "/etc/sysconfig/saptune"
+
 // set colors for the table and list output
 //var setBlueText = "\033[34m"
 //var setCyanText = "\033[36m"
@@ -65,6 +68,7 @@ var setBoldText = "\033[1m"
 var resetBoldText = "\033[22m"
 var setStrikeText = "\033[9m"
 var resetTextColor = "\033[0m"
+var dfltColorScheme = "full-noncmpl"
 
 // SelectAction selects the chosen action depending on the first command line
 // argument
@@ -147,9 +151,9 @@ func VerifyAllParameters(writer io.Writer, tuneApp *app.App) {
 		PrintNoteFields(writer, "NONE", comparisons, true)
 		tuneApp.PrintNoteApplyOrder(writer)
 		if len(unsatisfiedNotes) == 0 {
-			fmt.Fprintf(writer, "The running system is currently well-tuned according to all of the enabled notes.\n")
+			fmt.Fprintf(writer, "%s%sThe running system is currently well-tuned according to all of the enabled notes.%s%s\n", setGreenText, setBoldText, resetBoldText, resetTextColor)
 		} else {
-			system.ErrorExit("The parameters listed above have deviated from SAP/SUSE recommendations.")
+			system.ErrorExit("The parameters listed above have deviated from SAP/SUSE recommendations.", "colorPrint", setRedText, setBoldText, resetBoldText, resetTextColor)
 		}
 	}
 }

--- a/actions/footnote.go
+++ b/actions/footnote.go
@@ -34,9 +34,39 @@ const (
 // set 'unsupported' footnote regarding the architecture
 var footnote1 = footnote1X86
 
+// prepFN checks, if we need to prepare the footnote for a parameter
+// if the command line flage '--show-non-compliant' is used only non compliant
+// parameter rows will be printed and that has to be reflected to the footnotes 
+// too.
+func prepFN(comparison note.FieldComparison, compliant, inform string) bool {
+	prep := true
+	if system.IsFlagSet("show-non-compliant") {
+		// skip preparation of footnotes, if compliant state is not 'no'
+		if strings.Contains(compliant, "yes") || strings.Contains(compliant, "-") {
+			prep = false
+		}
+		// and now define the exceptions, which need a special handling
+		if comparison.ReflectMapKey == "force_latency" && inform == "hasDiffs" {
+			// compliant will be set to 'no' during footnote preparation
+			prep = true
+		}
+		if comparison.ReflectMapKey == "VSZ_TMPFS_PERCENT" {
+			// compliant will be set to '-' during footnote preparation
+			prep = true
+		}
+		if strings.Contains(comparison.ReflectMapKey, "xfsopt_") {
+			prep = true
+		}
+	}
+	return prep
+}
+
 // prepareFootnote prepares the content of the last column and the
 // corresponding footnotes
 func prepareFootnote(comparison note.FieldComparison, compliant, comment, inform string, footnote []string) (string, string, []string) {
+	if !prepFN(comparison, compliant, inform) {
+		return compliant, comment, footnote
+	}
 	// set 'unsupported' footnote regarding the architecture
 	if runtime.GOARCH == "ppc64le" {
 		footnote1 = footnote1IBM
@@ -216,7 +246,7 @@ func setSysctlGlobal(compliant, comment, info string, footnote []string) (string
 func setFSOptions(comparison note.FieldComparison, compliant, comment, info string, footnote []string) (string, string, []string) {
 	// check if there are mount points with wrong FS option settings
 	if strings.Contains(comparison.ReflectMapKey, "xfsopt_") {
-		if info != "" {
+		if !system.IsFlagSet("show-non-compliant") && info != "" {
 			// fs option info
 			compliant = compliant + " [12]"
 			comment = comment + " [12]"
@@ -242,9 +272,13 @@ func setNofile(mapKey, compliant, comment, info string, footnote []string) (stri
 // setMem sets footnote for VSZ_TMPFS_PERCENT parameter from mem section
 func setMem(mapKey, compliant, comment string, footnote []string) (string, string, []string) {
 	if mapKey == "VSZ_TMPFS_PERCENT" {
-		compliant = " -  [15]"
-		comment = comment + " [15]"
-		footnote[14] = footnote15
+		if system.IsFlagSet("show-non-compliant") {
+			compliant = " - "
+		} else {
+			compliant = " -  [15]"
+			comment = comment + " [15]"
+			footnote[14] = footnote15
+		}
 	}
 	return compliant, comment, footnote
 }

--- a/actions/noteacts.go
+++ b/actions/noteacts.go
@@ -127,9 +127,9 @@ func NoteActionVerify(writer io.Writer, noteID string, tuneApp *app.App) {
 		PrintNoteFields(writer, "HEAD", noteComp, true)
 		tuneApp.PrintNoteApplyOrder(writer)
 		if !conforming {
-			system.ErrorExit("The parameters listed above have deviated from the specified note.\n")
+			system.ErrorExit("The parameters listed above have deviated from the specified note.\n", "colorPrint", setRedText, setBoldText, resetBoldText, resetTextColor)
 		} else {
-			fmt.Fprintf(writer, "The system fully conforms to the specified note.\n")
+			fmt.Fprintf(writer, "%s%sThe system fully conforms to the specified note.%s%s\n", setGreenText, setBoldText, resetBoldText, resetTextColor)
 		}
 	}
 }

--- a/actions/noteacts_test.go
+++ b/actions/noteacts_test.go
@@ -95,7 +95,7 @@ Hints or values not yet handled by saptune. So please read carefully, check and 
 
 current order of enabled notes is: simpleNote
 
-The running system is currently well-tuned according to all of the enabled notes.
+[32m[1mThe running system is currently well-tuned according to all of the enabled notes.[22m[0m
 `
 		buffer := bytes.Buffer{}
 		VerifyAllParameters(&buffer, tApp)
@@ -125,7 +125,7 @@ Hints or values not yet handled by saptune. So please read carefully, check and 
 
 current order of enabled notes is: simpleNote
 
-The system fully conforms to the specified note.
+[32m[1mThe system fully conforms to the specified note.[22m[0m
 `
 		buffer := bytes.Buffer{}
 		nID := "simpleNote"

--- a/actions/solutionacts.go
+++ b/actions/solutionacts.go
@@ -140,9 +140,9 @@ func SolutionActionVerify(writer io.Writer, solName string, tuneApp *app.App) {
 		}
 		PrintNoteFields(writer, "NONE", comparisons, true)
 		if len(unsatisfiedNotes) == 0 {
-			fmt.Fprintf(writer, "The system fully conforms to the tuning guidelines of the specified SAP solution.\n")
+			fmt.Fprintf(writer, "%s%sThe system fully conforms to the tuning guidelines of the specified SAP solution.%s%s\n", setGreenText, setBoldText, resetBoldText, resetTextColor)
 		} else {
-			system.ErrorExit("The parameters listed above have deviated from the specified SAP solution recommendations.\n")
+			system.ErrorExit("The parameters listed above have deviated from the specified SAP solution recommendations.\n", "colorPrint", setRedText, setBoldText, resetBoldText, resetTextColor)
 		}
 	}
 }

--- a/actions/solutionacts_test.go
+++ b/actions/solutionacts_test.go
@@ -108,7 +108,7 @@ Hints or values not yet handled by saptune. So please read carefully, check and 
 # Everything the customer should know about this note, especially
 # which parameters are NOT handled and the reason.
 [0m
-The system fully conforms to the tuning guidelines of the specified SAP solution.
+[32m[1mThe system fully conforms to the tuning guidelines of the specified SAP solution.[22m[0m
 `
 		buffer := bytes.Buffer{}
 		sName := "sol1"

--- a/actions/stagingacts.go
+++ b/actions/stagingacts.go
@@ -26,7 +26,6 @@ type stageComparison struct {
 	MatchExpectation bool
 }
 
-var saptuneSysconfig = "/etc/sysconfig/saptune"
 var stagingSwitch = false
 var stagingOptions = note.GetTuningOptions(StagingSheets, "")
 var stgFiles stageFiles

--- a/actions/table_test.go
+++ b/actions/table_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/SUSE/saptune/sap/note"
 	"github.com/SUSE/saptune/system"
+	"os"
 	"testing"
 )
 
@@ -54,6 +55,9 @@ func TestSetWidthOfColums(t *testing.T) {
 }
 
 func TestPrintNoteFields(t *testing.T) {
+	os.Args = []string{"saptune", "note", "list", "--colorscheme=black", "--out=json", "--force", "--dryrun", "--help", "--version"}
+	system.RereadArgs()
+
 	footnote1 := " [1] setting is not supported by the system"
 	if system.GetCSP() == "azure" {
 		footnote1 = " [1] setting is not available on Azure instances (see SAP Note 2993054)."

--- a/main.go
+++ b/main.go
@@ -30,8 +30,8 @@ var logSwitch = map[string]string{"verbose": os.Getenv("SAPTUNE_VERBOSE"), "debu
 var SaptuneVersion = ""
 
 func main() {
-	// get saptune version
-	SaptuneVersion, logSwitch = checkSaptuneConfigFile(os.Stderr, app.SysconfigSaptuneFile, logSwitch)
+	// get saptune version and log switches from saptune sysconfig file
+	SaptuneVersion = checkSaptuneConfigFile(os.Stderr, app.SysconfigSaptuneFile, logSwitch)
 
 	arg1 := system.CliArg(1)
 	if arg1 == "version" || system.IsFlagSet("version") {
@@ -204,8 +204,8 @@ func checkWorkingArea() {
 // checkSaptuneConfigFile checks the config file /etc/sysconfig/saptune
 // if it exists, if it contains all needed variables and for some variables
 // checks, if the values is valid
-// returns the saptune version and some log switches
-func checkSaptuneConfigFile(writer io.Writer, saptuneConf string, lswitch map[string]string) (string, map[string]string) {
+// returns the saptune version and changes some log switches
+func checkSaptuneConfigFile(writer io.Writer, saptuneConf string, lswitch map[string]string) string {
 	missingKey := []string{}
 	keyList := []string{app.TuneForSolutionsKey, app.TuneForNotesKey, app.NoteApplyOrderKey, "SAPTUNE_VERSION", "STAGING"}
 	sconf, err := txtparser.ParseSysconfigFile(saptuneConf, false)
@@ -241,5 +241,5 @@ func checkSaptuneConfigFile(writer io.Writer, saptuneConf string, lswitch map[st
 	if lswitch["verbose"] == "" {
 		lswitch["verbose"] = sconf.GetString("VERBOSE", "on")
 	}
-	return saptuneVers, lswitch
+	return saptuneVers
 }

--- a/main_test.go
+++ b/main_test.go
@@ -55,7 +55,8 @@ func TestCheckSaptuneConfigFile(t *testing.T) {
 	saptuneConf := fmt.Sprintf("%s/saptune_VersAndDebug", TstFilesInGOPATH)
 	buffer := bytes.Buffer{}
 
-	saptuneVers, lSwitch := checkSaptuneConfigFile(&buffer, saptuneConf, logSwitch)
+	lSwitch := logSwitch
+	saptuneVers := checkSaptuneConfigFile(&buffer, saptuneConf, lSwitch)
 	if saptuneVers != "5" {
 		t.Errorf("wrong value for 'SAPTUNE_VERSION' - '%+v' instead of ''\n", saptuneVers)
 	}
@@ -73,7 +74,8 @@ func TestCheckSaptuneConfigFile(t *testing.T) {
 	// check missing variable
 	saptuneConf = fmt.Sprintf("%s/saptune_NoVersion", TstFilesInGOPATH)
 	matchTxt := fmt.Sprintf("Error: File '%s' is broken. Missing variables 'SAPTUNE_VERSION'\n", saptuneConf)
-	saptuneVers, lSwitch = checkSaptuneConfigFile(&buffer, saptuneConf, logSwitch)
+	lSwitch = logSwitch
+	saptuneVers = checkSaptuneConfigFile(&buffer, saptuneConf, lSwitch)
 
 	txt := buffer.String()
 	checkOut(t, txt, matchTxt)
@@ -93,7 +95,8 @@ func TestCheckSaptuneConfigFile(t *testing.T) {
 	saptuneConf = fmt.Sprintf("%s/saptune_WrongStaging", TstFilesInGOPATH)
 	saptuneVers = ""
 	matchTxt = fmt.Sprintf("Error: Variable 'STAGING' from file '%s' contains a wrong value 'hugo'. Needs to be 'true' or 'false'\n", saptuneConf)
-	saptuneVers, lSwitch = checkSaptuneConfigFile(&buffer, saptuneConf, logSwitch)
+	lSwitch = logSwitch
+	saptuneVers = checkSaptuneConfigFile(&buffer, saptuneConf, lSwitch)
 
 	txt = buffer.String()
 	checkOut(t, txt, matchTxt)

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -295,8 +295,30 @@ If SecureBoot is enabled some system settings are 'read only' and can not be cha
 .br
 The possible value for parameter 'MAX_SECTORS_KB' (/sys/block/*/queue/max_sectors_kb) is limited by the value of /sys/block/*/queue/max_hw_sectors_kb.
 
-
 If a Note definition contains a '\fB[reminder]\fP' section, this section will be printed below the table and the footnotes. It will be highlighted with red color.
+
+By using the command line argument '\fB--show-non-compliant\fP' it is possible to limit the verify output to show only non-compliant parameter. The output will \fBnot\fP be colorized even that a \fBcolor scheme\fP is defined.
+
+It is possible to use a \fBcolor scheme\fP for the verify output table.
+.br
+The \fBcolor scheme\fP can be given as a command line argument '\fB--colorscheme=<color scheme>\fP' or as variable '\fBCOLOR_SCHEME=<color scheme>\fP' in the saptune configuration file \fI/etc/sysconfig/saptune\fP.
+.br
+Possible \fBcolor schemes\fP are:
+.RS 7
+.IP \[bu]
+full-zebra   - whole line is colored green (compliant) or red (not compliant)
+.IP \[bu]
+cmpl-zebra   - only the content in the Compliant column is colored green (compliant) or red (not compliant)
+.IP \[bu]
+full-noncmpl - only the whole line of the not compliant parameter is colored red
+.IP \[bu]
+noncmpl      - only the content in the Compliant column of the not compliant parameter is colored red
+.RS 0
+
+The default, if no \fBcolor scheme\fP is given, is \fBfull-noncmpl\fP. If an unknown \fBcolor scheme\fP is given in the command line or in the config file, non-colorized, simple black text is printed.
+
+The 'final lines' with the overall result of the verify operation are colored green (compliant) or red (not compliant) independent from the chosen \fBcolor scheme\fP
+.SS
 .TP
 .B simulate
 Show all changes that will be applied to the system if the specified Note is applied.
@@ -778,6 +800,8 @@ If the values are applied by saptune, no further monitoring of the system parame
 Please do not change or remove files in this directory. The knowledge about the previous system state gets lost and the revert functionality of saptune will be destructed. So you will lose the capability to revert back the tunings saptune has done.
 .RE
 
+.SH NOTE
+Using saptune within a pipe, the color information will be removed from the output.
 .SH NOTE
 When the values from the saptune Note definitions are applied to the system, no further monitoring of the system parameters are done. So changes of saptune relevant parameters by using the 'sysctl' command or by editing configuration files will not be observed. If the values set by saptune should be reverted, these unrecognized changed settings will be overwritten by the previous saved system settings from saptune.
 

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -622,9 +622,11 @@ Will display the syntax of saptune
 .SH VENDOR SUPPORT
 To support vendor or customer specific tuning values, saptune supports 'drop-in' files residing in \fI/etc/saptune/extra\fP. All files found in \fI/etc/saptune/extra\fP are listed when running '\fBsaptune note list\fP'. All \fBnote options\fP are available for these files.
 
-We simplified the file name syntax for these vendor files. But the old file names are still valid and supported.
+We simplified the file name syntax for these vendor files.
 .br
 Related to this we add 'header' support (see description of section [version] in saptune-note(5)) for the vendor files as already available for the Note definition files in /usr/share/saptune/notes to get a proper description during saptune option 'list'
+.br
+The old file names are still valid, but \fBdeprecated\fP. The support will be dropped in the near future. That means, files without a valid header information (see description of section [version] in saptune-note(5)) will be skipped in the future.
 
 .SS
 .RS 0

--- a/sap/note/note.go
+++ b/sap/note/note.go
@@ -87,6 +87,7 @@ func GetTuningOptions(saptuneTuningDir, thirdPartyTuningDir string) TuningOption
 			// support of old style vendor file names for compatibility reasons
 			system.InfoLog("GetTuningOptions: no header information found in file \"%s\"", fileName)
 			system.InfoLog("falling back to old style vendor file names")
+			system.WarningLog("old style vendor files are deprecated. For future support add header information to the file - %s", fileName)
 			// By convention, the portion before dash makes up the ID.
 			idName := strings.SplitN(fileName, "-", 2)
 			if len(idName) != 2 {

--- a/system/logging.go
+++ b/system/logging.go
@@ -58,6 +58,13 @@ func WarningLog(txt string, stuff ...interface{}) {
 	}
 }
 
+// ErrLog sents text only to the errorLogger
+func ErrLog(txt string, stuff ...interface{}) {
+	if errorLogger != nil {
+		errorLogger.Printf(CalledFrom()+txt+"\n", stuff...)
+	}
+}
+
 // ErrorLog sents text to the errorLogger and stderr
 func ErrorLog(txt string, stuff ...interface{}) error {
 	if errorLogger != nil {

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -89,7 +89,7 @@ func TestCliArg(t *testing.T) {
 		t.Errorf("Test failed, expected 'output' flag as 'false', but got 'true'")
 	}
 	expected = "screen"
-	actual = GetOutTarget()
+	actual = GetFlagVal("output")
 	if actual != expected {
 		t.Errorf("Test failed, expected: '%s', got: '%s'", expected, actual)
 	}
@@ -125,7 +125,7 @@ func TestCliFlags(t *testing.T) {
 		t.Errorf("Test failed, expected 'output' flag as 'false', but got 'true'")
 	}
 	expected := "json"
-	actual := GetOutTarget()
+	actual := GetFlagVal("output")
 	if actual != expected {
 		t.Errorf("Test failed, expected: '%s', got: '%s'", expected, actual)
 	}


### PR DESCRIPTION
Colorized and filtered output for 'saptune note verify' (jsc#SLE-23727)
'verify' now uses a 'color scheme' for the output. The 'color scheme' can be given as command line argument '–colorscheme=\<color scheme\>' or as variable 'COLOR_SCHEME=\<color scheme\>' in the configuration file /etc/sysconfig/saptune.
Possible 'color schemes' are:

    full-zebra - whole line is colored green (compliant) or red (not compliant)
    cmpl-zebra - only the content in the Compliant column is colored green (compliant) or red (not compliant)
    full-noncmpl - only the whole line of the not compliant parameter is colored red
    noncmpl - only the content in the Compliant column of the not compliant parameter is colored red

The default, if no 'color scheme' is given, is 'full-noncmpl'. If an unknown 'color scheme' is given in the command line or in the config file, non-colorized, simple black text is printed.

The 'final lines' with the overall result of the 'verify' is colored green (compliant) or red (not compliant) independent from the chosen (or not) 'color scheme'

As usual, using 'saptune verify' within a pipe, the color information will be stripped.

By using the command line argument '--show-non-compliant' it is possible to limit the verify output to show only non-compliant parameter. The output will not be colorized even that a 'color scheme' is defined.

deprecate support for the v1 vendor or custom specific Note definition file format (jsc#SLE-23725)
The old file names (syntax: \<NoteID\>-\<description\>) are still valid, but **deprecated**. The support will be dropped in the near future. That means, files without a valid header information (see description of section [version] in saptune-note(5)) will be skipped in the future.
