### PR TITLE
new version section syntax (jsc#SLE-23722) and better IBM Power support (jsc#SLE-23824)

### DIFF
--- a/.github/workflows/saptune-ut.yml
+++ b/.github/workflows/saptune-ut.yml
@@ -24,6 +24,7 @@ jobs:
           git fetch --no-tags --prune --depth=1 origin +refs/heads/${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
           echo "GIT_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
           echo "GIT_COMMIT_SHA=$(git rev-parse origin/${{ github.head_ref }})" >> $GITHUB_ENV
+          echo "CC_TEST_REPORTER_ID=a3b62a56eae998a9e6684d9fa1ca2abe8f479c3d9e43ca69bdfa7a62115d388f" >> $GITHUB_ENV
         if: github.event_name == 'pull_request'
 
       - name: Set ENV for codeclimate (push)

--- a/.github/workflows/saptune-ut.yml
+++ b/.github/workflows/saptune-ut.yml
@@ -24,7 +24,6 @@ jobs:
           git fetch --no-tags --prune --depth=1 origin +refs/heads/${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
           echo "GIT_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
           echo "GIT_COMMIT_SHA=$(git rev-parse origin/${{ github.head_ref }})" >> $GITHUB_ENV
-          echo "CC_TEST_REPORTER_ID=a3b62a56eae998a9e6684d9fa1ca2abe8f479c3d9e43ca69bdfa7a62115d388f" >> $GITHUB_ENV
         if: github.event_name == 'pull_request'
 
       - name: Set ENV for codeclimate (push)
@@ -55,6 +54,7 @@ jobs:
 
       - name: Code Climate report coverage
         run: ./cc-test-reporter after-build --debug --prefix ${{ env.CC_PREFIX }} --exit-code $?
+        if: github.event_name != 'pull_request'
 
       - name: Stop and remove Docker Image
         run: |

--- a/actions/noteacts_test.go
+++ b/actions/noteacts_test.go
@@ -22,10 +22,10 @@ func TestNoteActions(t *testing.T) {
 All notes (+ denotes manually enabled notes, * denotes notes enabled by solutions, - denotes notes enabled by solutions but reverted manually later, O denotes override file exists for note, C denotes custom note):
 	NEWSOL2NOTE	
 	extraNote	Configuration drop in for extra tests
-			Version 0 from 04.06.2019 
+			Version 0 from 04.06.2019
 	oldFile		Name_syntax
 	simpleNote	Configuration drop in for simple tests
-			Version 1 from 09.07.2019 
+			Version 1 from 09.07.2019
 	wrongFileNamesyntax	
 
 Remember: if you wish to automatically activate the solution's tuning options after a reboot, you must enable and start saptune.service by running:
@@ -43,7 +43,7 @@ Remember: if you wish to automatically activate the solution's tuning options af
 		var simulateMatchText = `If you run ` + "`saptune note apply simpleNote`" + `, the following changes will be applied to your system:
 
 simpleNote - Configuration drop in for simple tests
-			Version 1 from 09.07.2019  
+			Version 1 from 09.07.2019 
 
    Parameter                    | Value set   | Value expected  | Override  | Comment
 --------------------------------+-------------+-----------------+-----------+--------------
@@ -107,7 +107,7 @@ current order of enabled notes is: simpleNote
 	t.Run("NoteActionVerify", func(t *testing.T) {
 		var verifyMatchText = `
 simpleNote - Configuration drop in for simple tests
-			Version 1 from 09.07.2019  
+			Version 1 from 09.07.2019 
 
    SAPNote, Version | Parameter                    | Expected    | Override  | Actual      | Compliant
 --------------------+------------------------------+-------------+-----------+-------------+-----------

--- a/actions/serviceacts.go
+++ b/actions/serviceacts.go
@@ -598,7 +598,6 @@ func printStagingStatus(writer io.Writer, jstage *system.JStatusStaging) {
 	fmt.Fprintln(writer, "")
 }
 
-
 // printSaptuneStatus checks for running saptune.service and print status
 func printSaptuneStatus(writer io.Writer, jstat *system.JStatusServs) (bool, bool, bool) {
 	remember := false

--- a/actions/table.go
+++ b/actions/table.go
@@ -165,7 +165,7 @@ func setupTableFormat(skeys []string, noteCompare map[string]map[string]note.Fie
 // printHeadline prints a headline for the table
 func printHeadline(writer io.Writer, header, id string, noteComparisons map[string]map[string]note.FieldComparison) {
 	if header != "NONE" {
-		nName := txtparser.GetINIFileDescriptiveName(noteComparisons[id]["ConfFilePath"].ActualValue.(string))
+		nName := noteComparisons[id]["DescriptiveName"].ActualValue.(string)
 		fmt.Fprintf(writer, "\n%s - %s \n\n", id, nName)
 	} else {
 		fmt.Fprintf(writer, "\n")

--- a/actions/table_test.go
+++ b/actions/table_test.go
@@ -65,7 +65,7 @@ func TestPrintNoteFields(t *testing.T) {
 
 	var printMatchText1 = `
 941735 - Configuration drop in for simple tests
-			Version 1 from 09.07.2019  
+			Version 1 from 09.07.2019 
 
    SAPNote, Version | Parameter                  | Expected             | Override  | Actual               | Compliant
 --------------------+----------------------------+----------------------+-----------+----------------------+-----------
@@ -90,7 +90,7 @@ func TestPrintNoteFields(t *testing.T) {
 `
 	var printMatchText2 = `
 941735 - Configuration drop in for simple tests
-			Version 1 from 09.07.2019  
+			Version 1 from 09.07.2019 
 
    Parameter                  | Value set            | Value expected       | Override  | Comment
 ------------------------------+----------------------+----------------------+-----------+--------------
@@ -173,7 +173,7 @@ func TestPrintNoteFields(t *testing.T) {
 	cfgFile := fmt.Sprintf("%ssimpleNote.conf", ExtraFilesInGOPATH)
 	fcomp1 := note.FieldComparison{ReflectFieldName: "ConfFilePath", ReflectMapKey: "", ActualValue: cfgFile, ExpectedValue: cfgFile, ActualValueJS: cfgFile, ExpectedValueJS: cfgFile, MatchExpectation: true}
 	fcomp2 := note.FieldComparison{ReflectFieldName: "ID", ReflectMapKey: "", ActualValue: "941735", ExpectedValue: "941735", ActualValueJS: "941735", ExpectedValueJS: "941735", MatchExpectation: true}
-	fcomp3 := note.FieldComparison{ReflectFieldName: "DescriptiveName", ReflectMapKey: "", ActualValue: "", ExpectedValue: "", ActualValueJS: "", ExpectedValueJS: "", MatchExpectation: true}
+	fcomp3 := note.FieldComparison{ReflectFieldName: "DescriptiveName", ReflectMapKey: "", ActualValue: "Configuration drop in for simple tests\n\t\t\tVersion 1 from 09.07.2019", ExpectedValue: "Configuration drop in for simple tests\n\t\t\tVersion 1 from 09.07.2019", ActualValueJS: "Configuration drop in for simple tests\n\t\t\tVersion 1 from 09.07.2019", ExpectedValueJS: "Configuration drop in for simple tests\n\t\t\tVersion 1 from 09.07.2019", MatchExpectation: true}
 	fcomp4 := note.FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "ShmFileSystemSizeMB", ActualValue: "488", ExpectedValue: "1714", ActualValueJS: "488", ExpectedValueJS: "1714", MatchExpectation: false}
 	fcomp5 := note.FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "kernel.shmmax", ActualValue: "18446744073709551615", ExpectedValue: "18446744073709551615", ActualValueJS: "18446744073709551615", ExpectedValueJS: "18446744073709551615", MatchExpectation: true}
 	fcomp6 := note.FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "IO_SCHEDULER_vda", ActualValue: "all:none", ExpectedValue: "noop", ActualValueJS: "all:none", ExpectedValueJS: "noop", MatchExpectation: false}

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -27,6 +27,10 @@ The \fBNote definition\fP files use the INI file format.
 .br
 A comment line starts with #.
 .br
+Inline comments are possible and start with a blank followed by a # followed by any non-# character. (' #anything except #')
+.br
+If you need to add a character sequenze of ' #anything' to your description, please write it as ' ##anything' (double the #) to give saptune the chance to distinguish this text from an inline comment. saptune will strip the second # from the output result, so that the resulting text will appear as ' #anything'.
+.br
 Lines starting with '[' indicate the begin of a new section.
 .SH SECTIONS
 A section starts with a '[section_name]' keyword in the first line, followed by lines with options and comments.
@@ -239,7 +243,7 @@ DESCRIPTION=VIP: this is VIP Note 1, which contains Very Important Parameters
 .br
 REFERENCES=https://inter.net.addr.com/path/Note_Info http://inter.net.addr.com/another_path/A_second_Note_Info
 
-The entries are treated as 'Key Value' pairs. The equal operator (=) is mandatory, but can be used with spaces around. The value can be placed in double quotes. The entries can be placed in any order inside the version section.
+The entries are treated as 'Key Value' pairs. The equal operator (=) is mandatory, but can be used with spaces around. The entries can be placed in any order inside the version section.
 
 We skipped the fields 'CATEGORY' and '<noteId>' from the old syntax because these values are not in use. The '<noteId>' was always taken from the filename of the Note definition file and we stay with this behaviour for now.
 
@@ -249,9 +253,9 @@ VERSION is a number that should indicate how many changes are done for this Note
 
 DATE is the date of the last changes.
 
-NAME is the description of the Note, which will be displayed during the action 'saptune note list'
+DESCRIPTION is the description of the Note, which will be displayed during the action 'saptune note list'.
 
-REFERENCES is a list of URLs separated by blank, which contain additional information about the Note definition and the content. 
+REFERENCES is a list of URLs separated by blank, which contain additional information about the Note definition and the content. If you need to use a 'blank' inside the URL definition please mask it as '%20'.
 \" section block
 .SH "[block]"
 The settings of the "[block]" section will be set on \fBall\fP block devices found in \fI/sys/block\fP, which are considered as \fBvalid\fP.

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -70,7 +70,8 @@ Valid values for \fBvendor=\fP are the values found in \fB/sys/class/dmi/id/boar
 .br
 The value of the vendor tag is used as a regular expression '\fB.*<value>.*\fP' to match the content of the vendor file.
 
-Attention: not usable on IBM Power platform (hardware architecture 'ppc64le')
+For IBM Power platform (hardware architecture 'ppc64le') the value is set to 'IBM'.
+
 .TP
 .BI model= <hardware model>
 to define a special \fIsystem hardware model\fP
@@ -79,7 +80,7 @@ Valid values for \fBmodel=\fP are the values found in \fB/sys/class/dmi/id/produ
 .br
 The value of the model tag is used as a regular expression '\fB.*<value>.*\fP' to match the content of the model file.
 
-Attention: not usable on IBM Power platform (hardware architecture 'ppc64le')
+On IBM Power platform (hardware architecture 'ppc64le') the file \fB/sys/firmware/devicetree/base/model\fP is used to identify the hardware model.
 
 .RS 4
 Example:
@@ -188,7 +189,7 @@ See detailed description below:
 .SH "[version]"
 This section is a mandatory section and is used to display version, description and last change date of the underlying Note during saptune action 'list'.
 
-Syntax:
+Old Syntax: \fBATTENTION: deprecated\fP
 .br
 .nf
 .B # <prefix>NOTE=<noteId> CATEGORY=<category> VERSION=<versionNo> DATE=<release date of used note and related values> NAME="<description of the note>"
@@ -211,6 +212,46 @@ DATE is the date of the last changes.
 NAME is the description of the Note, which will be displayed during the action 'saptune note list'
 .br
 Attention: The note description from the field NAME must be placed in double quotes even if there are no spaces used inside the description.
+
+\fBATTENTION:\fP The old syntax for the version section is deprecated. A Warning message will point to the affected Note definition file. Customer specific Note definition files need to be adapted to the new syntax by the admin.
+
+Only in the Solution definition files the old syntax is still valid. This may change with a next saptune version.
+
+New Syntax:
+.br
+.nf
+.B
+VERSION=<versionNo>
+.br
+DATE=<release date of used note and related values>
+.br
+NAME="<description of the note>"
+.br
+REFERENCES="<list of URLs containing information regarding the Note separated by blank>
+
+Example:
+.br
+VERSION=5
+.br
+DATE=16.04.2019
+.br
+DESCRIPTION=VIP: this is VIP Note 1, which contains Very Important Parameters
+.br
+REFERENCES=https://inter.net.addr.com/path/Note_Info http://inter.net.addr.com/another_path/A_second_Note_Info
+
+The entries are treated as 'Key Value' pairs. The equal operator (=) is mandatory, but can be used with spaces around. The value can be placed in double quotes. The entries can be placed in any order inside the version section.
+
+We skipped the fields 'CATEGORY' and '<noteId>' from the old syntax because these values are not in use. The '<noteId>' was always taken from the filename of the Note definition file and we stay with this behaviour for now.
+
+\"The <noteId> must be a text string without spaces, which will be used as the unique identifier of this Note definition. It will be displayed during the action 'saptune note list' and used for all other actions, where the NoteID is needed as parameter.
+
+VERSION is a number that should indicate how many changes are done for this Note definition in the past. Allowed are digits, upper-case and lower-case letters, dots, underscores, minus and plus signs.
+
+DATE is the date of the last changes.
+
+NAME is the description of the Note, which will be displayed during the action 'saptune note list'
+
+REFERENCES is a list of URLs separated by blank, which contain additional information about the Note definition and the content. 
 \" section block
 .SH "[block]"
 The settings of the "[block]" section will be set on \fBall\fP block devices found in \fI/sys/block\fP, which are considered as \fBvalid\fP.

--- a/ospackage/usr/share/saptune/NoteTemplate.conf
+++ b/ospackage/usr/share/saptune/NoteTemplate.conf
@@ -7,11 +7,20 @@
 # and add all the needed sections and parameter/value pairs
 
 [version]
-# _TEXT_TO_CHANGE_-NOTE=_TEXT_TO_CHANGE_ CATEGORY=_TEXT_TO_CHANGE_ VERSION=0 DATE=_TEXT_TO_CHANGE_ NAME=" _TEXT_TO_CHANGE_ "
+# add the current version of your Note
+VERSION=0
+# add the date of the last changes to your Note
+DATE=_TEXT_TO_CHANGE_
+# add the description of your Note
+DESCRIPTION=_TEXT_TO_CHANGE_
+# add references for your Note, like URLs
+# contains a list of references separated by blank
+REFERENCES=_TEXT_TO_CHANGE_ URL1 URL2
 
 # supported sections
 #[block]
 #[cpu]
+#[filesystem]
 #[grub]
 #[limits]
 #[login]
@@ -20,5 +29,6 @@
 #[reminder]
 #[rpm]
 #[service]
+#[sys]
 #[sysctl]
 #[vm]

--- a/ospackage/usr/share/saptune/notes/1410736
+++ b/ospackage/usr/share/saptune/notes/1410736
@@ -3,7 +3,10 @@
 # Version 6 from Jan 13, 2020 in English
 
 [version]
-# SAP-NOTE=1410736 CATEGORY=NET VERSION=6 DATE=13.01.2020 NAME="TCP/IP: setting keepalive interval"
+VERSION=6
+DATE=13.01.2020
+DESCRIPTION=TCP/IP: setting keepalive interval
+REFERENCES=https://launchpad.support.sap.com/#/notes/1410736
 
 [sysctl]
 net.ipv4.tcp_keepalive_time = 300

--- a/ospackage/usr/share/saptune/notes/1557506
+++ b/ospackage/usr/share/saptune/notes/1557506
@@ -1,9 +1,12 @@
 # 1557506 - Linux paging improvements
 # Description:    Tune page cache limit to prevent eviction of SAP applications memory into swap
-# Version 14 from 10.08.2015 in English
+# Version 16 from 06.02.2020 in English
 
 [version]
-# SAP-NOTE=1557506 CATEGORY=LINUX VERSION=14 DATE=10.08.2015 NAME="Linux paging improvements"
+VERSION=16
+DATE=06.02.2020
+DESCRIPTION=Linux paging improvements
+REFERENCES=https://launchpad.support.sap.com/#/notes/1557506
 
 [pagecache]
 ## Type:    yesno
@@ -19,10 +22,11 @@ ENABLE_PAGECACHE_LIMIT=no
 ## Default: 1
 #
 # Whether or not to ignore dirty memory when enforcing the pagecache limit.
-# If set to 0, dirty memory will be freed (written onto disk) when enforcing 
-# the pagecache limit.
-# If set to 1 (default), dirty memory will not be freed when enforcing the 
-# pagecache limit.
+# If set to 0, dirty (unmapped) memory will be considered freeable and the Linux
+# kernel will try to write the pages out when enforcing the page cache limit.
+# If set to 1 (ignore all dirty memory in the page cache when enforcing the limit)
+# the page cache can actually grow well beyond the configured limit if lots of writes
+# happen to local filesystems.
 # If set to 2 - a middle ground, some dirty memory will be freed when enforcing
 # the limit.
 vm.pagecache_limit_ignore_dirty=1

--- a/ospackage/usr/share/saptune/notes/1656250
+++ b/ospackage/usr/share/saptune/notes/1656250
@@ -1,8 +1,11 @@
 # 1656250 - SAP on AWS: Support prerequisites - only Linux Operating System IO Recommendations
-# Version 31 from 02.12.2020 in English
+# Version 46 from 11.05.2022 in English
 
 [version]
-# SAP-NOTE=1656250 CATEGORY=LNX-AWS VERSION=31 DATE=02.12.2020 NAME="SAP on AWS: Support prerequisites - only Linux Operating System IO Recommendations"
+VERSION=46
+DATE=11.05.2022
+DESCRIPTION=SAP on AWS: Support prerequisites - only Linux Operating System IO Recommendations
+REFERENCES=https://launchpad.support.sap.com/#/notes/1656250
 
 [sys:blkpat=nvme:csp=aws]
 # On linux operating systems the kernel parameter nvme_core.io_timeout controls

--- a/ospackage/usr/share/saptune/notes/1680803
+++ b/ospackage/usr/share/saptune/notes/1680803
@@ -12,10 +12,14 @@
 # Version 3.0 from 2020-07-31
 #
 # SAP ASE (Sybase)
-# Version 26 from 11.06.2021 in English
+# Version 27 from 04.11.2021 in English
 #
+
 [version]
-# SAP-NOTE=1680803 CATEGORY=SYBASE VERSION=26 DATE=11.06.2021 NAME="Sybase - SAP Adaptive Server Enterprise"
+VERSION=27
+DATE=04.11.2021
+DESCRIPTION=Sybase - SAP Adaptive Server Enterprise
+REFERENCES=https://launchpad.support.sap.com/#/notes/1680803
 
 [block]
 ## Type:    string
@@ -80,6 +84,12 @@ net.core.wmem_default = 16777216
 net.ipv4.tcp_rmem = 4096 87380 16777216
 net.ipv4.tcp_wmem = 4096 65536 16777216
 
+# Set the keepalive interval to a value higher than 1200 seconds.
+# The ABAP dispatcher initiates an empty network request to the database connection
+# every 1200 seconds. If the keepalive interval is lower, the operating system might
+# close the database connection.
+net.ipv4.tcp_keepalive_time = 1250
+
 # Increase the max packet backlog
 net.core.netdev_max_backlog = 30000
 
@@ -91,4 +101,5 @@ vm.swappiness = 15
 # DBMS data storage settings: use ext4 or xfs file system. 
 # For best performance, disable the journal via tune2fs ^has_journal.
 # For ext4 the recommended mount options are 'noatime,nodiratime', if journaling is disabled or 'noatime,nodiratime,cache=writeback,barrier=0', if journaling is not disabled
+# For xfs the recommended mount options are 'noatime,nodiratime,logbufs=8'.
 # network tuning including transmit queue (ifconfig <eth#> txqueuelen <value>). See the current online version of the best practice document 'Best Practice for SAP Business Suite and SAP BW' linked in the 'Solution' section of the related SAP Note 1680803 on SAP launchpad

--- a/ospackage/usr/share/saptune/notes/1771258
+++ b/ospackage/usr/share/saptune/notes/1771258
@@ -5,7 +5,10 @@
 # the Note
 
 [version]
-# SAP-NOTE=1771258 CATEGORY=LINUX VERSION=6 DATE=05.11.2021 NAME="Linux: User and system resource limits"
+VERSION=6
+DATE=05.11.2021
+DESCRIPTION=Linux: User and system resource limits
+REFERENCES=https://launchpad.support.sap.com/#/notes/1771258
 
 [limits]
 # /etc/security/limits.conf or drop-in file in /etc/securitty/limits.d

--- a/ospackage/usr/share/saptune/notes/1805750
+++ b/ospackage/usr/share/saptune/notes/1805750
@@ -1,9 +1,13 @@
 # 1805750 - SYB: Usage of HugePages on Linux Systems with Sybase ASE
 # Configuration of HugePages on Linux with SAP Sybase ASE
-# Version 6 from 14.11.2017 in English
+# Version 9 from 10.03.2020 in English
 #
+
 [version]
-# SAP-NOTE=1805750 CATEGORY=SYBASE VERSION=6 DATE=14.11.2017 NAME="SYB: Usage of HugePages on Linux Systems with Sybase ASE"
+VERSION=9
+DATE=10.03.2020
+DESCRIPTION=SYB: Usage of HugePages on Linux Systems with Sybase ASE
+REFERENCES=https://launchpad.support.sap.com/#/notes/1805750
 
 [limits]
 # Allow Sybase ASE owner to make use of available HugePages.

--- a/ospackage/usr/share/saptune/notes/1980196
+++ b/ospackage/usr/share/saptune/notes/1980196
@@ -2,7 +2,10 @@
 # Version 7 from 18.10.2017 in English
 
 [version]
-# SAP-NOTE=1980196 CATEGORY=HANA VERSION=7 DATE=18.10.2017 NAME="Setting Linux Kernel Parameter /proc/sys/vm/max_map_count on SAP HANA Systems"
+VERSION=7
+DATE=18.10.2017
+DESCRIPTION=Setting Linux Kernel Parameter /proc/sys/vm/max_map_count on SAP HANA Systems
+REFERENCES=https://launchpad.support.sap.com/#/notes/1980196
 
 [sysctl]
 # vm.max_map_count

--- a/ospackage/usr/share/saptune/notes/1984787
+++ b/ospackage/usr/share/saptune/notes/1984787
@@ -1,9 +1,12 @@
 # 1984787 - SUSE LINUX Enterprise Server 12: Installation notes
 # Description:    You want to use SAP software on SUSE Linux Enterprise Server 12 (SLES 12) or SUSE Linux Enterprise Server for SAP Applications 12 (SLES for SAP 12).
-# Version 36 from 06.08.2020 in English
+# Version 40 from 25.11.2021 in English
 
 [version]
-# SAP-NOTE=1984787 CATEGORY=LINUX VERSION=36 DATE=06.08.2020 NAME="SUSE LINUX Enterprise Server 12: Installation notes"
+VERSION=40
+DATE=25.11.2021
+DESCRIPTION=SUSE LINUX Enterprise Server 12: Installation notes
+REFERENCES=https://launchpad.support.sap.com/#/notes/1984787
 
 [login]
 # /etc/systemd/logind.conf.d/saptune-UserTasksMax.conf UserTasksMax setting
@@ -52,6 +55,7 @@ sapinit-systemd-compat 12-SP1 1.0-2.1
 util-linux 12-SP1 2.25-22.1
 uuidd 12-SP1 2.25-22
 util-linux-systemd 12-SP1 2.25-22.1
+psmisc 12-SP5 22.21-6.19.1
 
 [sysctl]
 # vm.dirty_bytes (indirect vm.dirty_ratio)

--- a/ospackage/usr/share/saptune/notes/2161991
+++ b/ospackage/usr/share/saptune/notes/2161991
@@ -1,10 +1,12 @@
 # 2161991 - VMware vSphere configuration guidelines
 # Description:    3. Recommendations for the guest operating system
-# Version 26 from 02.12.2019 in English
+# Version 28 from 29.07.2021 in English
 
-#
 [version]
-# SAP-NOTE=2161991 CATEGORY=VIRT VERSION=26 DATE=02.12.2019 NAME="VMware vSphere configuration guidelines"
+VERSION=28
+DATE=29.07.2021
+DESCRIPTION=VMware vSphere configuration guidelines
+REFERENCES=https://launchpad.support.sap.com/#/notes/2161991
 
 [block]
 ## Type:    string

--- a/ospackage/usr/share/saptune/notes/2205917
+++ b/ospackage/usr/share/saptune/notes/2205917
@@ -1,9 +1,12 @@
 # 2205917 - SAP HANA DB: Recommended OS settings for SLES 12 / SLES for SAP Applications 12
 # Description:    HANA DB settings
-# Version 61 from 12.11.2020 in English
+# Version 63 from 18.05.2021 in English
 
 [version]
-# SAP-NOTE=2205917 CATEGORY=HANA VERSION=61 DATE=12.11.2020 NAME="SAP HANA DB: Recommended OS settings for SLES 12 / SLES for SAP Applications 12"
+VERSION=63
+DATE=18.05.2021
+DESCRIPTION=SAP HANA DB: Recommended OS settings for SLES 12 / SLES for SAP Applications 12
+REFERENCES=https://launchpad.support.sap.com/#/notes/2205917
 
 [login]
 # /etc/systemd/logind.conf.d/saptune-UserTasksMax.conf UserTasksMax setting

--- a/ospackage/usr/share/saptune/notes/2382421
+++ b/ospackage/usr/share/saptune/notes/2382421
@@ -1,8 +1,11 @@
 # 2382421 - Optimizing the Network Configuration on HANA- and OS-Level
-# Version 38 from 29.06.2020 in English
+# Version 40 from 01.03.2021 in English
 
 [version]
-# SAP-NOTE=2382421 CATEGORY=HANA VERSION=38 DATE=29.06.2020 NAME="Optimizing the Network Configuration on HANA- and OS-Level"
+VERSION=40
+DATE=01.03.2021
+DESCRIPTION=Optimizing the Network Configuration on HANA- and OS-Level
+REFERENCES=https://launchpad.support.sap.com/#/notes/2382421
 
 [sysctl]
 # This parameter limits the size of the accept backlog of a listening socket.

--- a/ospackage/usr/share/saptune/notes/2534844
+++ b/ospackage/usr/share/saptune/notes/2534844
@@ -1,8 +1,11 @@
 # 2534844 - Indexserver Crash During Startup due to Insufficient Shared Memory Segment
-# Version 12 from 15.11.2017 in English
+# Version 13 from 09.04.2020 in English
 
 [version]
-# SAP-NOTE=2534844 CATEGORY=HANA VERSION=12 DATE=15.11.2017 NAME="Indexserver Crash During Startup due to Insufficient Shared Memory Segment"
+VERSION=13
+DATE=09.04.2020
+DESCRIPTION=Indexserver Crash During Startup due to Insufficient Shared Memory Segment
+REFERENCES=https://launchpad.support.sap.com/#/notes/2534844
 
 [sysctl]
 # kernel.shmmni

--- a/ospackage/usr/share/saptune/notes/2578899
+++ b/ospackage/usr/share/saptune/notes/2578899
@@ -1,9 +1,12 @@
 # 2578899 - SUSE Linux Enterprise Server 15: Installation Note
 # Description:    You want to use SAP software on SUSE Linux Enterprise Server 15 (SLES 15) or SUSE Linux Enterprise Server 15 for SAP Applications  (SLES for SAP 15).
-# Version 39 from 09.07.2021 in English
+# Version 41 from 05.04.2022 in English
 
 [version]
-# SAP-NOTE=2578899 CATEGORY=LINUX VERSION=39 DATE=09.07.2021 NAME="SUSE LINUX Enterprise Server 15: Installation notes"
+VERSION=41
+DATE=05.04.2022
+DESCRIPTION=SUSE Linux Enterprise Server 15: Installation Note
+REFERENCES=https://launchpad.support.sap.com/#/notes/2578899
 
 [service]
 # start the related services
@@ -42,8 +45,9 @@ tcsh 15-SP1 6.20.00-4.9.1
 psmisc 15-SP2 23.0-6.16.1
 psmisc 15-SP3 23.0-6.16.1
 binutils 15 2.35.1-6.20.1
-binutils 15SP1 2.35.1-7.18.1
-binutils 15SP2 2.35.1-7.18.1
+binutils 15-SP1 2.35.1-7.18.1
+binutils 15-SP2 2.35.1-7.18.1
+uuidd 15-SP3 2.36.2-150300.4.17.1
 
 [sysctl]
 # vm.dirty_bytes (indirect vm.dirty_ratio)

--- a/ospackage/usr/share/saptune/notes/2684254
+++ b/ospackage/usr/share/saptune/notes/2684254
@@ -3,7 +3,10 @@
 # Version 20 from 02.07.2021 in English
 
 [version]
-# SAP-NOTE=2684254 CATEGORY=HANA VERSION=20 DATE=02.07.2021 NAME="SAP HANA DB: Recommended OS settings for SLES 15 / SLES for SAP Applications 15"
+VERSION=20
+DATE=02.07.2021
+DESCRIPTION=SAP HANA DB: Recommended OS settings for SLES 15 / SLES for SAP Applications 15
+REFERENCES=https://launchpad.support.sap.com/#/notes/2684254
 
 [vm]
 # Disable transparent hugepages (THP)

--- a/ospackage/usr/share/saptune/notes/2993054
+++ b/ospackage/usr/share/saptune/notes/2993054
@@ -3,7 +3,10 @@
 # Version 2 from 12.07.2021 in English
 
 [version]
-# SAP-NOTE=2993054 CATEGORY=LNX-AZR VERSION=2 DATE=12.07.2021 NAME="Recommended settings for SAP systems on Linux running in Azure virtual machines"
+VERSION=2
+DATE=12.07.2021
+DESCRIPTION=Recommended settings for SAP systems on Linux running in Azure virtual machines
+REFERENCES=https://launchpad.support.sap.com/#/notes/2993054
 
 [sysctl:csp=azure]
 net.ipv4.tcp_keepalive_time = 300

--- a/ospackage/usr/share/saptune/notes/3024346
+++ b/ospackage/usr/share/saptune/notes/3024346
@@ -1,9 +1,12 @@
 # 3024346 - Linux Kernel Settings for NetApp NFS
-# Version 3 from 17.02.2021 in English
-# See TR-4290/TR-4435.
+# Version 6 from 29.04.2022 in English
+# See TR-4290 (FAS) or TR-4435 (AFF).
 
 [version]
-# SAP-NOTE=3024346 CATEGORY=Consulting VERSION=3 DATE=17.02.2021 NAME="Linux Kernel Settings for NetApp NFS"
+VERSION=6
+DATE=29.04.2022
+DESCRIPTION=Linux Kernel Settings for NetApp NFS
+REFERENCES=https://launchpad.support.sap.com/#/notes/3024346 https://docs.netapp.com/us-en/netapp-solutions-sap/bp/saphana-fas-nfs_introduction.html https://docs.netapp.com/us-en/netapp-solutions-sap/bp/saphana_aff_nfs_introduction.html
 
 [sysctl]
 net.core.rmem_max = 16777216

--- a/ospackage/usr/share/saptune/notes/900929
+++ b/ospackage/usr/share/saptune/notes/900929
@@ -2,7 +2,10 @@
 # Version 7 from 31.07.2017 in English
 
 [version]
-# SAP-NOTE=900929 CATEGORY=LINUX VERSION=7 DATE=31.07.2017 NAME="Linux: STORAGE_PARAMETERS_WRONG_SET and 'mmap() failed'"
+VERSION=7
+DATE=31.07.2017
+DESCRIPTION=Linux: STORAGE_PARAMETERS_WRONG_SET and 'mmap() failed'
+REFERENCES=https://launchpad.support.sap.com/#/notes/900929
 
 [sysctl]
 # vm.max_map_count

--- a/ospackage/usr/share/saptune/notes/941735
+++ b/ospackage/usr/share/saptune/notes/941735
@@ -3,7 +3,10 @@
 # Version 11 from 04.05.2018 in English
 
 [version]
-# SAP-NOTE=941735 CATEGORY=LINUX VERSION=11 DATE=04.05.2018 NAME="SAP memory management system for 64-bit Linux systems"
+VERSION=11
+DATE=04.05.2018
+DESCRIPTION=SAP memory management system for 64-bit Linux systems
+REFERENCES=https://launchpad.support.sap.com/#/notes/941735
 
 [mem]
 # /dev/shm

--- a/ospackage/usr/share/saptune/notes/SAP_BOBJ
+++ b/ospackage/usr/share/saptune/notes/SAP_BOBJ
@@ -1,14 +1,17 @@
 # BOBJ - operating system tuning for SAP Business OBJects (BOBJ)
 #
-# https://help.sap.com/doc/46b1602a6e041014910aba7db0e91070/4.2/en-US/sbo42sp4_bip_inst_unix_en.pdf
+# https://help.sap.com/doc/46b1602a6e041014910aba7db0e91070/4.3/en-US/sbo43_bip_inst_unix_en.pdf
 #
 # SAP BusinessObjects Business Intelligence platform
-# Document Version: 4.2 Support Package 04 – 2017-03-10
+# Document Version: 4.3 – 2020-06-12
 # Business Intelligence Platform Installation Guide for Unix
 # section '4.1.3 Additional requirements for SUSE'
 
 [version]
-# SAP-NOTE=INST-DOC CATEGORY=BOBJ VERSION=0 DATE=10.03.2017 NAME="operating system tuning for SAP Business OBJects (BOBJ)"
+VERSION=1
+DATE=12.06.2020
+DESCRIPTION=operating system tuning for SAP Business OBJects (BOBJ)
+REFERENCES=https://help.sap.com/doc/46b1602a6e041014910aba7db0e91070/4.3/en-US/sbo43_bip_inst_unix_en.pdf
 
 [sysctl]
 kernel.sem = 250 32000 32 1024

--- a/sap/note/ini_test.go
+++ b/sap/note/ini_test.go
@@ -28,7 +28,7 @@ func TestVendorSettings(t *testing.T) {
 	if ini.Name() == "" {
 		t.Error(ini.Name())
 	}
-	if ini.Name() != fmt.Sprintf("ini_test: SAP Note file for ini_test\n\t\t\tVersion 2 from 02.11.2017 ") {
+	if ini.Name() != fmt.Sprintf("ini_test: SAP Note file for ini_test\n\t\t\tVersion 2 from 02.11.2017") {
 		t.Error(ini.Name())
 	}
 
@@ -100,7 +100,7 @@ func TestAllSettings(t *testing.T) {
 	if ini.Name() == "" {
 		t.Error(ini.Name())
 	}
-	if ini.Name() != fmt.Sprintf("ini_all_test: SAP Note file for ini_all_test\n\t\t\tVersion 3 from 02.01.2019 ") {
+	if ini.Name() != fmt.Sprintf("ini_all_test: SAP Note file for ini_all_test\n\t\t\tVersion 3 from 02.01.2019") {
 		t.Error(ini.Name())
 	}
 
@@ -301,7 +301,7 @@ func TestOverrideAllSettings(t *testing.T) {
 	if ini.Name() == "" {
 		t.Error(ini.Name())
 	}
-	if ini.Name() != fmt.Sprintf("ini_all_test: SAP Note file for ini_all_test\n\t\t\tVersion 3 from 02.01.2019 ") {
+	if ini.Name() != fmt.Sprintf("ini_all_test: SAP Note file for ini_all_test\n\t\t\tVersion 3 from 02.01.2019") {
 		t.Error(ini.Name())
 	}
 
@@ -424,7 +424,7 @@ func TestPageCacheSettings(t *testing.T) {
 	if ini.Name() == "" {
 		t.Error(ini.Name())
 	}
-	if ini.Name() != fmt.Sprintf("Linux paging improvements\n\t\t\tVersion 14 from 10.08.2015 ") {
+	if ini.Name() != fmt.Sprintf("Linux paging improvements\n\t\t\tVersion 14 from 10.08.2015") {
 		t.Error(ini.Name())
 	}
 

--- a/sap/note/note.go
+++ b/sap/note/note.go
@@ -51,7 +51,7 @@ func GetTuningOptions(saptuneTuningDir, thirdPartyTuningDir string) TuningOption
 		ret[fileName] = INISettings{
 			ConfFilePath:    path.Join(saptuneTuningDir, fileName),
 			ID:              fileName,
-			DescriptiveName: "",
+			DescriptiveName: txtparser.GetINIFileDescriptiveName(path.Join(saptuneTuningDir, fileName)),
 		}
 	}
 

--- a/system/json.go
+++ b/system/json.go
@@ -98,16 +98,16 @@ type notesOrder struct {
 
 // JNoteListEntry is one line of 'saptune note list'
 type JNoteListEntry struct {
-	NoteID       string   `json:"Note ID"`
-	NoteDesc     string   `json:"Note description"`
-	NoteRef      JObj     `json:"Note reference"`
-	NoteVers     string   `json:"Note version"`
-	NoteRdate    string   `json:"Note release date"`
-	ManEnabled   bool     `json:"Note enabled manually"`
-	SolEnabled   bool     `json:"Note enabled by Solution"`
-	ManReverted  bool     `json:"Note reverted manually"`
-	NoteOverride bool     `json:"Note override exists"`
-	CustomNote   bool     `json:"custom Note"`
+	NoteID       string `json:"Note ID"`
+	NoteDesc     string `json:"Note description"`
+	NoteRef      JObj   `json:"Note reference"`
+	NoteVers     string `json:"Note version"`
+	NoteRdate    string `json:"Note release date"`
+	ManEnabled   bool   `json:"Note enabled manually"`
+	SolEnabled   bool   `json:"Note enabled by Solution"`
+	ManReverted  bool   `json:"Note reverted manually"`
+	NoteOverride bool   `json:"Note override exists"`
+	CustomNote   bool   `json:"custom Note"`
 }
 
 // JNoteList is the whole 'saptune note list'
@@ -141,9 +141,9 @@ type JStatusStaging struct {
 
 // JStatusServs are the mentioned systemd services in 'saptune status'
 type JStatusServs struct {
-	SaptuneService JObj   `json:"saptune"`
-	SapconfService JObj   `json:"sapconf"`
-	TunedService   JObj   `json:"tuned"`
+	SaptuneService JObj    `json:"saptune"`
+	SapconfService JObj    `json:"sapconf"`
+	TunedService   JObj    `json:"tuned"`
 	TunedProfile   *string `json:"tuned profile,omitempty"`
 }
 
@@ -160,7 +160,7 @@ type JSolListEntry struct {
 // JSolList is the whole 'saptune solution list'
 type JSolList struct {
 	SolsList []JSolListEntry `json:"available Solutions"`
-	Msg      string         `json:"remember message"`
+	Msg      string          `json:"remember message"`
 }
 
 // jInit creates an initial json entry
@@ -260,7 +260,7 @@ func Jcollect(data interface{}) {
 		}
 	case JSolList, JNoteList, JStatus:
 		switch rac {
-		case "solution list" , "note list" , "status", "daemon status", "service status":
+		case "solution list", "note list", "status", "daemon status", "service status":
 			jentry.CmdResult = res
 		}
 	default:

--- a/system/json.go
+++ b/system/json.go
@@ -232,27 +232,15 @@ func JnotSupportedYet() {
 
 // Jcollect collects the result data
 func Jcollect(data interface{}) {
-	var val JObj
 	rac := realmAndCmd()
 	if GetFlagVal("format") != "json" || !racIsSupported(rac) {
 		return
 	}
 	switch res := data.(type) {
 	case string:
-		if res == "" {
-			val = nil
-		} else {
-			val = res
-		}
 		if rac == "version" {
 			jentry.CmdResult = versResults{ConfVers: res}
 		}
-		//if rac == "solution enabled" {
-			//jentry.CmdResult = configuredSol{ConfiguredSol: val}
-		//}
-		//if rac == "solution applied" {
-		//	jentry.CmdResult = appliedSol{AppliedSol: val}
-		//}
 	case []string:
 		if len(res) == 1 && res[0] == "" {
 			// replace empty string by empty slice

--- a/system/system.go
+++ b/system/system.go
@@ -300,11 +300,17 @@ func GetHWIdentity(info string) (string, error) {
 // StripComment will strip everything right from the given comment character
 // (including the comment character) and returns the resulting string
 // comment characters can be '#' or ';' or something else
+// or a regex like `\s#[^#]|"\s#[^#]`
 func StripComment(str, commentChars string) string {
-	if cut := strings.IndexAny(str, commentChars); cut >= 0 {
-		return strings.TrimRightFunc(str[:cut], unicode.IsSpace)
+	ret := str
+	re := regexp.MustCompile(commentChars)
+	if cut := re.FindStringIndex(str); cut != nil {
+		ret = strings.TrimRightFunc(str[:cut[0]], unicode.IsSpace)
+		// strip masked # (\s## -> \s#) inside the text
+		re = regexp.MustCompile(`\s(##)`)
+		ret = re.ReplaceAllString(ret, "#")
 	}
-	return str
+	return ret
 }
 
 // GetVirtStatus gets the status of virtualization environment

--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -3,7 +3,6 @@ package txtparser
 import (
 	"fmt"
 	"github.com/SUSE/saptune/system"
-	"io/ioutil"
 	"regexp"
 	"strings"
 )
@@ -25,8 +24,6 @@ var RegexKeyOperatorValue = regexp.MustCompile(`([\w.+_-]+)\s*([<=>]+)\s*["']*(.
 
 // regKey gives the parameter part of the line from the note definition file
 var regKey = regexp.MustCompile(`(.*)\s*[<=>]+\s*["']*.*?["']*$`)
-
-var saptuneSectionDir = system.SaptuneSectionDir
 
 // counter to control the [login] section info message
 var loginCnt = 0
@@ -56,61 +53,15 @@ type INIFile struct {
 
 // GetINIFileDescriptiveName return the descriptive name of the Note
 func GetINIFileDescriptiveName(fileName string) string {
-	var re = regexp.MustCompile(`# .*NOTE=.*VERSION=([\w.+-_]+)\s*DATE=(.*)\s*NAME="([^"]*)"`)
 	rval := ""
-	content, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		return ""
-	}
-	matches := re.FindStringSubmatch(string(content))
-	if len(matches) != 0 {
-		rval = fmt.Sprintf("%s\n\t\t\t%sVersion %s from %s", matches[3], "", matches[1], matches[2])
-	}
-	return rval
-}
-
-// GetINIFileVersionSectionEntry returns the field 'entryName' from the version
-// section of the Note configuration file
-func GetINIFileVersionSectionEntry(fileName, entryName string) string {
-	var re = regexp.MustCompile(`# .*NOTE=.*TEST=([\w.+-_]+)\s*DATE=.*"`)
-	switch entryName {
-	case "version":
-		re = regexp.MustCompile(`# .*NOTE=.*VERSION=([\w.+-_]+)\s*DATE=.*"`)
-	case "category":
-		re = regexp.MustCompile(`# .*NOTE=.*CATEGORY=(\w*)\s*VERSION=.*"`)
-	case "reference":
-		re = regexp.MustCompile(`# .*NOTE=.*REFERENCE="([^"]*)"\s*VERSION=.*"`)
-	case "date":
-		re = regexp.MustCompile(`# .*NOTE=.*VERSION=[\w.+-_]+\s*DATE=(.*)\s*NAME=.*"`)
-	case "name":
-		re = regexp.MustCompile(`# .*NOTE=.*VERSION=[\w.+-_]+\s*DATE=.*\s*NAME="([^"]*)"`)
-	default:
-		return ""
-	}
-	rval := ""
-	content, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		return ""
-	}
-	matches := re.FindStringSubmatch(string(content))
-	if len(matches) != 0 {
-		rval = fmt.Sprintf("%s", strings.TrimSpace(matches[1]))
-	}
-	return rval
-}
-
-// GetINIFileVersionSectionRefs returns the reference field from the version
-// section of the Note configuration file
-func GetINIFileVersionSectionRefs(fileName string) []string {
-	rval := make([]string, 0)
-	var re = regexp.MustCompile(`# .*NOTE=.*REFERENCE="([^"]*)"\s*VERSION=.*"`)
-	content, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		return rval
-	}
-	matches := re.FindStringSubmatch(string(content))
-	if len(matches) != 0 {
-		rval = append(rval, matches[1])
+	desc := GetINIFileVersionSectionEntry(fileName, "description")
+	vers := GetINIFileVersionSectionEntry(fileName, "version")
+	refs := GetINIFileVersionSectionEntry(fileName, "reference")
+	date := GetINIFileVersionSectionEntry(fileName, "date")
+	if desc != "" && vers != "" && date != "" && refs != "" {
+		rval = fmt.Sprintf("%s\n\t\t\t%sVersion %s from %s\n\t\t\t%s", desc, "", vers, date, refs)
+	} else if desc != "" && vers != "" && date != "" {
+		rval = fmt.Sprintf("%s\n\t\t\t%sVersion %s from %s", desc, "", vers, date)
 	}
 	return rval
 }

--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -58,9 +58,12 @@ func GetINIFileDescriptiveName(fileName string) string {
 	vers := GetINIFileVersionSectionEntry(fileName, "version")
 	refs := GetINIFileVersionSectionEntry(fileName, "reference")
 	date := GetINIFileVersionSectionEntry(fileName, "date")
-	if desc != "" && vers != "" && date != "" && refs != "" {
+	if desc == "" && vers == "" && refs == "" && date == "" {
+		// no version section found in file
+		rval = ""
+	} else if refs != "" {
 		rval = fmt.Sprintf("%s\n\t\t\t%sVersion %s from %s\n\t\t\t%s", desc, "", vers, date, refs)
-	} else if desc != "" && vers != "" && date != "" {
+	} else {
 		rval = fmt.Sprintf("%s\n\t\t\t%sVersion %s from %s", desc, "", vers, date)
 	}
 	return rval
@@ -68,7 +71,7 @@ func GetINIFileDescriptiveName(fileName string) string {
 
 // splitLineIntoKOV break apart a line into key, operator, value.
 func splitLineIntoKOV(curSection, line string) []string {
-	kov := make([]string, 0)
+	var kov []string
 	if curSection == "rpm" {
 		kov = splitRPM(line)
 	} else if curSection == "ArchX86" || curSection == "ArchPPC64LE" {
@@ -90,8 +93,8 @@ func splitLineIntoKOV(curSection, line string) []string {
 
 // splitRPM split line of section rpm into the needed syntax
 func splitRPM(line string) []string {
+	var kov []string
 	fields := strings.Fields(line)
-	kov := make([]string, 0)
 	kov = nil
 	if len(fields) == 3 {
 		// old syntax - rpm to check | os version | expected package version
@@ -230,7 +233,7 @@ func ParseINI(input string) *INIFile {
 		}
 
 		// remove trailing comments from line
-		line = system.StripComment(line, "#")
+		line = system.StripComment(line, `\s#[^#]|"\s#[^#]`)
 		// Break apart a line into key, operator, value.
 		kov := splitLineIntoKOV(currentSection, line)
 		if kov == nil {

--- a/txtparser/ini_test.go
+++ b/txtparser/ini_test.go
@@ -16,7 +16,6 @@ var tstFile = path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testd
 var tst2File = path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/wrong_limit_test.ini")
 var fileName = path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/ospackage/usr/share/saptune/notes/1557506")
 var descName = fmt.Sprintf("%s\n\t\t\t%sVersion %s from %s\n\t\t\t%s", "Linux paging improvements", "", "16", "06.02.2020", "https://launchpad.support.sap.com/#/notes/1557506")
-//var noteCategory = "LINUX"
 var noteVersion = "16"
 var noteDate = "06.02.2020"
 var noteTitle = "Linux paging improvements"

--- a/txtparser/ini_test.go
+++ b/txtparser/ini_test.go
@@ -15,11 +15,12 @@ var fileNotExist = "/file_does_not_exist"
 var tstFile = path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/ini_all_test.ini")
 var tst2File = path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/wrong_limit_test.ini")
 var fileName = path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/ospackage/usr/share/saptune/notes/1557506")
-var descName = fmt.Sprintf("%s\n\t\t\t%sVersion %s from %s", "Linux paging improvements", "", "14", "10.08.2015 ")
-var noteCategory = "LINUX"
-var noteVersion = "14"
-var noteDate = "10.08.2015"
+var descName = fmt.Sprintf("%s\n\t\t\t%sVersion %s from %s\n\t\t\t%s", "Linux paging improvements", "", "16", "06.02.2020", "https://launchpad.support.sap.com/#/notes/1557506")
+//var noteCategory = "LINUX"
+var noteVersion = "16"
+var noteDate = "06.02.2020"
 var noteTitle = "Linux paging improvements"
+var noteRefs = "https://launchpad.support.sap.com/#/notes/1557506"
 
 var iniExample = `
 # comment
@@ -226,11 +227,11 @@ func TestGetINIFileDescriptiveName(t *testing.T) {
 }
 
 func TestGetINIFileVersionSectionEntry(t *testing.T) {
-	str := GetINIFileVersionSectionEntry(fileName, "category")
-	if str != noteCategory {
-		t.Errorf("\n'%+v'\nis not\n'%+v'\n", str, noteCategory)
+	str := GetINIFileVersionSectionEntry(fileName, "reference")
+	if str != noteRefs {
+		t.Errorf("\n'%+v'\nis not\n'%+v'\n", str, noteRefs)
 	}
-	str = GetINIFileVersionSectionEntry(fileNotExist, "category")
+	str = GetINIFileVersionSectionEntry(fileNotExist, "reference")
 	if str != "" {
 		t.Errorf(str)
 	}

--- a/txtparser/section.go
+++ b/txtparser/section.go
@@ -267,7 +267,10 @@ func GetINIFileVersionSectionEntry(fileName, entryName string) string {
 	for _, entryLine := range content {
 		matches := re.FindStringSubmatch(entryLine)
 		if len(matches) > 1 {
-			val := system.StripComment(matches[1], "#")
+			val := matches[1]
+			if entryName != "reference" {
+				val = system.StripComment(val, "#")
+			}
 			rval = fmt.Sprintf("%s", strings.TrimSpace(val))
 			break
 		}

--- a/txtparser/section.go
+++ b/txtparser/section.go
@@ -1,15 +1,28 @@
 package txtparser
 
 import (
+	"github.com/SUSE/saptune/system"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
 )
 
 // OverrideTuningSheets defines saptunes override directory
 const OverrideTuningSheets = "/etc/saptune/override/"
+
+var saptuneSectionDir = system.SaptuneSectionDir
+
+// counter to control the warning message for the use of old style
+// version section
+var oldStyleCnt = map[string]int{"file": 0}
+
+// counter to control the error message of missing or wrong version section
+var missVersionCnt = map[string]int{"file": 0}
 
 // StoreSectionInfo stores INIFile section information to section directory
 func StoreSectionInfo(obj *INIFile, file, ID string, overwriteExisting bool) error {
@@ -81,4 +94,251 @@ func GetOverrides(filetype, ID string) (bool, *INIFile) {
 		override = true
 	}
 	return override, ow
+}
+
+// readVersionSection read content of [version] section from config file
+func readVersionSection(fileName string) ([]string, bool, error) {
+	skipSection := false
+	chkVersEntries := map[string]bool{"missing": false, "found": false, "isNew": false, "isOld": false, "skip": false, "mandVers": false, "mandDate": false, "mandDesc": false, "mandRefs": false}
+	vsection := []string{}
+	fName := filepath.Base(fileName)
+	versRun := fmt.Sprintf("%s/version_%s.run", saptuneSectionDir, fName)
+	if _, err := os.Stat(versRun); err == nil {
+		return getVersionRunInfo(versRun)
+	}
+	content, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return vsection, chkVersEntries["isNew"], err
+	}
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if len(line) == 0 {
+			// skip empty lines
+			continue
+		}
+		if line[0] != '[' && skipSection {
+			// skip all lines from a non-valid section
+			continue
+		}
+		if line[0] == '[' {
+			if chkVersEntries["found"] {
+				// stop reading beyond section [version]
+				break
+			}
+			if skipSection {
+				skipSection = false
+			}
+			if line[1 : len(line)-1] != "version" {
+				// skip whole section
+				skipSection = true
+				continue
+			}
+			// found section [version]
+			chkVersEntries["found"] = true
+			continue
+		}
+		chkVersEntriesSyntax(line, chkVersEntries)
+		if chkVersEntries["skip"] {
+			// Skip comments. But include old style version header
+			chkVersEntries["skip"] = false
+			continue
+		}
+		vsection = append(vsection, line)
+	}
+
+	err = chkVersEntriesResult(fileName, chkVersEntries)
+	if !chkVersEntries["missing"] {
+		err = storeVersionRunInfo(versRun, vsection, chkVersEntries["isNew"])
+	}
+	return vsection, chkVersEntries["isNew"], err
+}
+
+// getVersionRunInfo reads content of stored version section info from
+// saptuneSectionDir (/run/saptune/sections)
+func getVersionRunInfo(versRun string) ([]string, bool, error) {
+	var dest []string
+	var vsection []string
+	isNew := true
+	content, err := ioutil.ReadFile(versRun)
+	if err == nil && len(content) != 0 {
+		err = json.Unmarshal(content, &dest)
+		vsection = dest[0:len(dest)-1]
+		if dest[len(dest)-1] == "ISNEW=false" {
+			isNew = false
+		}
+	}
+	return vsection, isNew, err
+}
+
+// storeVersionRunInfo stores the version section info for re-use
+// in saptuneSectionDir (/run/saptune/sections)
+func storeVersionRunInfo(versRun string, vsection []string, isNew bool) error {
+	overwriteExisting := true
+	obj := []string{}
+	if isNew {
+		obj = append(vsection, "ISNEW=true")
+	} else {
+		obj = append(vsection, "ISNEW=false")
+	}
+	content, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	if err = os.MkdirAll(saptuneSectionDir, 0755); err != nil {
+		return err
+	}
+	if _, err := os.Stat(versRun); os.IsNotExist(err) || overwriteExisting {
+		return ioutil.WriteFile(versRun, content, 0644)
+	}
+	return nil
+}
+
+// chkVersEntriesSyntax checks the version section for syntax errors like
+// missing mandatory fields or completely missing version section
+func chkVersEntriesSyntax(line string, chkVents map[string]bool) {
+	var old = regexp.MustCompile(`# .*NOTE=.*VERSION=([\w.+-_]+)\s*DATE=(.*)\s*NAME="([^"]*)"`)
+	matches := old.FindStringSubmatch(line)
+	if len(matches) != 0 {
+		chkVents["isOld"] = true
+	}
+	if !chkVents["isOld"] && strings.HasPrefix(line, "#") {
+		// Skip comments. But include old style version header
+		chkVents["skip"] = true
+		return
+	}
+	// check for the mandatory fields in the new style version section
+	ents := map[string]string{"version": "mandVers", "date": "mandDate", "reference": "mandRefs", "description": "mandDesc"}
+	for key, ent := range ents {
+		re := regexp.MustCompile(newStyleVersionSectionEntry(key))
+		matches = re.FindStringSubmatch(line)
+		if len(matches) > 1 {
+			chkVents[ent] = true
+		}
+	}
+}
+
+// chkVersEntriesResult checks the result of the version section entries check.
+// print and return error message
+func chkVersEntriesResult(fileName string, chkVents map[string]bool) error {
+	var err error
+	if !chkVents["mandVers"] && !chkVents["mandDate"] && !chkVents["mandRefs"] && !chkVents["mandDesc"] {
+		chkVents["isNew"] = false
+	} else {
+		chkVents["isNew"] = true
+	}
+	if (!chkVents["isNew"] && !chkVents["isOld"]) || !chkVents["found"] {
+		// missing version section
+		chkVents["missing"] = true
+		if missVersionCnt[fileName] < 1 {
+			err = system.ErrorLog("missing version section in Note definition file '%s'. Please check", fileName)
+			missVersionCnt[fileName] = missVersionCnt[fileName] + 1
+		} else {
+			err = fmt.Errorf("1")
+		}
+	}
+	if chkVents["isNew"] && (!chkVents["mandVers"] || !chkVents["mandDate"] || !chkVents["mandRefs"] || !chkVents["mandDesc"]) {
+		// wrong version section
+		chkVents["missing"] = true
+		if missVersionCnt[fileName] < 1 {
+			if chkVents["isOld"] {
+				// version section mismatch
+				system.ErrorLog("version section mismatch in Note definition file '%s - old and (partial) new style version header found. Please check", fileName)
+			}
+			err = system.ErrorLog("wrong version section found in Note definition file '%s'. At least one of the mandatory fields is missing. Please check", fileName)
+			missVersionCnt[fileName] = missVersionCnt[fileName] + 1
+		} else {
+			err = fmt.Errorf("2")
+		}
+	}
+	return err
+}
+
+// GetINIFileVersionSectionEntry returns the field 'entryName' from the version
+// section of the Note configuration file
+func GetINIFileVersionSectionEntry(fileName, entryName string) string {
+	var re = regexp.MustCompile(`.*(ID\s*=).*`)
+	rval := ""
+	content, isNewStyle, err := readVersionSection(fileName)
+        if err != nil {
+                return ""
+        }
+	regex := selectVersionExpression(isNewStyle, entryName, fileName)
+	re = regexp.MustCompile(regex)
+	for _, entryLine := range content {
+		matches := re.FindStringSubmatch(entryLine)
+		if len(matches) > 1 {
+			val := system.StripComment(matches[1], "#")
+			rval = fmt.Sprintf("%s", strings.TrimSpace(val))
+			break
+		}
+	}
+	return rval
+}
+
+// GetINIFileVersionSectionRefs returns the reference field from the version
+// section of the Note configuration file
+func GetINIFileVersionSectionRefs(fileName string) []string {
+	rval := make([]string, 0)
+	refs := GetINIFileVersionSectionEntry(fileName, "reference")
+	rval = strings.Fields(refs)
+	return rval
+}
+
+// selectVersionExpression returns the regular expression needed to
+// identify a specific version section entry
+func selectVersionExpression(newStyle bool, entry, file string) string {
+	regex := ""
+	if newStyle {
+		regex = newStyleVersionSectionEntry(entry)
+	} else {
+		if oldStyleCnt[file] < 1 {
+			system.WarningLog("You are still using the old style version section syntax in Note definition file '%s' which is deprecated. Please adapt.", file)
+			oldStyleCnt[file] = oldStyleCnt[file] + 1
+		}
+		regex = oldStyleVersionSectionEntry(entry)
+	}
+	return regex
+}
+
+// newStyleVersionSectionEntry returns the regular expression to retrieve
+// the field 'entryName' from the new style version section of the Note
+// configuration file
+func newStyleVersionSectionEntry(entryName string) string {
+	var re = `^\s*TESTID\s*=\s*"?([^\s].*?)"?$`
+	switch entryName {
+	//case "id":
+	//	re = `^\s*ID\s*=\s*"?([^\s].*?)"?$`
+	case "version":
+		re = `^\s*VERSION\s*=\s*"?([\w.+-_]+)"?$`
+	case "category":
+		re = `^\s*CATEGORY\s*=\s*"?(\w*)"?$`
+	case "reference":
+		re = `^\s*REFERENCES\s*=\s*"?(.*?)"?$`
+	case "date":
+		re = `^\s*DATE\s*=\s*"?(\d{2}[-./]{1}\d{2}[-./]{1}\d{4}|\d{4}[-./]{1}\d{2}[-./]{1}\d{2})"?$`
+	case "name", "description":
+		re = `^\s*DESCRIPTION\s*=\s*"?([^"]*)"?$`
+	}
+	return re
+}
+
+// oldStyleVersionSectionEntry returns the regular expression to retrieve
+// the field 'entryName' from the old style version section of the Note
+// configuration file
+// needed for compatibility reason
+func oldStyleVersionSectionEntry(entryName string) string {
+	var re = `# .*NOTE=.*TEST=([\w.+-_]+)\s*DATE=.*"`
+	switch entryName {
+	case "version":
+		re = `# .*NOTE=.*VERSION=([\w.+-_]+)\s*DATE=.*"`
+	case "category":
+		re = `# .*NOTE=.*CATEGORY=(\w*)\s*VERSION=.*"`
+	case "reference":
+		re = `# .*NOTE=.*REFERENCES="([^"]*)"\s*VERSION=.*"`
+	case "date":
+		re = `# .*NOTE=.*VERSION=[\w.+-_]+\s*DATE=(.*)\s*NAME=.*"`
+	case "name", "description":
+		re = `# .*NOTE=.*VERSION=[\w.+-_]+\s*DATE=.*\s*NAME="([^"]*)"`
+	}
+	return re
 }

--- a/txtparser/section.go
+++ b/txtparser/section.go
@@ -1,9 +1,9 @@
 package txtparser
 
 import (
-	"github.com/SUSE/saptune/system"
 	"encoding/json"
 	"fmt"
+	"github.com/SUSE/saptune/system"
 	"io/ioutil"
 	"os"
 	"path"
@@ -128,7 +128,7 @@ func readVersionSection(fileName string) ([]string, bool, error) {
 			if skipSection {
 				skipSection = false
 			}
-			if line[1 : len(line)-1] != "version" {
+			if line[1:len(line)-1] != "version" {
 				// skip whole section
 				skipSection = true
 				continue
@@ -162,7 +162,7 @@ func getVersionRunInfo(versRun string) ([]string, bool, error) {
 	content, err := ioutil.ReadFile(versRun)
 	if err == nil && len(content) != 0 {
 		err = json.Unmarshal(content, &dest)
-		vsection = dest[0:len(dest)-1]
+		vsection = dest[0 : len(dest)-1]
 		if dest[len(dest)-1] == "ISNEW=false" {
 			isNew = false
 		}
@@ -173,8 +173,8 @@ func getVersionRunInfo(versRun string) ([]string, bool, error) {
 // storeVersionRunInfo stores the version section info for re-use
 // in saptuneSectionDir (/run/saptune/sections)
 func storeVersionRunInfo(versRun string, vsection []string, isNew bool) error {
+	var obj []string
 	overwriteExisting := true
-	obj := []string{}
 	if isNew {
 		obj = append(vsection, "ISNEW=true")
 	} else {
@@ -244,10 +244,8 @@ func chkVersEntriesResult(fileName string, chkVents map[string]bool) error {
 				// version section mismatch
 				system.ErrorLog("version section mismatch in Note definition file '%s - old and (partial) new style version header found. Please check", fileName)
 			}
-			err = system.ErrorLog("wrong version section found in Note definition file '%s'. At least one of the mandatory fields is missing. Please check", fileName)
+			system.ErrorLog("wrong version section found in Note definition file '%s'. At least one of the mandatory fields is missing. Please check", fileName)
 			missVersionCnt[fileName] = missVersionCnt[fileName] + 1
-		} else {
-			err = fmt.Errorf("2")
 		}
 	}
 	return err
@@ -259,19 +257,17 @@ func GetINIFileVersionSectionEntry(fileName, entryName string) string {
 	var re = regexp.MustCompile(`.*(ID\s*=).*`)
 	rval := ""
 	content, isNewStyle, err := readVersionSection(fileName)
-        if err != nil {
-                return ""
-        }
+	if err != nil {
+		return ""
+	}
 	regex := selectVersionExpression(isNewStyle, entryName, fileName)
 	re = regexp.MustCompile(regex)
 	for _, entryLine := range content {
 		matches := re.FindStringSubmatch(entryLine)
 		if len(matches) > 1 {
 			val := matches[1]
-			if entryName != "reference" {
-				val = system.StripComment(val, "#")
-			}
-			rval = fmt.Sprintf("%s", strings.TrimSpace(val))
+			val = system.StripComment(val, `\s#[^#]|"\s#[^#]`)
+			rval = strings.TrimSpace(val)
 			break
 		}
 	}
@@ -281,9 +277,8 @@ func GetINIFileVersionSectionEntry(fileName, entryName string) string {
 // GetINIFileVersionSectionRefs returns the reference field from the version
 // section of the Note configuration file
 func GetINIFileVersionSectionRefs(fileName string) []string {
-	rval := make([]string, 0)
 	refs := GetINIFileVersionSectionEntry(fileName, "reference")
-	rval = strings.Fields(refs)
+	rval := strings.Fields(refs)
 	return rval
 }
 
@@ -312,15 +307,15 @@ func newStyleVersionSectionEntry(entryName string) string {
 	//case "id":
 	//	re = `^\s*ID\s*=\s*"?([^\s].*?)"?$`
 	case "version":
-		re = `^\s*VERSION\s*=\s*"?([\w.+-_]+)"?$`
+		re = `^\s*VERSION\s*=\s*"?([\w.+-_]+)"?.*$`
 	case "category":
 		re = `^\s*CATEGORY\s*=\s*"?(\w*)"?$`
 	case "reference":
-		re = `^\s*REFERENCES\s*=\s*"?(.*?)"?$`
+		re = `^\s*REFERENCES\s*=\s*"?(.*)"?$`
 	case "date":
-		re = `^\s*DATE\s*=\s*"?(\d{2}[-./]{1}\d{2}[-./]{1}\d{4}|\d{4}[-./]{1}\d{2}[-./]{1}\d{2})"?$`
+		re = `^\s*DATE\s*=\s*"?(\d{2}[-./]{1}\d{2}[-./]{1}\d{4}|\d{4}[-./]{1}\d{2}[-./]{1}\d{2})"?.*$`
 	case "name", "description":
-		re = `^\s*DESCRIPTION\s*=\s*"?([^"]*)"?$`
+		re = `^\s*DESCRIPTION\s*=\s*"?(.*)"?$`
 	}
 	return re
 }


### PR DESCRIPTION
rework the version section of the Note definition files to get a better overview, which information need to be provided.
Add check that all mandatory parameter of the version section are available.
Adapt the unit tests and improve the inline comment detection.
(jsc#SLE-23722)

add IBM Power support to the vendor and model tagging (jsc#SLE-23824)