### PR TITLE
bsc#1209408 - add parameter IGNORE_RELOAD to saptune too

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,13 +216,12 @@ func checkWorkingArea() {
 // returns the saptune version and changes some log switches
 func checkSaptuneConfigFile(writer io.Writer, saptuneConf string, lswitch map[string]string) string {
 	missingKey := []string{}
-	keyList := []string{app.TuneForSolutionsKey, app.TuneForNotesKey, app.NoteApplyOrderKey, "SAPTUNE_VERSION", "STAGING", "COLOR_SCHEME"}
+	keyList := []string{app.TuneForSolutionsKey, app.TuneForNotesKey, app.NoteApplyOrderKey, "SAPTUNE_VERSION", "STAGING", "COLOR_SCHEME", "SKIP_SYSCTL_FILES", "IGNORE_RELOAD"}
 	sconf, err := txtparser.ParseSysconfigFile(saptuneConf, false)
 	if err != nil {
 		fmt.Fprintf(writer, "Error: Unable to read file '%s': %v\n", saptuneConf, err)
 		system.ErrorExit("", 128)
 	}
-	txtparser.GetSysctlExcludes(sconf.GetString("SKIP_SYSCTL_FILES", ""))
 	// check, if all needed variables are available in the saptune
 	// config file
 	for _, key := range keyList {
@@ -234,6 +233,7 @@ func checkSaptuneConfigFile(writer io.Writer, saptuneConf string, lswitch map[st
 		fmt.Fprintf(writer, "Error: File '%s' is broken. Missing variables '%s'\n", saptuneConf, strings.Join(missingKey, ", "))
 		system.ErrorExit("", 128)
 	}
+	txtparser.GetSysctlExcludes(sconf.GetString("SKIP_SYSCTL_FILES", ""))
 	stageVal := sconf.GetString("STAGING", "")
 	if stageVal != "true" && stageVal != "false" {
 		fmt.Fprintf(writer, "Error: Variable 'STAGING' from file '%s' contains a wrong value '%s'. Needs to be 'true' or 'false'\n", saptuneConf, stageVal)

--- a/ospackage/etc/sysconfig/saptune
+++ b/ospackage/etc/sysconfig/saptune
@@ -57,3 +57,13 @@ COLOR_SCHEME=""
 # comma separated list of sysctl.conf files or directories containing sysctl
 # files, which should be excluded from the 'additional defined' WARNING
 SKIP_SYSCTL_FILES="/boot"
+
+## Type:    string
+## Default: "no"
+#
+# IGNORE_RELOAD is used to control the 'systemctl reload saptune.service'
+# and the 'systemctl try-restart saptune.service' during package installation
+# behavior.
+# Default is 'no'. If set to 'yes' a 'systemctl reload' will do nothing.
+# same reason as for sapconf bsc#1209408
+IGNORE_RELOAD="no"

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -205,7 +205,9 @@ Example:
 
 All fields are separated by spaces. But please do not use spaces around the equal operator (=) of the fields. And please do not change the order of the fields.
 
-The <noteId> must be a text string without spaces, which will be used as the unique identifier of this Note definition. It will be displayed during the action 'saptune note list' and used for all other actions, where the NoteID is needed as parameter.
+The <noteId> must be a text string without spaces. It was planned for future use, but this field was never used.
+
+The internal used NoteID - the unique identifier of a Note definition - was always taken from the filename of the Note definition file without extention '.conf'. It will be displayed during the action 'saptune note list' and used for all other actions, where the NoteID is needed as parameter.
 
 The CATEGORY is for future use. So we do not have defined CATEGORIES at the moment. It must be a text string without spaces.
 

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -201,6 +201,9 @@ It redirects to '\fIsystemctl restart saptune.service\fP'
 Success is reported on stdout, errors including systemd error messages are printed on stderr. The action gets logged.
 
 If the action was successfully the exit code is 0, otherwise 1.
+
+If '\fIIGNORE_RELOAD\fP' is set to '\fByes\fP' in the saptune configuration file the action '\fIrestart\fP' will do \fBnothing\fP. The reason will be logged.
+See the 'NOTE' section at the end of the man page for more information.
 .TP
 .B enable
 Enables the saptune service. To activate the tuning, the saptune service needs to be started. But as the service is now enabled, the tuning will automatically activated upon system boot.
@@ -894,6 +897,18 @@ Please do not change or remove files in this directory. The knowledge about the 
 Using saptune within a pipe, the color information will be removed from the output.
 .SH NOTE
 When the values from the saptune Note definitions are applied to the system, no further monitoring of the system parameters are done. So changes of saptune relevant parameters by using the 'sysctl' command or by editing configuration files will not be observed. If the values set by saptune should be reverted, these unrecognized changed settings will be overwritten by the previous saved system settings from saptune.
+.SH NOTE
+To prevent unintended reload/restart of saptune during package installation/update of saptune or normal work, which will result in a short time period, where the system is not tuned for SAP workloads, it's possible to set the parameter \fBIGNORE_RELOAD\fP in the central saptune configuration file \fI/etc/sysconfig/saptune\fP.
+.br
+\fBIGNORE_RELOAD\fP is used to control the '\fBsystemctl reload saptune.service\fP' behavior.
+.br
+Default is \fBIGNORE_RELOAD="no"\fP, which means that the 'reload' is working as expected.
+.br
+If set to '\fByes\fP' a '\fBsystemctl reload saptune.service\fP' and a '\fBsaptune service restart\fP' will do \fBnothing\fP. The reason will be logged.
+.br
+Additional this parameter setting will prevent '\fBsystemctl restart saptune.service\fP' (which is a 'ExecStop' followed by 'ExecStart') called from macros used during the package installation/update of the saptune package from restarting the tuning.
+.br
+ATTENTION: Outside the saptune package installation '\fBsystemctl restart saptune.service\fP' can \fBnot\fP be blocked.
 
 .SH ATTENTION
 Higher or lower system values set by the system, the SAP installer or by the administrator using sysctl command or sysctl configuration files will be now \fBoverwritten\fP by saptune, if they are part of the applied Note definitions.

--- a/ospackage/usr/share/saptune/notes/2382421
+++ b/ospackage/usr/share/saptune/notes/2382421
@@ -198,6 +198,17 @@ net.ipv4.tcp_tw_recycle =
 #net.ipv4.tcp_tw_recycle
 net.ipv4.tcp_tw_recycle =
 
+# net.ipv4.tcp_timestamps for Azure
+# This setting adds the timestamp field to the TCP header.
+# It should already be active on most systems and is a prerequisite for
+# net.ipv4.tcp_tw_reuse and net.ipv4.tcp_tw_recycle.
+# If you are running on Microsoft Azure depending on your scenario the setting
+# of this OS parameter might not be supported. Please refer to the documentation
+# provided by Microsoft for details. In this case please adjust the OS
+# parameters as recommended by Microsoft.
+[sysctl:csp=azure]
+net.ipv4.tcp_timestamps =
+
 [reminder]
 # SAP HANA Parameters - all '.ini' file changes - not handled by saptune
 # WARNING - on systems with iSCSI devices the setting of 'net.ipv4.tcp_syn_retries = 8'

--- a/testdata/saptune_NoVersion
+++ b/testdata/saptune_NoVersion
@@ -49,3 +49,21 @@ STAGING="false"
 # 'yellow-noncmpl'
 # Refer to the man page for a desciprion of the color schemes.
 COLOR_SCHEME=""
+
+## Type:    string
+## Default: "/boot"
+#
+# exclude list for the sysctl config warnings
+# comma separated list of sysctl.conf files or directories containing sysctl
+# files, which should be excluded from the 'additional defined' WARNING
+SKIP_SYSCTL_FILES="/boot"
+
+## Type:    string
+## Default: "no"
+#
+# IGNORE_RELOAD is used to control the 'systemctl reload saptune.service'
+# and the 'systemctl try-restart saptune.service' during package installation
+# behavior.
+# Default is 'no'. If set to 'yes' a 'systemctl reload' will do nothing.
+# same reason as for sapconf bsc#1209408
+IGNORE_RELOAD="no"

--- a/testdata/saptune_WrongStaging
+++ b/testdata/saptune_WrongStaging
@@ -49,3 +49,21 @@ STAGING="hugo"
 # 'yellow-noncmpl'
 # Refer to the man page for a desciprion of the color schemes.
 COLOR_SCHEME=""
+
+## Type:    string
+## Default: "/boot"
+#
+# exclude list for the sysctl config warnings
+# comma separated list of sysctl.conf files or directories containing sysctl
+# files, which should be excluded from the 'additional defined' WARNING
+SKIP_SYSCTL_FILES="/boot"
+
+## Type:    string
+## Default: "no"
+#
+# IGNORE_RELOAD is used to control the 'systemctl reload saptune.service'
+# and the 'systemctl try-restart saptune.service' during package installation
+# behavior.
+# Default is 'no'. If set to 'yes' a 'systemctl reload' will do nothing.
+# same reason as for sapconf bsc#1209408
+IGNORE_RELOAD="no"


### PR DESCRIPTION
add parameter IGNORE_RELOAD to /etc/sysconfig/saptune to prevent saptune from stopping and starting the system tuning during package update
Related to sapconf bug bsc#1209408