### PR TITLE
fix ci testing

### DIFF
--- a/.github/workflows/saptune-ut.yml
+++ b/.github/workflows/saptune-ut.yml
@@ -21,7 +21,6 @@ jobs:
 
       - name: Set ENV for codeclimate (pull_request)
         run: |
-          #git fetch --no-tags --prune --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.head_ref }}
           git fetch --no-tags --prune --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.head_ref }}
           echo "GIT_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
           echo "GIT_COMMIT_SHA=$(git rev-parse origin/${{ github.head_ref }})" >> $GITHUB_ENV
@@ -39,14 +38,14 @@ jobs:
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
 
-      - name: Pull the Docker Image
-        run: docker pull registry.opensuse.org/home/angelabriel/st-ci-base/containers/st-ci-base:latest
+      - name: Pull the Container Image
+        run: podman pull registry.opensuse.org/home/angelabriel/st-ci-base/containers/st-ci-base:latest
 
-      - name: Run Docker Image
-        run: docker run --name saptune-ci --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -td -v "${{ github.workspace }}:/app" registry.opensuse.org/home/angelabriel/st-ci-base/containers/st-ci-base:latest
+      - name: Run Container Image
+        run: podman run --name saptune-ci --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -td -v "${{ github.workspace }}:/app" registry.opensuse.org/home/angelabriel/st-ci-base/containers/st-ci-base:latest
 
       - name: Run saptune unit tests
-        run: docker exec -t saptune-ci /bin/sh -c "cd /app; ./run_saptune_ci_tst.sh;"
+        run: podman exec -t saptune-ci /bin/sh -c "cd /app; ./run_saptune_ci_tst.sh;"
 
       #- name: Check test result file for debug
         #run: |
@@ -57,8 +56,8 @@ jobs:
         run: ./cc-test-reporter after-build --debug --prefix ${{ env.CC_PREFIX }} --exit-code $?
         if: ${{ env.CC_TEST_REPORTER_ID }}
 
-      - name: Stop and remove Docker Image
+      - name: Stop and remove Container Image
         run: |
-          docker stop saptune-ci
-          docker rm saptune-ci
+          podman stop saptune-ci
+          podman rm saptune-ci
 

--- a/.github/workflows/saptune-ut.yml
+++ b/.github/workflows/saptune-ut.yml
@@ -39,18 +39,16 @@ jobs:
           ./cc-test-reporter before-build
 
       - name: Pull the Container Image
-        run: podman pull registry.opensuse.org/home/angelabriel/st-ci-base/containers/st-ci-base:latest
+        run: docker pull registry.opensuse.org/home/angelabriel/st-ci-base/containers/st-ci-base:latest
 
       - name: Run Container Image
-        run: podman run --name saptune-ci --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -td -v "${{ github.workspace }}:/app" registry.opensuse.org/home/angelabriel/st-ci-base/containers/st-ci-base:latest
+        run: docker run --name saptune-ci --privileged --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host -td -v "${{ github.workspace }}:/app" registry.opensuse.org/home/angelabriel/st-ci-base/containers/st-ci-base:latest
+
+      - name: Get Container Logs
+        run: docker logs saptune-ci
 
       - name: Run saptune unit tests
-        run: podman exec -t saptune-ci /bin/sh -c "cd /app; ./run_saptune_ci_tst.sh;"
-
-      #- name: Check test result file for debug
-        #run: |
-          #ls -l ${{github.workspace}}
-          #grep action ${{github.workspace}}/c.out
+        run: docker exec -t saptune-ci /bin/sh -c "cd /app; ./run_saptune_ci_tst.sh;"
 
       - name: Code Climate report coverage
         run: ./cc-test-reporter after-build --debug --prefix ${{ env.CC_PREFIX }} --exit-code $?
@@ -58,6 +56,5 @@ jobs:
 
       - name: Stop and remove Container Image
         run: |
-          podman stop saptune-ci
-          podman rm saptune-ci
-
+          docker stop saptune-ci
+          docker rm saptune-ci

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -140,12 +140,17 @@ func rememberMessage(writer io.Writer) {
 
 // VerifyAllParameters Verify that all system parameters do not deviate from any of the enabled solutions/notes.
 func VerifyAllParameters(writer io.Writer, tuneApp *app.App) {
-	result := system.JPNotes{}
+	result := system.JPNotes{
+		Verifications: []system.JPNotesLine{},
+		Attentions:    []system.JPNotesRemind{},
+		NotesOrder:    []string{},
+	}
 	if len(tuneApp.NoteApplyOrder) == 0 {
 		fmt.Fprintf(writer, "No notes or solutions enabled, nothing to verify.\n")
 	} else {
 		unsatisfiedNotes, comparisons, err := tuneApp.VerifyAll()
 		if err != nil {
+			system.Jcollect(result)
 			system.ErrorExit("Failed to inspect the current system: %v", err)
 		}
 		PrintNoteFields(writer, "NONE", comparisons, true, &result)
@@ -153,13 +158,14 @@ func VerifyAllParameters(writer io.Writer, tuneApp *app.App) {
 		result.NotesOrder = tuneApp.NoteApplyOrder
 		sysComp := len(unsatisfiedNotes) == 0
 		result.SysCompliance = &sysComp
-		system.Jcollect(result)
 		if len(unsatisfiedNotes) == 0 {
 			fmt.Fprintf(writer, "%s%sThe running system is currently well-tuned according to all of the enabled notes.%s%s\n", setGreenText, setBoldText, resetBoldText, resetTextColor)
 		} else {
+			system.Jcollect(result)
 			system.ErrorExit("The parameters listed above have deviated from SAP/SUSE recommendations.", "colorPrint", setRedText, setBoldText, resetBoldText, resetTextColor)
 		}
 	}
+	system.Jcollect(result)
 }
 
 // getFileName returns the corresponding filename of a given definition file

--- a/main.go
+++ b/main.go
@@ -239,11 +239,12 @@ func checkSaptuneConfigFile(writer io.Writer, saptuneConf string, lswitch map[st
 
 	// set values read from the config file
 	saptuneVers := sconf.GetString("SAPTUNE_VERSION", "")
-	// Switch Debug on ("1") or off ("0" - default)
+	// Switch Debug on ("on") or off ("off" - default)
 	// Switch verbose mode on ("on" - default) or off ("off")
+	// Switch error mode on ("on" - default) or off ("off")
 	// check, if DEBUG, ERROR or VERBOSE is set in /etc/sysconfig/saptune
 	if lswitch["debug"] == "" {
-		lswitch["debug"] = sconf.GetString("DEBUG", "0")
+		lswitch["debug"] = sconf.GetString("DEBUG", "off")
 	}
 	if lswitch["verbose"] == "" {
 		lswitch["verbose"] = sconf.GetString("VERBOSE", "on")

--- a/main_test.go
+++ b/main_test.go
@@ -144,8 +144,8 @@ func TestCheckSaptuneConfigFile(t *testing.T) {
 	if saptuneVers != "5" {
 		t.Errorf("wrong value for 'SAPTUNE_VERSION' - '%+v' instead of ''\n", saptuneVers)
 	}
-	if lSwitch["debug"] != "1" {
-		t.Errorf("wrong value for 'DEBUG' - '%+v' instead of '1'\n", lSwitch["debug"])
+	if lSwitch["debug"] != "on" {
+		t.Errorf("wrong value for 'DEBUG' - '%+v' instead of 'on'\n", lSwitch["debug"])
 	}
 	if lSwitch["verbose"] != "on" {
 		t.Errorf("wrong value for 'VERBOSE' - '%+v' instead of 'on'\n", lSwitch["debug"])

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -15,7 +15,7 @@
 .\" */
 .\" 
 
-.TH "saptune-note" "5" "December 2021" "" "saptune note file format description"
+.TH "saptune-note" "5" "Januar 2023" "" "saptune note file format description"
 .SH NAME
 saptune\-note - Note definition files for saptune version \fB3\fP
 .SH DESCRIPTION
@@ -229,9 +229,9 @@ VERSION=<versionNo>
 .br
 DATE=<release date of used note and related values>
 .br
-NAME="<description of the note>"
+DESCRIPTION=<description of the note>
 .br
-REFERENCES="<list of URLs containing information regarding the Note separated by blank>
+REFERENCES=<list of URLs containing information regarding the Note separated by blank>
 
 Example:
 .br

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -554,6 +554,12 @@ Revert optimisation settings recommended by the solution, and these settings wil
 .B change
 Switch to a new solution even that another solution was already applied.
 .br This is basically a revert of the old solution and an apply of the new solution. A confirmation is needed to finish the revert action of the old solution. The confirmation can be suppressed by '--force'
+.br
+ATTENTION:
+.br
+because of the revert of the old solution during the execution of the action 'change' the system will be not sufficient tuned for SAP workloads for a short period of time until the new solution is applied successfully. This may harm a running SAP system. So use this action carefully.
+.br
+And please be in mind: Because of the 'revert' and 'apply' the order of notes and therefore the active tuning may change, especially if additional notes were applied beside the old applied solution.
 .TP
 .B show
 Print content of solution definition file to stdout

--- a/run_saptune_ci_tst.sh
+++ b/run_saptune_ci_tst.sh
@@ -59,7 +59,7 @@ sleep 10
 ps -ef
 loginctl --no-pager
 
-echo "exchange /etc/os-release"
+echo "prepare exchange of /etc/os-release"
 cp /etc/os-release /etc/os-release_OrG
 
 # for some sysctl tests

--- a/sap/note/ini_test.go
+++ b/sap/note/ini_test.go
@@ -196,7 +196,12 @@ func TestAllSettings(t *testing.T) {
 		t.Error(optimisedINI.SysctlParams)
 	}
 	if optimisedINI.SysctlParams["UserTasksMax"] != "setinpostinstall" {
-		t.Error(optimisedINI.SysctlParams)
+		switch system.GetOsVers() {
+		case "15", "15-SP1", "15-SP2", "15-SP3", "15-SP4", "15-SP5":
+			t.Logf("UserTasksMax not set in SLE15 - OK\n")
+		default:
+			t.Error(optimisedINI.SysctlParams)
+		}
 	}
 	if runtime.GOARCH != "ppc64le" {
 		if i, err := strconv.ParseInt(optimisedINI.SysctlParams["vm.nr_hugepages"], 10, 64); err != nil || i != 128 {
@@ -398,7 +403,12 @@ func TestOverrideAllSettings(t *testing.T) {
 		t.Error(optimisedINI.SysctlParams)
 	}
 	if optimisedINI.SysctlParams["UserTasksMax"] != "infinity" {
-		t.Error(optimisedINI.SysctlParams)
+		switch system.GetOsVers() {
+		case "15", "15-SP1", "15-SP2", "15-SP3", "15-SP4", "15-SP5":
+			t.Logf("UserTasksMax not set in SLE15 - OK\n")
+		default:
+			t.Error(optimisedINI.SysctlParams)
+		}
 	}
 	if runtime.GOARCH != "ppc64le" {
 		if i, err := strconv.ParseInt(optimisedINI.SysctlParams["vm.nr_hugepages"], 10, 64); err != nil || i != 126 {

--- a/system/json.go
+++ b/system/json.go
@@ -9,7 +9,7 @@ import (
 )
 
 var schemaDir = "file:///usr/share/saptune/schemas/1.0/"
-var supportedRAC = map[string]bool{"daemon start": false, "daemon status": true, "daemon stop": false, "service apply": false, "service start": false, "service status": true, "service stop": false, "service restart": false, "service revert": false, "service reload": false, "service takeover": false, "service enable": false, "service disable": false, "service enablestart": false, "service disablestop": false, "note list": true, "note revertall": false, "note enabled": true, "note applied": true, "note apply": false, "note simulate": true, "note customise": false, "note create": false, "note edit": false, "note revert": false, "note show": false, "note delete": false, "note verify": true, "note rename": false, "solution list": true, "solution verify": true, "solution enabled": true, "solution applied": true, "solution apply": false, "solution change": false, "solution simulate": true, "solution customise": false, "solution create": false, "solution edit": false, "solution revert": false, "solution show": false, "solution delete": false, "solution rename": false, "staging status": false, "staging enable": false, "staging disable": false, "staging is-enabled": false, "staging list": false, "staging diff": false, "staging analysis": false, "staging release": false, "revert all": false, "lock remove": false, "check": false, "status": true, "version": true, "help": false}
+var supportedRAC = map[string]bool{"daemon start": false, "daemon status": true, "daemon stop": false, "service apply": false, "service start": false, "service status": true, "service stop": false, "service restart": false, "service revert": false, "service reload": false, "service takeover": false, "service enable": false, "service disable": false, "service enablestart": false, "service disablestop": false, "note list": true, "note revertall": false, "note enabled": true, "note applied": true, "note apply": false, "note simulate": false, "note customise": false, "note create": false, "note edit": false, "note revert": false, "note show": false, "note delete": false, "note verify": true, "note rename": false, "solution list": true, "solution verify": true, "solution enabled": true, "solution applied": true, "solution apply": false, "solution change": false, "solution simulate": false, "solution customise": false, "solution create": false, "solution edit": false, "solution revert": false, "solution show": false, "solution delete": false, "solution rename": false, "staging status": false, "staging enable": false, "staging disable": false, "staging is-enabled": false, "staging list": false, "staging diff": false, "staging analysis": false, "staging release": false, "revert all": false, "lock remove": false, "check": false, "status": true, "version": true, "help": false}
 
 // jentry is the json entry to display
 var jentry JEntry
@@ -154,10 +154,10 @@ type JPNotesRemind struct {
 // if we need to differ between 'verify' and 'simulate' this
 // can be done in PrintNoteFields' or in jcollect.
 type JPNotes struct {
-	Verifications []JPNotesLine   `json:"verifications,omitempty"`
+	Verifications []JPNotesLine   `json:"verifications"`
 	Simulations   []JPNotesLine   `json:"simulations,omitempty"`
-	Attentions    []JPNotesRemind `json:"attentions,omitempty"`
-	NotesOrder    []string        `json:"Notes enabled,omitempty"`
+	Attentions    []JPNotesRemind `json:"attentions"`
+	NotesOrder    []string        `json:"Notes enabled"`
 	SysCompliance *bool           `json:"system compliance,omitempty"`
 }
 

--- a/system/logging.go
+++ b/system/logging.go
@@ -26,7 +26,7 @@ var debugSwitch = os.Getenv("SAPTUNE_DEBUG")                // Switch Debug on o
 
 // DebugLog sents text to the debugLogger and stderr
 func DebugLog(txt string, stuff ...interface{}) {
-	if debugSwitch == "1" {
+	if debugSwitch == "on" {
 		if debugLogger != nil {
 			debugLogger.Printf(CalledFrom()+txt+"\n", stuff...)
 		}
@@ -118,7 +118,7 @@ func LogInit(logFile string, logSwitch map[string]string) {
 
 // SwitchOffLogging disables logging
 func SwitchOffLogging() {
-	debugSwitch = "0"
+	debugSwitch = "off"
 	verboseSwitch = "off"
 	errorSwitch = "off"
 	log.SetOutput(ioutil.Discard)

--- a/system/logging_test.go
+++ b/system/logging_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestLog(t *testing.T) {
 	logFile := "/tmp/saptune_tst.log"
-	logSwitch := map[string]string{"verbose": "on", "debug": "1", "error": "on"}
+	logSwitch := map[string]string{"verbose": "on", "debug": "on", "error": "on"}
 
 	LogInit(logFile, logSwitch)
 	DebugLog("TestMessage%s_%s", "1", "Debug")

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -60,16 +60,9 @@ func TestGetSolutionSelector(t *testing.T) {
 }
 
 func TestGetOsName(t *testing.T) {
-	_ = CopyFile("/etc/os-release_OrG", "/etc/os-release")
 	actualVal := GetOsName()
-	//if actualVal != "SLES" && actualVal != "openSUSE Leap" {
 	if actualVal != "SLES" {
-		t.Logf("OS is '%s' and not 'SLES'\n", actualVal)
-		_ = CopyFile(path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/osr15"), "/etc/os-release")
-		actualVal = GetOsName()
-		if actualVal != "SLES" {
-			t.Errorf("OS is '%s' and not 'SLES'\n", actualVal)
-		}
+		t.Errorf("OS is '%s' and not 'SLES'\n", actualVal)
 	}
 	// test with non existing file
 	os.Remove("/etc/os-release")
@@ -81,26 +74,22 @@ func TestGetOsName(t *testing.T) {
 }
 
 func TestGetOsVers(t *testing.T) {
-	_ = CopyFile("/etc/os-release_OrG", "/etc/os-release")
 	actualVal := GetOsVers()
-	if actualVal == "" {
-		_ = CopyFile(path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/osr15"), "/etc/os-release")
-		actualVal = GetOsVers()
-		if actualVal != "15-SP2" {
-			t.Errorf("unexpected OS version '%s'\n", actualVal)
-		}
-		_ = CopyFile(path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/osr12"), "/etc/os-release")
-		actualVal = GetOsVers()
-		if actualVal != "12-SP5" {
-			t.Errorf("unexpected OS version '%s'\n", actualVal)
-		}
-	} else {
-		switch actualVal {
-		case "12", "12-SP1", "12-SP2", "12-SP3", "12-SP4", "12-SP5", "15", "15-SP1", "15-SP2", "15-SP3":
-			t.Logf("expected OS version '%s' found\n", actualVal)
-		default:
-			t.Logf("unexpected OS version '%s'\n", actualVal)
-		}
+	switch actualVal {
+	case "12", "12-SP1", "12-SP2", "12-SP3", "12-SP4", "12-SP5", "15", "15-SP1", "15-SP2", "15-SP3", "15-SP4", "15-SP5":
+		t.Logf("expected OS version '%s' found\n", actualVal)
+	default:
+		t.Errorf("unexpected OS version '%s'\n", actualVal)
+	}
+	_ = CopyFile(path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/osr15"), "/etc/os-release")
+	actualVal = GetOsVers()
+	if actualVal != "15-SP2" {
+		t.Errorf("unexpected OS version '%s'\n", actualVal)
+	}
+	_ = CopyFile(path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/osr12"), "/etc/os-release")
+	actualVal = GetOsVers()
+	if actualVal != "12-SP5" {
+		t.Errorf("unexpected OS version '%s'\n", actualVal)
 	}
 
 	// test with non existing file
@@ -113,15 +102,14 @@ func TestGetOsVers(t *testing.T) {
 }
 
 func TestIsSLE15(t *testing.T) {
-	_ = CopyFile(path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/osr15"), "/etc/os-release")
 	if IsSLE15() {
 		t.Logf("found SLE15 OS version\n")
-		_ = CopyFile("/etc/os-release_OrG", "/etc/os-release")
+		_ = CopyFile(path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/osr12"), "/etc/os-release")
 		if IsSLE15() {
 			t.Errorf("expected a non SLE15 os version, but OS version is '%s'\n", GetOsVers())
 		}
 	} else {
-		t.Errorf("expected '15-SP2', but OS version is '%s'\n", GetOsVers())
+		t.Errorf("expected SLE15 os version, but OS version is '%s'\n", GetOsVers())
 	}
 	_ = CopyFile("/etc/os-release_OrG", "/etc/os-release")
 }

--- a/testdata/saptune_VersAndDebug
+++ b/testdata/saptune_VersAndDebug
@@ -40,4 +40,4 @@ SAPTUNE_VERSION="5"
 # Disabled by default. To enable use 'saptune staging enable'
 STAGING="false"
 
-DEBUG="1"
+DEBUG="on"

--- a/txtparser/ini_test.go
+++ b/txtparser/ini_test.go
@@ -3,7 +3,6 @@ package txtparser
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/SUSE/saptune/system"
 	"io/ioutil"
 	"os"
 	"path"
@@ -192,7 +191,6 @@ func TestParseINIFile(t *testing.T) {
 }
 
 func TestParseINI(t *testing.T) {
-	_ = system.CopyFile(path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/osr15"), "/etc/os-release")
 	actualINI := ParseINI(iniExample)
 	var expectedINI INIFile
 	if err := json.Unmarshal([]byte(iniJSON), &expectedINI); err != nil {
@@ -221,7 +219,6 @@ func TestParseINI(t *testing.T) {
 	if !reflect.DeepEqual(*newINI, wrongINI) {
 		t.Errorf("\n%+v\n%+v\n", *newINI, wrongINI)
 	}
-	_ = system.CopyFile("/etc/os-release_OrG", "/etc/os-release")
 }
 
 func TestGetINIFileDescriptiveName(t *testing.T) {

--- a/txtparser/tags_test.go
+++ b/txtparser/tags_test.go
@@ -11,16 +11,16 @@ func TestChkOsTags(t *testing.T) {
 	tag := "15-*"
 	secFields := []string{"rpm", "os=15-*", "arch=amd64"}
 
-	_ = system.CopyFile(path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/osr15"), "/etc/os-release")
 	ret := chkOsTags(tag, secFields)
 	if !ret {
 		t.Error("not matching os version")
 	}
-	_ = system.CopyFile("/etc/os-release_OrG", "/etc/os-release")
+	_ = system.CopyFile(path.Join(os.Getenv("GOPATH"), "/src/github.com/SUSE/saptune/testdata/osr12"), "/etc/os-release")
 	ret = chkOsTags(tag, secFields)
 	if ret {
 		t.Error("matching os version, but shouldn't")
 	}
+	_ = system.CopyFile("/etc/os-release_OrG", "/etc/os-release")
 }
 
 func TestChkHWTags(t *testing.T) {


### PR DESCRIPTION
get ci container running again by adding 'rw' and '--cgroupns=host' to the docker run command.
adapting some unit tests as the used ci container now is based on the bci-init container, which is SLES based (so no longer using a openSUSE based container)
adding fixes for some first findings of the ongoing automatic testings