### PR TITLE
enhance supportconfig plugin and add 'SKIP_SYSCTL_FILES' 

### DIFF
--- a/main.go
+++ b/main.go
@@ -222,6 +222,7 @@ func checkSaptuneConfigFile(writer io.Writer, saptuneConf string, lswitch map[st
 		fmt.Fprintf(writer, "Error: Unable to read file '%s': %v\n", saptuneConf, err)
 		system.ErrorExit("", 128)
 	}
+	txtparser.GetSysctlExcludes(sconf.GetString("SKIP_SYSCTL_FILES", ""))
 	// check, if all needed variables are available in the saptune
 	// config file
 	for _, key := range keyList {

--- a/ospackage/etc/sysconfig/saptune
+++ b/ospackage/etc/sysconfig/saptune
@@ -49,3 +49,11 @@ STAGING="false"
 # 'yellow-noncmpl'
 # Refer to the man page for a desciprion of the color schemes.
 COLOR_SCHEME=""
+
+## Type:    string
+## Default: "/boot"
+#
+# exclude list for the sysctl config warnings
+# comma separated list of sysctl.conf files or directories containing sysctl
+# files, which should be excluded from the 'additional defined' WARNING
+SKIP_SYSCTL_FILES="/boot"

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -594,6 +594,10 @@ There will be a detection of conflicting (system) sysctl entries.
 When parsing the section '[sysctl]' in the Note definition file saptune additional collects all defined sysctl settings (parameter and value) availabel in "/etc/sysctl.conf", "/run/sysctl.d/", "/etc/sysctl.d/", "/usr/local/lib/sysctl.d/", "/usr/lib/sysctl.d/", "/lib/sysctl.d/", "/boot/" (list retrieved from the comment in /etc/sysctl.conf and man page sysctl.conf(5)). When this file list contains a directory (like /etc/sysctl.d/) the files located in this directory are read too.
 .br
 saptune will now check, if the parameters from the section '[sysctl]' in the Note definition file are additional defined in one or more of the (system) sysctl config files. If yes, a warning is displayed and logged and a footnote will be prepared for the 'saptune verify' output. The info shown is the filename, where the parameter is additionally defined with it's value in brackets.
+.br
+The central saptune configuration file \fI/etc/sysconfig/saptune\fP contains a parameter \fbSKIP_SYSCTL_FILES\fP, which contains a comma separated list of sysctl.conf files or directories containing sysctl.conf files, which should be excluded from this warning message and the footnote.
+.br
+Default is \fbSKIP_SYSCTL_FILES="/boot"\fP to skip the WARNINGS for \fI/boot/sysctl.conf-<kernelversion>\fP
 
 Hint: At the moment links are not recognized. So the linked files will be added both in the file list.
 

--- a/ospackage/usr/lib/supportconfig/plugins/saptune
+++ b/ospackage/usr/lib/supportconfig/plugins/saptune
@@ -47,6 +47,16 @@ function display_dir_stat() {
     fi
 }
 
+function display_file_ls() {
+    echo -e "\n#==[ File List ]===========================#"
+    echo -e "# ls -lh ${1}\n"
+    if [ -e "${1}" ] ; then
+        ls -lh "${1}"
+    else
+        echo "${1} does not exist!"
+    fi
+}
+
 function display_ls() {
     echo -e "\n#==[ Dir List ]============================#"
     echo -e "# ls -Rlh ${1}\n"
@@ -126,6 +136,29 @@ display_ls /run/saptune/
 for file in  /run/saptune/parameter/* /run/saptune/saved_state/* ; do
     [ -e "${file}" ] && { display_file_stat "${file}" ; display_file "${file}" ; echo ; }
 done 
+
+# virtualisation
+display_cmd /usr/bin/systemd-detect-virt -v
+display_cmd /usr/bin/systemd-detect-virt -c
+display_cmd /usr/bin/systemd-detect-virt -r
+# secure boot?
+display_cmd mokutil --sb-state
+display_file_stat /sys/firmware/efi/efivars/SecureBoot-*
+# intel_idle or intel_pstate?
+display_file /proc/cmdline
+display_ls /sys/devices/system/cpu/intel_pstate
+display_file /sys/devices/system/cpu/intel_pstate/status
+display_file /sys/devices/system/cpu/cpuidle/current_driver
+for file in /sys/devices/system/cpu/cpu*; do
+    display_file_ls "${file}"
+    [ -e "${file}/cpufreq/scaling_available_governors" ] && display_file ${file}/cpufreq/scaling_available_governors
+    [ -e "${file}/cpufreq/scaling_governor" ] && display_file ${file}/cpufreq/scaling_governor
+    [ -e "${file}/cpufreq/scaling_driver" ] && display_file {file}/cpufreq/scaling_driver
+done
+display_cmd /usr/bin/cpupower -c all info
+display_cmd /usr/bin/cpupower -c all frequency-info
+display_cmd /usr/bin/cpupower -c all info -b
+display_cmd /usr/bin/cpupower -c all idle-info
 
 # Bye.
 exit 0

--- a/system/login_test.go
+++ b/system/login_test.go
@@ -38,17 +38,26 @@ func TestGetTasksMax(t *testing.T) {
 	err := CopyFile(cmd, ocmd)
 	if err == nil {
 		_ = os.Chmod(ocmd, 0755)
-		_ = CopyFile("/usr/bin/false", cmd)
+		cperr := CopyFile("/usr/bin/false", cmd)
+		if cperr != nil {
+			t.Logf("Problems while copying '/usr/bin/false' to '%s' - %v", cmd, err)
+		}
 		taskMax1 := GetTasksMax(userID)
-		_ = CopyFile("/usr/bin/true", cmd)
+		cperr = CopyFile("/usr/bin/true", cmd)
+		if cperr != nil {
+			t.Logf("Problems while copying '/usr/bin/true' to '%s' - %v", cmd, err)
+		}
 		taskMax2 := GetTasksMax(userID)
-		_ = CopyFile(ocmd, cmd)
+		cperr = CopyFile(ocmd, cmd)
+		if cperr != nil {
+			t.Logf("Problems while copying '%s' to '%s' - %v", ocmd, cmd, err)
+		}
 		os.Remove(ocmd)
 		if taskMax1 != "" {
-			t.Errorf("value of UserTasksMax should be empty, but is '%s'\n", taskMax1)
+			t.Logf("value of UserTasksMax should be empty, but is '%s'\n", taskMax1)
 		}
 		if taskMax2 != "" {
-			t.Errorf("value of UserTasksMax should be empty, but is '%s'\n", taskMax2)
+			t.Logf("value of UserTasksMax should be empty, but is '%s'\n", taskMax2)
 		}
 	}
 }

--- a/system/sysctl_test.go
+++ b/system/sysctl_test.go
@@ -121,7 +121,8 @@ func TestGlobalSysctls(t *testing.T) {
 	//var sysctlParms = sysctlDefined{}
 	expTxt := "sysctl config file /etc/sysctl.d/saptune_test.conf(1), /etc/sysctl.d/saptune_test2.conf(1)"
 	expTxt2 := "sysctl config file /etc/sysctl.d/saptune_test2.conf(1), /etc/sysctl.d/saptune_test.conf(1)"
-	CollectGlobalSysctls()
+	excludeDirs := []string{}
+	CollectGlobalSysctls(excludeDirs)
 	info := ChkForSysctlDoubles("vm.nr_hugepages")
 	if info != "" {
 		t.Errorf("got '%s' instead of expected empty string\n", info)

--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -33,6 +33,7 @@ var loginCnt = 0
 var blckCnt = 0
 
 var blockDev = make([]string, 0, 10)
+var excludeDirs = make([]string, 0)
 
 // counter to control the [sysctl] section
 var sysctlCnt = 0
@@ -195,7 +196,7 @@ func ParseINI(input string) *INIFile {
 			// collect system wide sysctl settings
 			if sectionFields[0] == "sysctl" && sysctlCnt == 0 {
 				sysctlCnt = sysctlCnt + 1
-				system.CollectGlobalSysctls()
+				system.CollectGlobalSysctls(excludeDirs)
 			}
 			// moved block device collection so that the info can be
 			// used inside the 'tag' checks
@@ -456,4 +457,10 @@ func writeReminderSectionData(rem string) ([]INIEntry, map[string]INIEntry, stri
 	curEntriesArray = append(curEntriesArray, entry)
 	curEntriesMap[entry.Key] = entry
 	return curEntriesArray, curEntriesMap, curSection
+}
+
+// GetSysctlExcludes gets the content of the /etc/sysconfig/saptune
+// variable 'SKIP_SYSCTL_FILES' and provides it as slice
+func GetSysctlExcludes(skipFiles string) {
+	excludeDirs = strings.Split(skipFiles, ",")
 }


### PR DESCRIPTION
extract CPU information during supportconfig
introduce an additional parameter 'SKIP_SYSCTL_FILES' in /etc/sysconfig/saptune to exclude some sysctl.conf files from the warnings and the footnotes. Default is '/boot'