### PR TITLE
bugfixes for bash completion (v2.3) (TEAM-6777)

### DIFF
--- a/ospackage/usr/share/bash-completion/completions/build/saptune-completion.yaml
+++ b/ospackage/usr/share/bash-completion/completions/build/saptune-completion.yaml
@@ -1,7 +1,7 @@
 # This is the input configuration for 'completely' (https://github.com/DannyBen/completely)
 # to generate the bash completion script.
 #
-# v2.2
+# v2.3
 #
 # Changelog:    29.09.2022  v2.0  - first release for saptune 3.1
 #               21.11.2022  v2.1  - Replace --output with --format in syntax description
@@ -9,6 +9,10 @@
 #               16.01.2023  v2.2  - Bugfix: custom notes have bee displayed with `.conf` suffix
 #                                 - Bugfix: `saptune note|solution create` don't have a completion anymore
 #                                 - Bugfix: `saptune note|solution delete|rename' now only offers custom notes/solutions
+#               13.06.2023  v2.3  - Bugfix: `saptune staging` commands do not remove the required `.sol` extension anymore
+#                                 - Bugfix: some `saptune note verify` commands did not remove the `.conf` suffix
+#                                 - Bugfix: `saptune note|solution revert` now only completes applied notes/solutions.
+#                                 - Bugfix: `saptune solution edit` now only completes custom solutions
 #
 # Syntax:       saptune [--format FORMAT] help
 #               saptune [--format FORMAT] version  
@@ -24,8 +28,8 @@
 #               saptune [--format FORMAT] solution verify [--colorscheme SCHEME] [--show-non-compliant] [SOLUTIONID]
 #               saptune [--format FORMAT] solution rename SOLUTIONNAME NEWSSOLUTIONNAME
 #               saptune [--format FORMAT] staging ( status | enable | disable | is-enabled | list )
-#               saptune [--format FORMAT] staging ( analysis | diff ) [ ( NOTEID | SOLUTIONNAME )... | all ]
-#               saptune [--format FORMAT] staging release [--force|--dry-run] [ ( NOTEID | SOLUTIONNAME )... | all ]
+#               saptune [--format FORMAT] staging ( analysis | diff ) [ ( NOTEID | SOLUTIONNAME.sol )... | all ]
+#               saptune [--format FORMAT] staging release [--force|--dry-run] [ ( NOTEID | SOLUTIONNAME.sol )... | all ]
 #               saptune [--format FORMAT] revert all
 #               saptune [--format FORMAT] lock remove
 #               saptune [--format FORMAT] check
@@ -218,11 +222,13 @@ saptune note create: *stop
 
 saptune note create *: *stop
 
-saptune note edit: *list-all-notes
+saptune note edit:
+  - $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)
 
 saptune note edit *: *stop
 
-saptune note revert: *list-all-notes
+saptune note revert:
+  - $(saptune note applied)
 
 saptune note revert *: *stop
 
@@ -235,16 +241,18 @@ saptune note delete:
 
 saptune note delete *: *stop
 
-saptune note verify: 
+saptune note verify:
   - --colorscheme
   - --show-non-compliant
-  - $(ls /var/lib/saptune/working/notes ; ls /etc/saptune/extra)
+  - $(ls /var/lib/saptune/working/notes/)
+  - $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)
 
 saptune note verify *: *stop
   
 saptune note verify --show-non-compliant:
   - --colorscheme
-  - $(ls /var/lib/saptune/working/notes ; ls /etc/saptune/extra)
+  - $(ls /var/lib/saptune/working/notes/)
+  - $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)
 
 saptune note verify --show-non-compliant *: *stop
 
@@ -266,7 +274,8 @@ saptune note verify --colorscheme: *color-schemes
 
 saptune note verify --colorscheme *:
   - --show-non-compliant
-  - $(ls /var/lib/saptune/working/notes ; ls /etc/saptune/extra)
+  - $(ls /var/lib/saptune/working/notes/)
+  - $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)
 
 saptune note verify --colorscheme * *: *stop
 
@@ -322,11 +331,13 @@ saptune solution create: *stop
 
 saptune solution create *: *stop
 
-saptune solution edit: *list-all-solutions
+saptune solution edit:
+  - $(cd /etc/saptune/extra/; for f in *.sol ; do echo ${f%.sol} ; done)
 
 saptune solution edit *: *stop
 
-saptune solution revert: *list-all-solutions
+saptune solution revert: 
+  - $(saptune solution applied | sed 's/(partial)//g')
 
 saptune solution revert *: *stop
 
@@ -422,21 +433,21 @@ saptune staging list:
 
 
 saptune staging diff:
-  - $(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')
+  - $(find /var/lib/saptune/staging/latest/ -printf '%P ')
   - all
   
 saptune staging diff *:
-  - $(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')
+  - $(find /var/lib/saptune/staging/latest/ -printf '%P ')
 
 saptune staging diff all:
   - $()
 
 saptune staging analysis:
-  - $(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')
+  - $(find /var/lib/saptune/staging/latest/ -printf '%P ')
   - all
   
 saptune staging analysis *:
-  - $(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')
+  - $(find /var/lib/saptune/staging/latest/ -printf '%P ')
 
 saptune staging analysis all:
   - $()
@@ -444,25 +455,25 @@ saptune staging analysis all:
 saptune staging release:
   - --force
   - --dry-run
-  - $(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')
+  - $(find /var/lib/saptune/staging/latest/ -printf '%P ')
   - all
 
 saptune staging release --force:
-  - $(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')
+  - $(find /var/lib/saptune/staging/latest/ -printf '%P ')
   - all
 
 saptune staging release --force all:
   - $()
 
 saptune staging release --dry-run:
-  - $(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')
+  - $(find /var/lib/saptune/staging/latest/ -printf '%P ')
   - all
 
 saptune staging release --dry-run all:
   - $()
 
 saptune staging release *:
-  - $(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')
+  - $(find /var/lib/saptune/staging/latest/ -printf '%P ')
 
 saptune staging release all:
   - $()

--- a/ospackage/usr/share/bash-completion/completions/build/saptune.completion
+++ b/ospackage/usr/share/bash-completion/completions/build/saptune.completion
@@ -101,7 +101,7 @@ _saptune_completions() {
       ;;
 
     'note verify --show-non-compliant'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--colorscheme $(ls /var/lib/saptune/working/notes ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--colorscheme $(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'solution verify --colorscheme '*'')
@@ -125,7 +125,7 @@ _saptune_completions() {
       ;;
 
     'note verify --colorscheme '*'')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--show-non-compliant $(ls /var/lib/saptune/working/notes ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--show-non-compliant $(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'staging release --force all'*)
@@ -133,7 +133,7 @@ _saptune_completions() {
       ;;
 
     'staging release --dry-run'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g') all")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ') all")" -- "$cur" )
       ;;
 
     'note verify --colorscheme'*)
@@ -149,7 +149,7 @@ _saptune_completions() {
       ;;
 
     'staging release --force'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g') all")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ') all")" -- "$cur" )
       ;;
 
     'solution customise '*'')
@@ -181,7 +181,7 @@ _saptune_completions() {
       ;;
 
     'staging analysis '*'')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ')")" -- "$cur" )
       ;;
 
     'staging is-enabled'*)
@@ -217,7 +217,7 @@ _saptune_completions() {
       ;;
 
     'staging release '*'')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ')")" -- "$cur" )
       ;;
 
     'note customise '*'')
@@ -241,7 +241,7 @@ _saptune_completions() {
       ;;
 
     'staging analysis'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g') all")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ') all")" -- "$cur" )
       ;;
 
     'solution apply '*'')
@@ -281,11 +281,11 @@ _saptune_completions() {
       ;;
 
     'solution revert'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /var/lib/saptune/working/sols/ ; for f in *.sol ; do echo ${f%.sol} ; done) $(cd /etc/saptune/extra/; for f in *.sol ; do echo ${f%.sol} ; done)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(saptune solution applied | sed 's/(partial)//g')")" -- "$cur" )
       ;;
 
     'staging release'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--force --dry-run $(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g') all")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--force --dry-run $(find /var/lib/saptune/staging/latest/ -printf '%P ') all")" -- "$cur" )
       ;;
 
     'solution change'*)
@@ -305,7 +305,7 @@ _saptune_completions() {
       ;;
 
     'staging diff '*'')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ')")" -- "$cur" )
       ;;
 
     'note customise'*)
@@ -401,7 +401,7 @@ _saptune_completions() {
       ;;
 
     'staging diff'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g') all")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ') all")" -- "$cur" )
       ;;
 
     'note rename'*)
@@ -409,7 +409,7 @@ _saptune_completions() {
       ;;
 
     'note verify'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--colorscheme --show-non-compliant $(ls /var/lib/saptune/working/notes ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--colorscheme --show-non-compliant $(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'note delete'*)
@@ -429,7 +429,7 @@ _saptune_completions() {
       ;;
 
     'note revert'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(saptune note applied)")" -- "$cur" )
       ;;
 
     'daemon stop'*)
@@ -453,7 +453,7 @@ _saptune_completions() {
       ;;
 
     'note edit'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'note list'*)

--- a/ospackage/usr/share/bash-completion/completions/build/saptune.completion.compiled
+++ b/ospackage/usr/share/bash-completion/completions/build/saptune.completion.compiled
@@ -93,7 +93,7 @@ _saptune_completions() {
       ;;
 
     'note verify --show-non-compliant'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--colorscheme $(ls /var/lib/saptune/working/notes ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--colorscheme $(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'solution verify --colorscheme '*'')
@@ -117,7 +117,7 @@ _saptune_completions() {
       ;;
 
     'note verify --colorscheme '*'')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--show-non-compliant $(ls /var/lib/saptune/working/notes ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--show-non-compliant $(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'staging release --force all'*)
@@ -125,7 +125,7 @@ _saptune_completions() {
       ;;
 
     'staging release --dry-run'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g') all")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ') all")" -- "$cur" )
       ;;
 
     'note verify --colorscheme'*)
@@ -141,7 +141,7 @@ _saptune_completions() {
       ;;
 
     'staging release --force'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g') all")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ') all")" -- "$cur" )
       ;;
 
     'solution customise '*'')
@@ -173,7 +173,7 @@ _saptune_completions() {
       ;;
 
     'staging analysis '*'')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ')")" -- "$cur" )
       ;;
 
     'staging is-enabled'*)
@@ -209,7 +209,7 @@ _saptune_completions() {
       ;;
 
     'staging release '*'')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ')")" -- "$cur" )
       ;;
 
     'note customise '*'')
@@ -233,7 +233,7 @@ _saptune_completions() {
       ;;
 
     'staging analysis'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g') all")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ') all")" -- "$cur" )
       ;;
 
     'solution apply '*'')
@@ -273,11 +273,11 @@ _saptune_completions() {
       ;;
 
     'solution revert'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /var/lib/saptune/working/sols/ ; for f in *.sol ; do echo ${f%.sol} ; done) $(cd /etc/saptune/extra/; for f in *.sol ; do echo ${f%.sol} ; done)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(saptune solution applied | sed 's/(partial)//g')")" -- "$cur" )
       ;;
 
     'staging release'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--force --dry-run $(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g') all")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--force --dry-run $(find /var/lib/saptune/staging/latest/ -printf '%P ') all")" -- "$cur" )
       ;;
 
     'solution change'*)
@@ -297,7 +297,7 @@ _saptune_completions() {
       ;;
 
     'staging diff '*'')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ')")" -- "$cur" )
       ;;
 
     'note customise'*)
@@ -393,7 +393,7 @@ _saptune_completions() {
       ;;
 
     'staging diff'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g') all")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ') all")" -- "$cur" )
       ;;
 
     'note rename'*)
@@ -401,7 +401,7 @@ _saptune_completions() {
       ;;
 
     'note verify'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--colorscheme --show-non-compliant $(ls /var/lib/saptune/working/notes ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--colorscheme --show-non-compliant $(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'note delete'*)
@@ -421,7 +421,7 @@ _saptune_completions() {
       ;;
 
     'note revert'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(saptune note applied)")" -- "$cur" )
       ;;
 
     'daemon stop'*)
@@ -445,7 +445,7 @@ _saptune_completions() {
       ;;
 
     'note edit'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'note list'*)

--- a/ospackage/usr/share/bash-completion/completions/saptune.completion
+++ b/ospackage/usr/share/bash-completion/completions/saptune.completion
@@ -45,11 +45,11 @@ _saptune_completions() {
       ;;
 
     'solution verify --colorscheme '*' --show-non-compliant')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find   /var/lib/saptune/working/sols /etc/saptune/extra/ -name '*.sol' -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /var/lib/saptune/working/sols/ ; for f in *.sol ; do echo ${f%.sol} ; done) $(cd /etc/saptune/extra/; for f in *.sol ; do echo ${f%.sol} ; done)")" -- "$cur" )
       ;;
 
     'solution verify --show-non-compliant --colorscheme '*'')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find   /var/lib/saptune/working/sols /etc/saptune/extra/ -name '*.sol' -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /var/lib/saptune/working/sols/ ; for f in *.sol ; do echo ${f%.sol} ; done) $(cd /etc/saptune/extra/; for f in *.sol ; do echo ${f%.sol} ; done)")" -- "$cur" )
       ;;
 
     'note verify --colorscheme '*' --show-non-compliant '*'')
@@ -65,11 +65,11 @@ _saptune_completions() {
       ;;
 
     'note verify --colorscheme '*' --show-non-compliant')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/ ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'note verify --show-non-compliant --colorscheme '*'')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/ ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'note verify --show-non-compliant --colorscheme'*)
@@ -101,7 +101,7 @@ _saptune_completions() {
       ;;
 
     'note verify --show-non-compliant'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--colorscheme $(ls /var/lib/saptune/working/notes ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--colorscheme $(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'solution verify --colorscheme '*'')
@@ -125,7 +125,7 @@ _saptune_completions() {
       ;;
 
     'note verify --colorscheme '*'')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--show-non-compliant $(ls /var/lib/saptune/working/notes ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--show-non-compliant $(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'staging release --force all'*)
@@ -133,7 +133,7 @@ _saptune_completions() {
       ;;
 
     'staging release --dry-run'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g') all")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ') all")" -- "$cur" )
       ;;
 
     'note verify --colorscheme'*)
@@ -145,11 +145,11 @@ _saptune_completions() {
       ;;
 
     'solution change --force'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find   /var/lib/saptune/working/sols /etc/saptune/extra/ -name '*.sol' -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /var/lib/saptune/working/sols/ ; for f in *.sol ; do echo ${f%.sol} ; done) $(cd /etc/saptune/extra/; for f in *.sol ; do echo ${f%.sol} ; done)")" -- "$cur" )
       ;;
 
     'staging release --force'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g') all")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ') all")" -- "$cur" )
       ;;
 
     'solution customise '*'')
@@ -177,11 +177,11 @@ _saptune_completions() {
       ;;
 
     'solution customise'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find   /var/lib/saptune/working/sols /etc/saptune/extra/ -name '*.sol' -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /var/lib/saptune/working/sols/ ; for f in *.sol ; do echo ${f%.sol} ; done) $(cd /etc/saptune/extra/; for f in *.sol ; do echo ${f%.sol} ; done)")" -- "$cur" )
       ;;
 
     'staging analysis '*'')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ')")" -- "$cur" )
       ;;
 
     'staging is-enabled'*)
@@ -201,7 +201,7 @@ _saptune_completions() {
       ;;
 
     'solution simulate'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find   /var/lib/saptune/working/sols /etc/saptune/extra/ -name '*.sol' -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /var/lib/saptune/working/sols/ ; for f in *.sol ; do echo ${f%.sol} ; done) $(cd /etc/saptune/extra/; for f in *.sol ; do echo ${f%.sol} ; done)")" -- "$cur" )
       ;;
 
     'solution rename '*'')
@@ -217,7 +217,7 @@ _saptune_completions() {
       ;;
 
     'staging release '*'')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ')")" -- "$cur" )
       ;;
 
     'note customise '*'')
@@ -241,7 +241,7 @@ _saptune_completions() {
       ;;
 
     'staging analysis'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g') all")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ') all")" -- "$cur" )
       ;;
 
     'solution apply '*'')
@@ -257,7 +257,7 @@ _saptune_completions() {
       ;;
 
     'solution rename'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find   /var/lib/saptune/working/sols /etc/saptune/extra/ -name '*.sol' -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /etc/saptune/extra/; for f in *.sol ; do echo ${f%.sol} ; done)")" -- "$cur" )
       ;;
 
     'solution verify'*)
@@ -269,7 +269,7 @@ _saptune_completions() {
       ;;
 
     'solution create'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find   /var/lib/saptune/working/sols /etc/saptune/extra/ -name '*.sol' -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$()")" -- "$cur" )
       ;;
 
     'service disable'*)
@@ -281,11 +281,11 @@ _saptune_completions() {
       ;;
 
     'solution revert'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find   /var/lib/saptune/working/sols /etc/saptune/extra/ -name '*.sol' -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(saptune solution applied | sed 's/(partial)//g')")" -- "$cur" )
       ;;
 
     'staging release'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--force --dry-run $(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g') all")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--force --dry-run $(find /var/lib/saptune/staging/latest/ -printf '%P ') all")" -- "$cur" )
       ;;
 
     'solution change'*)
@@ -297,19 +297,19 @@ _saptune_completions() {
       ;;
 
     'solution delete'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find   /var/lib/saptune/working/sols /etc/saptune/extra/ -name '*.sol' -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /etc/saptune/extra/; for f in *.sol ; do echo ${f%.sol} ; done)")" -- "$cur" )
       ;;
 
     'solution apply'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find   /var/lib/saptune/working/sols /etc/saptune/extra/ -name '*.sol' -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /var/lib/saptune/working/sols/ ; for f in *.sol ; do echo ${f%.sol} ; done) $(cd /etc/saptune/extra/; for f in *.sol ; do echo ${f%.sol} ; done)")" -- "$cur" )
       ;;
 
     'staging diff '*'')
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ')")" -- "$cur" )
       ;;
 
     'note customise'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/ ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'note revertall'*)
@@ -357,11 +357,11 @@ _saptune_completions() {
       ;;
 
     'note simulate'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/ ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'solution edit'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find   /var/lib/saptune/working/sols /etc/saptune/extra/ -name '*.sol' -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /var/lib/saptune/working/sols/ ; for f in *.sol ; do echo ${f%.sol} ; done) $(cd /etc/saptune/extra/; for f in *.sol ; do echo ${f%.sol} ; done)")" -- "$cur" )
       ;;
 
     'service start'*)
@@ -373,7 +373,7 @@ _saptune_completions() {
       ;;
 
     'solution show'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find   /var/lib/saptune/working/sols /etc/saptune/extra/ -name '*.sol' -printf '%P ' | sed 's/\.sol//g')")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /var/lib/saptune/working/sols/ ; for f in *.sol ; do echo ${f%.sol} ; done) $(cd /etc/saptune/extra/; for f in *.sol ; do echo ${f%.sol} ; done)")" -- "$cur" )
       ;;
 
     'note apply '*'')
@@ -401,19 +401,19 @@ _saptune_completions() {
       ;;
 
     'staging diff'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ' | sed 's/\.sol//g') all")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(find /var/lib/saptune/staging/latest/ -printf '%P ') all")" -- "$cur" )
       ;;
 
     'note rename'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/ ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'note verify'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--colorscheme --show-non-compliant $(ls /var/lib/saptune/working/notes ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "--colorscheme --show-non-compliant $(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'note delete'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/ ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'note show '*'')
@@ -425,11 +425,11 @@ _saptune_completions() {
       ;;
 
     'note create'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/ ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$()")" -- "$cur" )
       ;;
 
     'note revert'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/ ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(saptune note applied)")" -- "$cur" )
       ;;
 
     'daemon stop'*)
@@ -441,7 +441,7 @@ _saptune_completions() {
       ;;
 
     'note apply'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/ ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'revert all'*)
@@ -453,7 +453,7 @@ _saptune_completions() {
       ;;
 
     'note edit'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/ ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'note list'*)
@@ -461,7 +461,7 @@ _saptune_completions() {
       ;;
 
     'note show'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/ ; ls /etc/saptune/extra)")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_saptune_completions_filter "$(ls /var/lib/saptune/working/notes/) $(cd /etc/saptune/extra/; for f in *.conf ; do echo ${f%.conf} ; done)")" -- "$cur" )
       ;;
 
     'solution'*)


### PR DESCRIPTION
Contains fixes for bash completion found during SUSECon23 preparation:

v2.3

- Bugfix: `saptune staging` commands do not remove the required `.sol` extension anymore
- Bugfix: some `saptune note verify` commands did not remove the `.conf` suffix
- Bugfix: `saptune note|solution revert` now only completes applied notes/solutions.
- Bugfix: `saptune solution edit` now only completes custom solutions