### PR TITLE
change value flag syntax from using "=" as separator between flag name and flag value to blank

### DIFF
--- a/.github/workflows/saptune-ut.yml
+++ b/.github/workflows/saptune-ut.yml
@@ -21,7 +21,8 @@ jobs:
 
       - name: Set ENV for codeclimate (pull_request)
         run: |
-          git fetch --no-tags --prune --depth=1 origin +refs/heads/${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
+          #git fetch --no-tags --prune --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.head_ref }}
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.head_ref }}
           echo "GIT_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
           echo "GIT_COMMIT_SHA=$(git rev-parse origin/${{ github.head_ref }})" >> $GITHUB_ENV
         if: github.event_name == 'pull_request'

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -301,6 +301,11 @@ Print current saptune status:
 Print current saptune version:
   saptune [--format=FORMAT] version
 Print this message:
-  saptune [--format=FORMAT] help`)
+  saptune [--format=FORMAT] help
+
+Deprecation list:
+  all 'saptune daemon' actions
+  'saptune note simulate'
+  'saptune solution simulate'`)
 	system.ErrorExit("", exitStatus)
 }

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -273,35 +273,35 @@ func PrintHelpAndExit(writer io.Writer, exitStatus int) {
 	}
 	fmt.Fprintln(writer, `saptune: Comprehensive system optimisation management for SAP solutions.
 Daemon control:
-  saptune [--format=FORMAT] daemon ( start | stop | status [--non-compliance-check] ) ATTENTION: deprecated
-  saptune [--format=FORMAT] service ( start | stop | restart | takeover | enable | disable | enablestart | disablestop | status [--non-compliance-check] )
+  saptune [--format FORMAT] daemon ( start | stop | status [--non-compliance-check] ) ATTENTION: deprecated
+  saptune [--format FORMAT] service ( start | stop | restart | takeover | enable | disable | enablestart | disablestop | status [--non-compliance-check] )
 Tune system according to SAP and SUSE notes:
-  saptune [--format=FORMAT] note ( list | revertall | enabled | applied )
-  saptune [--format=FORMAT] note ( apply | simulate | customise | create | edit | revert | show | delete ) NOTEID
-  saptune [--format=FORMAT] note verify [--colorscheme=SCHEME] [--show-non-compliant] [NOTEID]
-  saptune [--format=FORMAT] note rename NOTEID NEWNOTEID
+  saptune [--format FORMAT] note ( list | revertall | enabled | applied )
+  saptune [--format FORMAT] note ( apply | simulate | customise | create | edit | revert | show | delete ) NOTEID
+  saptune [--format FORMAT] note verify [--colorscheme SCHEME] [--show-non-compliant] [NOTEID]
+  saptune [--format FORMAT] note rename NOTEID NEWNOTEID
 Tune system for all notes applicable to your SAP solution:
-  saptune [--format=FORMAT] solution ( list | verify | enabled | applied )
-  saptune [--format=FORMAT] solution ( apply | simulate | customise | create | edit | revert | show | delete ) SOLUTIONNAME
-  saptune [--format=FORMAT] solution change [--force] SOLUTIONNAME
-  saptune [--format=FORMAT] solution verify [--colorscheme=SCHEME] [--show-non-compliant] [SOLUTIONNAME]
-  saptune [--format=FORMAT] solution rename SOLUTIONNAME NEWSOLUTIONNAME
+  saptune [--format FORMAT] solution ( list | verify | enabled | applied )
+  saptune [--format FORMAT] solution ( apply | simulate | customise | create | edit | revert | show | delete ) SOLUTIONNAME
+  saptune [--format FORMAT] solution change [--force] SOLUTIONNAME
+  saptune [--format FORMAT] solution verify [--colorscheme SCHEME] [--show-non-compliant] [SOLUTIONNAME]
+  saptune [--format FORMAT] solution rename SOLUTIONNAME NEWSOLUTIONNAME
 Staging control:
-   saptune [--format=FORMAT] staging ( status | enable | disable | is-enabled | list )
-   saptune [--format=FORMAT] staging ( analysis | diff ) [ ( NOTEID | SOLUTIONNAME )... | all ]
-   saptune [--format=FORMAT] staging release [--force|--dry-run] [ ( NOTEID | SOLUTIONNAME )... | all ]
+   saptune [--format FORMAT] staging ( status | enable | disable | is-enabled | list )
+   saptune [--format FORMAT] staging ( analysis | diff ) [ ( NOTEID | SOLUTIONNAME )... | all ]
+   saptune [--format FORMAT] staging release [--force|--dry-run] [ ( NOTEID | SOLUTIONNAME )... | all ]
 Revert all parameters tuned by the SAP notes or solutions:
-  saptune [--format=FORMAT] revert all
+  saptune [--format FORMAT] revert all
 Remove the pending lock file from a former saptune call
-  saptune [--format=FORMAT] lock remove
+  saptune [--format FORMAT] lock remove
 Call external script '/usr/sbin/saptune_check'
-  saptune [--format=FORMAT] check
+  saptune [--format FORMAT] check
 Print current saptune status:
-  saptune [--format=FORMAT] status [--non-compliance-check]
+  saptune [--format FORMAT] status [--non-compliance-check]
 Print current saptune version:
-  saptune [--format=FORMAT] version
+  saptune [--format FORMAT] version
 Print this message:
-  saptune [--format=FORMAT] help
+  saptune [--format FORMAT] help
 
 Deprecation list:
   all 'saptune daemon' actions

--- a/actions/actionsMatchtxt_test.go
+++ b/actions/actionsMatchtxt_test.go
@@ -84,35 +84,35 @@ Your system has not yet been tuned. Please visit `+"`"+`saptune note`+"`"+` and 
 
 var PrintHelpAndExitMatchText = `saptune: Comprehensive system optimisation management for SAP solutions.
 Daemon control:
-  saptune [--format=FORMAT] daemon ( start | stop | status [--non-compliance-check] ) ATTENTION: deprecated
-  saptune [--format=FORMAT] service ( start | stop | restart | takeover | enable | disable | enablestart | disablestop | status [--non-compliance-check] )
+  saptune [--format FORMAT] daemon ( start | stop | status [--non-compliance-check] ) ATTENTION: deprecated
+  saptune [--format FORMAT] service ( start | stop | restart | takeover | enable | disable | enablestart | disablestop | status [--non-compliance-check] )
 Tune system according to SAP and SUSE notes:
-  saptune [--format=FORMAT] note ( list | revertall | enabled | applied )
-  saptune [--format=FORMAT] note ( apply | simulate | customise | create | edit | revert | show | delete ) NOTEID
-  saptune [--format=FORMAT] note verify [--colorscheme=SCHEME] [--show-non-compliant] [NOTEID]
-  saptune [--format=FORMAT] note rename NOTEID NEWNOTEID
+  saptune [--format FORMAT] note ( list | revertall | enabled | applied )
+  saptune [--format FORMAT] note ( apply | simulate | customise | create | edit | revert | show | delete ) NOTEID
+  saptune [--format FORMAT] note verify [--colorscheme SCHEME] [--show-non-compliant] [NOTEID]
+  saptune [--format FORMAT] note rename NOTEID NEWNOTEID
 Tune system for all notes applicable to your SAP solution:
-  saptune [--format=FORMAT] solution ( list | verify | enabled | applied )
-  saptune [--format=FORMAT] solution ( apply | simulate | customise | create | edit | revert | show | delete ) SOLUTIONNAME
-  saptune [--format=FORMAT] solution change [--force] SOLUTIONNAME
-  saptune [--format=FORMAT] solution verify [--colorscheme=SCHEME] [--show-non-compliant] [SOLUTIONNAME]
-  saptune [--format=FORMAT] solution rename SOLUTIONNAME NEWSOLUTIONNAME
+  saptune [--format FORMAT] solution ( list | verify | enabled | applied )
+  saptune [--format FORMAT] solution ( apply | simulate | customise | create | edit | revert | show | delete ) SOLUTIONNAME
+  saptune [--format FORMAT] solution change [--force] SOLUTIONNAME
+  saptune [--format FORMAT] solution verify [--colorscheme SCHEME] [--show-non-compliant] [SOLUTIONNAME]
+  saptune [--format FORMAT] solution rename SOLUTIONNAME NEWSOLUTIONNAME
 Staging control:
-   saptune [--format=FORMAT] staging ( status | enable | disable | is-enabled | list )
-   saptune [--format=FORMAT] staging ( analysis | diff ) [ ( NOTEID | SOLUTIONNAME )... | all ]
-   saptune [--format=FORMAT] staging release [--force|--dry-run] [ ( NOTEID | SOLUTIONNAME )... | all ]
+   saptune [--format FORMAT] staging ( status | enable | disable | is-enabled | list )
+   saptune [--format FORMAT] staging ( analysis | diff ) [ ( NOTEID | SOLUTIONNAME )... | all ]
+   saptune [--format FORMAT] staging release [--force|--dry-run] [ ( NOTEID | SOLUTIONNAME )... | all ]
 Revert all parameters tuned by the SAP notes or solutions:
-  saptune [--format=FORMAT] revert all
+  saptune [--format FORMAT] revert all
 Remove the pending lock file from a former saptune call
-  saptune [--format=FORMAT] lock remove
+  saptune [--format FORMAT] lock remove
 Call external script '/usr/sbin/saptune_check'
-  saptune [--format=FORMAT] check
+  saptune [--format FORMAT] check
 Print current saptune status:
-  saptune [--format=FORMAT] status [--non-compliance-check]
+  saptune [--format FORMAT] status [--non-compliance-check]
 Print current saptune version:
-  saptune [--format=FORMAT] version
+  saptune [--format FORMAT] version
 Print this message:
-  saptune [--format=FORMAT] help
+  saptune [--format FORMAT] help
 
 Deprecation list:
   all 'saptune daemon' actions

--- a/actions/actionsMatchtxt_test.go
+++ b/actions/actionsMatchtxt_test.go
@@ -113,4 +113,9 @@ Print current saptune version:
   saptune [--format=FORMAT] version
 Print this message:
   saptune [--format=FORMAT] help
+
+Deprecation list:
+  all 'saptune daemon' actions
+  'saptune note simulate'
+  'saptune solution simulate'
 `

--- a/actions/table_test.go
+++ b/actions/table_test.go
@@ -56,7 +56,8 @@ func TestSetWidthOfColums(t *testing.T) {
 }
 
 func TestPrintNoteFields(t *testing.T) {
-	os.Args = []string{"saptune", "note", "list", "--colorscheme=black", "--format=json", "--force", "--dryrun", "--help", "--version"}
+	//os.Args = []string{"saptune", "--format", "json", "note", "list", "--colorscheme", "black", "--force", "--dryrun", "--help", "--version"}
+	os.Args = []string{"saptune", "note", "list", "--colorscheme", "black", "--force", "--dryrun", "--help", "--version"}
 	system.RereadArgs()
 
 	footnote1 := " [1] setting is not supported by the system"
@@ -248,7 +249,8 @@ func TestPrintNoteFields(t *testing.T) {
 	})
 
 	t.Run("verify with header and show-non-compliant", func(t *testing.T) {
-		os.Args = []string{"saptune", "note", "list", "--colorscheme=black", "--show-non-compliant", "--format=json", "--force", "--dryrun", "--help", "--version"}
+		//os.Args = []string{"saptune", "--format", "json", "note", "list", "--colorscheme", "black", "--show-non-compliant", "--force", "--dryrun", "--help", "--version"}
+		os.Args = []string{"saptune", "note", "list", "--colorscheme", "black", "--show-non-compliant", "--force", "--dryrun", "--help", "--version"}
 		system.RereadArgs()
 
 		buffer := bytes.Buffer{}

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -774,6 +774,9 @@ will show the content of the file
 With the update to saptune version 3 saptune does no longer use tuned(8) to restart after a system reboot. It is using it's own systemd service named "saptune.service".
 .br
 So we now \fBdeprecated\fP all "DAEMON ACTIONS" like '\fIsaptune daemon start\fP'. These commands will still work as they are internally linked to the related "SERVICE ACTIONS" like '\fIsaptune service takeover\fP'. Please refer to the related section descriptions at the top of this man page.
+.TP
+.B version 3.1
+With the update to saptune version 3.1 we \fBdeprecated\fP the actions '\fIsaptune note simulate\fP' and '\fIsaptune solution simulate\fP'.
 
 .SH FILES
 .PP

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -21,58 +21,58 @@ saptune \- Comprehensive system optimisation management for SAP solutions (\fBVe
 ATTENTION: If you still use version \fB1\fP of saptune it's now time to migrate to saptune version \fB3\fP, so please refer to man page saptune-migrate(7).
 
 .SH SYNOPSIS
-\fBsaptune\fP [--format=FORMAT] \fBdaemon\fP
+\fBsaptune\fP [--format FORMAT] \fBdaemon\fP
 ( start | stop | status [--non-compliance-check] ) \fBATTENTION: deprecated\fP
 
-\fBsaptune\fP [--format=FORMAT] \fBservice\fP
+\fBsaptune\fP [--format FORMAT] \fBservice\fP
 ( start | stop | restart | takeover | enable | disable | enablestart | disablestop | status [--non-compliance-check] )
 
-\fBsaptune\fP [--format=FORMAT] \fBnote\fP
+\fBsaptune\fP [--format FORMAT] \fBnote\fP
 ( list | revertall | enabled | applied )
 
-\fBsaptune\fP [--format=FORMAT] \fBnote\fP
+\fBsaptune\fP [--format FORMAT] \fBnote\fP
 ( apply | simulate | customise | create | edit | revert | show | delete ) NOTEID
 
-\fBsaptune\fP [--format=FORMAT] \fBnote\fP
-verify [--colorscheme=SCHEME] [--show-non-compliant] [NOTEID]
+\fBsaptune\fP [--format FORMAT] \fBnote\fP
+verify [--colorscheme SCHEME] [--show-non-compliant] [NOTEID]
 
-\fBsaptune\fP [--format=FORMAT] \fBnote\fP
+\fBsaptune\fP [--format FORMAT] \fBnote\fP
 rename NOTEID NEWNOTEID
 
-\fBsaptune\fP [--format=FORMAT] \fBsolution\fP
+\fBsaptune\fP [--format FORMAT] \fBsolution\fP
 ( list | verify | enabled | applied )
 
-\fBsaptune\fP [--format=FORMAT] \fBsolution\fP
+\fBsaptune\fP [--format FORMAT] \fBsolution\fP
 ( apply | simulate | customise | create | edit | revert | show | delete ) SOLUTIONNAME
 
-\fBsaptune\fP [--format=FORMAT] \fBsolution\fP
+\fBsaptune\fP [--format FORMAT] \fBsolution\fP
 change [--force] SOLUTIONNAME
 
-\fBsaptune\fP [--format=FORMAT] \fBsolution\fP
-verify [--colorscheme=SCHEME] [--show-non-compliant] [SOLUTIONNAME]
+\fBsaptune\fP [--format FORMAT] \fBsolution\fP
+verify [--colorscheme SCHEME] [--show-non-compliant] [SOLUTIONNAME]
 
-\fBsaptune\fP [--format=FORMAT] \fBsolution\fP
+\fBsaptune\fP [--format FORMAT] \fBsolution\fP
 rename SOLUTIONNAME NEWSOLUTIONNAME
 
-\fBsaptune\fP [--format=FORMAT] \fBstaging\fP
+\fBsaptune\fP [--format FORMAT] \fBstaging\fP
 ( status | enable | disable | is-enabled | list )
 
-\fBsaptune\fP [--format=FORMAT] \fBstaging\fP
+\fBsaptune\fP [--format FORMAT] \fBstaging\fP
 ( analysis | diff ) [ ( NOTEID | SOLUTIONNAME )... | all ]
 
-\fBsaptune\fP [--format=FORMAT] \fBstaging\fP
+\fBsaptune\fP [--format FORMAT] \fBstaging\fP
 release [--force|--dry-run] [ ( NOTEID | SOLUTIONNAME )... | all ]
 
-\fBsaptune\fP [--format=FORMAT] \fBrevert\fP
+\fBsaptune\fP [--format FORMAT] \fBrevert\fP
 all
 
-\fBsaptune\fP [--format=FORMAT] \fBcheck\fP
+\fBsaptune\fP [--format FORMAT] \fBcheck\fP
 
-\fBsaptune\fP [--format=FORMAT] \fBstatus [--non-compliance-check]\fP
+\fBsaptune\fP [--format FORMAT] \fBstatus [--non-compliance-check]\fP
 
-\fBsaptune\fP [--format=FORMAT] \fBversion\fP
+\fBsaptune\fP [--format FORMAT] \fBversion\fP
 
-\fBsaptune\fP [--format=FORMAT] \fBhelp\fP
+\fBsaptune\fP [--format FORMAT] \fBhelp\fP
 
 .SH DESCRIPTION
 saptune is designed to automate the configuration recommendations from SAP and SUSE to run an SAP application on SLES for SAP. These configuration recommendations normally referred to as SAP Notes. So some dedicated SAP Notes are the base for the work of saptune. Additional some best practice guides are added as Note definitions to optimise the system for some really special cases.
@@ -86,7 +86,7 @@ saptune does not only set kernel values (like sysctl does), but also values like
 .PP
 /proc/sys/, /proc/sys/vm/, /proc/sys/kernel, /proc/sys/fs, /sys/block/*/queue/scheduler and /sys/block/*/queue/nr_requests, /sys/devices/system/cpu/*/cpufreq/scaling_governor, /sys/devices/system/cpu/*/cpuidle/state*/latency, /sys/devices/system/cpu/*/cpuidle/state*/disable, /dev/shm, /etc/security/limits.d/, /etc/systemd/logind.conf.d/ and some others.
 
-By default saptune is printing all results to stdout, Errors and Warnings are printed to stderr. By using \fB[--format=FORMAT]\fP this behaviour can be changed.
+By default saptune is printing all results to stdout, Errors and Warnings are printed to stderr. By using \fB[--format FORMAT]\fP this behaviour can be changed.
 .br
 Supported formats are:
 .TP
@@ -335,7 +335,7 @@ By using the command line argument '\fB--show-non-compliant\fP' it is possible t
 
 It is possible to use a \fBcolor scheme\fP for the verify output table.
 .br
-The \fBcolor scheme\fP can be given as a command line argument '\fB--colorscheme=SCHEME\fP' or as variable '\fBCOLOR_SCHEME=SCHEME\fP' in the saptune configuration file \fI/etc/sysconfig/saptune\fP.
+The \fBcolor scheme\fP can be given as a command line argument '\fB--colorscheme SCHEME\fP' or as variable '\fBCOLOR_SCHEME SCHEME\fP' in the saptune configuration file \fI/etc/sysconfig/saptune\fP.
 .br
 Possible \fBcolor schemes\fP are:
 .RS 7

--- a/system/argsAndFlags.go
+++ b/system/argsAndFlags.go
@@ -411,7 +411,7 @@ func chkVerifySyntax(cmdLinePos map[string]int) bool {
 			DebugLog("chkVerifySyntax failed - missing colorscheme leads to wrong position of 'show-non-compliant' flag in command line")
 			ret = false
 		}
- 		if stArgs[cmdLinePos["cmdOpt"]] != "--colorscheme" {
+		if stArgs[cmdLinePos["cmdOpt"]] != "--colorscheme" {
 			// flag at wrong place in arg list
 			DebugLog("chkVerifySyntax failed - 'colorscheme' flag on wrong position in command line")
 			ret = false

--- a/system/argsAndFlags.go
+++ b/system/argsAndFlags.go
@@ -286,7 +286,8 @@ func chkCmdOpts(cmdLinePos map[string]int) bool {
 		ret = false
 	}
 	// saptune note verify [--colorscheme=<color scheme>] [--show-non-compliant] [NOTEID]
-	if !chkNoteVerifySyntax(cmdLinePos) {
+	// saptune solution verify [--colorscheme=<color scheme>] [--show-non-compliant] [SOLUTIONNAME]
+	if !chkVerifySyntax(cmdLinePos) {
 		ret = false
 	}
 	// saptune (service) status  [--non-compliance-check]
@@ -332,14 +333,15 @@ func chkDryrunFlag(cmdLinePos map[string]int) bool {
 	return ret
 }
 
-// chkNoteVerifySyntax checks the syntax of 'saptune note verify' command line
-// regarding command line options
+// chkVerifySyntax checks the syntax of 'saptune note|solution verify' command
+// line regarding command line options
 // saptune note verify [--colorscheme=<color scheme>] [--show-non-compliant] [NOTEID]
-func chkNoteVerifySyntax(cmdLinePos map[string]int) bool {
+// saptune solution verify [--colorscheme=<color scheme>] [--show-non-compliant] [SOLUTIONNAME]
+func chkVerifySyntax(cmdLinePos map[string]int) bool {
 	stArgs := os.Args
 	ret := true
 	if IsFlagSet("colorscheme") || IsFlagSet("show-non-compliant") {
-		if !(stArgs[cmdLinePos["realm"]] == "note" && stArgs[cmdLinePos["cmd"]] == "verify") {
+		if !((stArgs[cmdLinePos["realm"]] == "note" || stArgs[cmdLinePos["realm"]] == "solution") && stArgs[cmdLinePos["cmd"]] == "verify") {
 			ret = false
 		}
 	}

--- a/system/argsAndFlags_test.go
+++ b/system/argsAndFlags_test.go
@@ -255,8 +255,8 @@ func TestChkCliSyntax(t *testing.T) {
 		t.Errorf("Test failed, expected wrong syntax, but got 'good'")
 	}
 
-	// {"saptune", "--out=json", "note", "list"} -> wrong
-	os.Args = []string{"saptune", "--out=json", "note", "list"}
+	// {"saptune", "--out json", "note", "list"} -> wrong
+	os.Args = []string{"saptune", "--out", "json", "note", "list"}
 	saptArgs, saptFlags = ParseCliArgs()
 	if ChkCliSyntax() {
 		t.Errorf("Test failed, expected wrong syntax, but got 'good'")

--- a/system/argsAndFlags_test.go
+++ b/system/argsAndFlags_test.go
@@ -70,7 +70,7 @@ func TestCliArg(t *testing.T) {
 }
 
 func TestCliFlags(t *testing.T) {
-	os.Args = []string{"saptune", "note", "list", "--format=json", "--force", "--dryrun", "--help", "--version", "--colorscheme=zebra", "--show-non-compliant", "--wrongflag", "--unknownflag=none"}
+	os.Args = []string{"saptune", "note", "list", "--format", "json", "--force", "--dryrun", "--help", "--version", "--colorscheme", "full-green-zebra", "--show-non-compliant", "--wrongflag", "--unknownflag=none"}
 	// parse command line, to get the test parameters
 	saptArgs, saptFlags = ParseCliArgs()
 
@@ -170,7 +170,7 @@ func TestRereadArgs(t *testing.T) {
 	os.Args = []string{"saptune", "note", "list"}
 	// parse command line, to get the test parameters
 	saptArgs, saptFlags = ParseCliArgs()
-	os.Args = []string{"saptune", "--format=json", "solution", "enabled"}
+	os.Args = []string{"saptune", "--format", "json", "solution", "enabled"}
 	RereadArgs()
 
 	expected := "solution"
@@ -214,8 +214,16 @@ func TestRereadArgs(t *testing.T) {
 }
 
 func TestChkCliSyntax(t *testing.T) {
-	// {"saptune", "note", "list", "--format=json"} -> wrong
-	os.Args = []string{"saptune", "note", "list", "--format=json"}
+	// {"saptune", "note", "list", "--format json"} -> wrong
+	os.Args = []string{"saptune", "note", "list", "--format", "json"}
+	// parse command line, to get the test parameters
+	saptArgs, saptFlags = ParseCliArgs()
+	if ChkCliSyntax() {
+		t.Errorf("Test failed, expected wrong syntax, but got 'good'")
+	}
+
+	// {"saptune", "--format hugo", "note", "list"} -> wrong
+	os.Args = []string{"saptune", "--format", "hugo", "note", "list"}
 	// parse command line, to get the test parameters
 	saptArgs, saptFlags = ParseCliArgs()
 	if ChkCliSyntax() {
@@ -254,8 +262,8 @@ func TestChkCliSyntax(t *testing.T) {
 		t.Errorf("Test failed, expected wrong syntax, but got 'good'")
 	}
 
-	// {"saptune", "--format=json", "note", "list"} -> ok
-	os.Args = []string{"saptune", "--format=json", "note", "list"}
+	// {"saptune", "--format json", "note", "list"} -> ok
+	os.Args = []string{"saptune", "--format", "json", "note", "list"}
 	saptArgs, saptFlags = ParseCliArgs()
 	if !ChkCliSyntax() {
 		t.Errorf("Test failed, expected good syntax, but got 'wrong'")
@@ -347,9 +355,9 @@ func TestChkCliSyntax(t *testing.T) {
 		t.Errorf("Test failed, expected wrong syntax, but got 'good'")
 	}
 
-	// saptune note verify [--colorscheme=<color scheme>] [--show-non-compliant] [NOTEID]
-	// {"saptune", "note", "list", "--colorscheme=zebra"} -> wrong
-	os.Args = []string{"saptune", "note", "list", "--colorscheme=zebra"}
+	// saptune note verify [--colorscheme <color scheme>] [--show-non-compliant] [NOTEID]
+	// {"saptune", "note", "list", "--colorscheme full-green-zebra"} -> wrong
+	os.Args = []string{"saptune", "note", "list", "--colorscheme", "full-green-zebra"}
 	saptArgs, saptFlags = ParseCliArgs()
 	if ChkCliSyntax() {
 		t.Errorf("Test failed, expected wrong syntax, but got 'good'")
@@ -362,15 +370,15 @@ func TestChkCliSyntax(t *testing.T) {
 		t.Errorf("Test failed, expected wrong syntax, but got 'good'")
 	}
 
-	// {"saptune", "note", "list", "--colorscheme=zebra", "--show-non-compliant"} -> wrong
-	os.Args = []string{"saptune", "note", "list", "--colorscheme=zebra", "--show-non-compliant"}
+	// {"saptune", "note", "list", "--colorscheme full-green-zebra", "--show-non-compliant"} -> wrong
+	os.Args = []string{"saptune", "note", "list", "--colorscheme", "full-green-zebra", "--show-non-compliant"}
 	saptArgs, saptFlags = ParseCliArgs()
 	if ChkCliSyntax() {
 		t.Errorf("Test failed, expected wrong syntax, but got 'good'")
 	}
 
-	// {"saptune", "staging", "list", "--colorscheme=zebra"} -> wrong
-	os.Args = []string{"saptune", "staging", "list", "--colorscheme=zebra"}
+	// {"saptune", "staging", "list", "--colorscheme full-green-zebra"} -> wrong
+	os.Args = []string{"saptune", "staging", "list", "--colorscheme", "full-green-zebra"}
 	saptArgs, saptFlags = ParseCliArgs()
 	if ChkCliSyntax() {
 		t.Errorf("Test failed, expected wrong syntax, but got 'good'")
@@ -383,15 +391,15 @@ func TestChkCliSyntax(t *testing.T) {
 		t.Errorf("Test failed, expected good syntax, but got 'wrong'")
 	}
 
-	// {"saptune", "note", "verify", "--colorscheme=zebra"} -> ok
-	os.Args = []string{"saptune", "note", "verify", "--colorscheme=zebra"}
+	// {"saptune", "note", "verify", "--colorscheme full-green-zebra"} -> ok
+	os.Args = []string{"saptune", "note", "verify", "--colorscheme", "full-green-zebra"}
 	saptArgs, saptFlags = ParseCliArgs()
 	if !ChkCliSyntax() {
 		t.Errorf("Test failed, expected good syntax, but got 'wrong'")
 	}
 
-	// {"saptune", "note", "verify", "--colorscheme=zebra", "--show-non-compliant"} -> ok
-	os.Args = []string{"saptune", "note", "verify", "--colorscheme=zebra", "--show-non-compliant"}
+	// {"saptune", "note", "verify", "--colorscheme full-green-zebra", "--show-non-compliant"} -> ok
+	os.Args = []string{"saptune", "note", "verify", "--colorscheme", "full-green-zebra", "--show-non-compliant"}
 	saptArgs, saptFlags = ParseCliArgs()
 	if !ChkCliSyntax() {
 		t.Errorf("Test failed, expected good syntax, but got 'wrong'")
@@ -404,8 +412,15 @@ func TestChkCliSyntax(t *testing.T) {
 		t.Errorf("Test failed, expected good syntax, but got 'wrong'")
 	}
 
-	// {"saptune", "note", "verify", "--show-non-compliant", "--colorscheme=zebra"} -> wrong
-	os.Args = []string{"saptune", "note", "verify", "--show-non-compliant", "--colorscheme=zebra"}
+	// {"saptune", "note", "verify", "--colorscheme zebra", "--show-non-compliant"} -> ok
+	os.Args = []string{"saptune", "note", "verify", "--colorscheme", "zebra", "--show-non-compliant"}
+	saptArgs, saptFlags = ParseCliArgs()
+	if !ChkCliSyntax() {
+		t.Errorf("Test failed, expected good syntax, but got 'wrong'")
+	}
+
+	// {"saptune", "note", "verify", "--show-non-compliant", "--colorscheme full-green-zebra"} -> wrong
+	os.Args = []string{"saptune", "note", "verify", "--show-non-compliant", "--colorscheme", "full-green-zebra"}
 	saptArgs, saptFlags = ParseCliArgs()
 	if ChkCliSyntax() {
 		t.Errorf("Test failed, expected wrong syntax, but got 'good'")
@@ -418,8 +433,8 @@ func TestChkCliSyntax(t *testing.T) {
 		t.Errorf("Test failed, expected wrong syntax, but got 'good'")
 	}
 
-	// {"saptune", "note", "--colorscheme=zebra", "verify"} -> wrong
-	os.Args = []string{"saptune", "note", "--colorscheme=zebra", "verify"}
+	// {"saptune", "note", "--colorscheme full-green-zebra", "verify"} -> wrong
+	os.Args = []string{"saptune", "note", "--colorscheme", "full-green-zebra", "verify"}
 	saptArgs, saptFlags = ParseCliArgs()
 	if ChkCliSyntax() {
 		t.Errorf("Test failed, expected wrong syntax, but got 'good'")

--- a/system/file.go
+++ b/system/file.go
@@ -220,7 +220,7 @@ func WriteBackupValue(value, fileName string) {
 
 // AddGap adds an empty line to improve readability of the screen output
 func AddGap(writer io.Writer) {
-	if GetFlagVal("format") == "" {
+	if GetFlagVal("format") == "" || GetFlagVal("format") == "flag_value" {
 		fmt.Fprintf(writer, "\n")
 	}
 }

--- a/system/file_test.go
+++ b/system/file_test.go
@@ -231,7 +231,7 @@ func TestBackupValue(t *testing.T) {
 }
 
 func TestAddGap(t *testing.T) {
-	os.Args = []string{"saptune", "--format json"}
+	os.Args = []string{"saptune", "--format", "json"}
 	RereadArgs()
 	buffer := bytes.Buffer{}
 	AddGap(&buffer)

--- a/system/file_test.go
+++ b/system/file_test.go
@@ -231,7 +231,7 @@ func TestBackupValue(t *testing.T) {
 }
 
 func TestAddGap(t *testing.T) {
-	os.Args = []string{"saptune", "--format=json"}
+	os.Args = []string{"saptune", "--format json"}
 	RereadArgs()
 	buffer := bytes.Buffer{}
 	AddGap(&buffer)
@@ -247,7 +247,7 @@ func TestAddGap(t *testing.T) {
 	if txt2 != "\n" {
 		t.Errorf("got: %s, expected: '\n'\n", txt2)
 	}
-	os.Args = []string{"saptune", "status", "--format="}
+	os.Args = []string{"saptune", "status", "--format"}
 	RereadArgs()
 	buffer3 := bytes.Buffer{}
 	AddGap(&buffer3)

--- a/system/logging.go
+++ b/system/logging.go
@@ -22,7 +22,7 @@ var severInfoFormat = "INFO     "
 var severWarnFormat = "WARNING  "
 var severErrorFormat = "ERROR    "
 var logpidFormat = fmt.Sprintf("saptune[%v] ", os.Getpid()) // format to add pid of current saptune process to the log message
-var debugSwitch = os.Getenv("SAPTUNE_DEBUG")      // Switch Debug on or off
+var debugSwitch = os.Getenv("SAPTUNE_DEBUG")                // Switch Debug on or off
 
 // DebugLog sents text to the debugLogger and stderr
 func DebugLog(txt string, stuff ...interface{}) {

--- a/system/logging.go
+++ b/system/logging.go
@@ -15,7 +15,6 @@ var noticeLogger *log.Logger  // Notice logger
 var debugLogger *log.Logger   // Debug logger
 var errorLogger *log.Logger   // Error logger
 var warningLogger *log.Logger // Warning logger
-var debugSwitch string        // Switch Debug on or off
 var verboseSwitch string      // Switch verbose mode on or off
 var errorSwitch string        // Switch error mode on or off
 var severNoticeFormat = "NOTICE   "
@@ -23,11 +22,14 @@ var severInfoFormat = "INFO     "
 var severWarnFormat = "WARNING  "
 var severErrorFormat = "ERROR    "
 var logpidFormat = fmt.Sprintf("saptune[%v] ", os.Getpid()) // format to add pid of current saptune process to the log message
+var debugSwitch = os.Getenv("SAPTUNE_DEBUG")      // Switch Debug on or off
 
 // DebugLog sents text to the debugLogger and stderr
 func DebugLog(txt string, stuff ...interface{}) {
-	if debugLogger != nil && debugSwitch == "1" {
-		debugLogger.Printf(CalledFrom()+txt+"\n", stuff...)
+	if debugSwitch == "1" {
+		if debugLogger != nil {
+			debugLogger.Printf(CalledFrom()+txt+"\n", stuff...)
+		}
 		fmt.Fprintf(os.Stderr, "DEBUG: "+txt+"\n", stuff...)
 	}
 }


### PR DESCRIPTION
to support automatic bash completion generation we changed the syntax to skip the '=' in favour of ' '