### PR TITLE
Fixing issue  #116: saptune 3.1 creates /varlog/saptune instead of /v…

### DIFF
--- a/system/logging.go
+++ b/system/logging.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-var saptuneLogDir = "/varlog/saptune"
+var saptuneLogDir = "/var/log/saptune"
 var infoLogger *log.Logger    // Info logger
 var noticeLogger *log.Logger  // Notice logger
 var debugLogger *log.Logger   // Debug logger


### PR DESCRIPTION
…ar/log/saptune

bsc#1215969 - saptune 3.1 creates /varlog/saptune instead of /var/log/saptune