### PR TITLE
limited the lock setting (bsc#1219500)

### DIFF
--- a/ospackage/usr/share/saptune/notes/1410736
+++ b/ospackage/usr/share/saptune/notes/1410736
@@ -1,10 +1,9 @@
 # 1410736 - TCP/IP: setting keepalive interval
 # Description:    Set keepalive interval
-# Version 6 from Jan 13, 2020 in English
 
 [version]
 VERSION=6
-DATE=13.01.2020
+DATE=15.06.2020
 DESCRIPTION=TCP/IP: setting keepalive interval
 REFERENCES=https://launchpad.support.sap.com/#/notes/1410736
 

--- a/ospackage/usr/share/saptune/notes/1557506
+++ b/ospackage/usr/share/saptune/notes/1557506
@@ -1,6 +1,5 @@
 # 1557506 - Linux paging improvements
 # Description:    Tune page cache limit to prevent eviction of SAP applications memory into swap
-# Version 16 from 06.02.2020 in English
 
 [version]
 VERSION=16

--- a/ospackage/usr/share/saptune/notes/1656250
+++ b/ospackage/usr/share/saptune/notes/1656250
@@ -1,9 +1,8 @@
 # 1656250 - SAP on AWS: Support prerequisites - only Linux Operating System IO Recommendations
-# Version 46 from 11.05.2022 in English
 
 [version]
-VERSION=46
-DATE=11.05.2022
+VERSION=63
+DATE=05.02.2024
 DESCRIPTION=SAP on AWS: Support prerequisites - only Linux Operating System IO Recommendations
 REFERENCES=https://launchpad.support.sap.com/#/notes/1656250
 

--- a/ospackage/usr/share/saptune/notes/1771258
+++ b/ospackage/usr/share/saptune/notes/1771258
@@ -1,12 +1,11 @@
 # 1771258 - Linux: User and system resource limits
-# Version 6 from 05.11.2021 in English
 # as it is planned by SAP to use this Note for Netweaver AND HANA we just
 # changed the values while we are still waiting for the updated version of
 # the Note
 
 [version]
-VERSION=6
-DATE=05.11.2021
+VERSION=8
+DATE=05.01.2023
 DESCRIPTION=Linux: User and system resource limits
 REFERENCES=https://launchpad.support.sap.com/#/notes/1771258
 

--- a/ospackage/usr/share/saptune/notes/1805750
+++ b/ospackage/usr/share/saptune/notes/1805750
@@ -1,6 +1,5 @@
 # 1805750 - SYB: Usage of HugePages on Linux Systems with Sybase ASE
 # Configuration of HugePages on Linux with SAP Sybase ASE
-# Version 9 from 10.03.2020 in English
 #
 
 [version]

--- a/ospackage/usr/share/saptune/notes/1868829
+++ b/ospackage/usr/share/saptune/notes/1868829
@@ -1,5 +1,4 @@
 # 1868829 - Startup Issues Because Number of Active I/O Requests to Queue Exceeds aio-max-nr Limit
-# Version 5 from 29.03.2018 in English
 
 [version]
 VERSION=5

--- a/ospackage/usr/share/saptune/notes/1980196
+++ b/ospackage/usr/share/saptune/notes/1980196
@@ -1,5 +1,4 @@
 # 1980196 - Setting Linux Kernel Parameter /proc/sys/vm/max_map_count on SAP HANA Systems
-# Version 7 from 18.10.2017 in English
 
 [version]
 VERSION=7

--- a/ospackage/usr/share/saptune/notes/1984787
+++ b/ospackage/usr/share/saptune/notes/1984787
@@ -1,10 +1,9 @@
 # 1984787 - SUSE LINUX Enterprise Server 12: Installation notes
 # Description:    You want to use SAP software on SUSE Linux Enterprise Server 12 (SLES 12) or SUSE Linux Enterprise Server for SAP Applications 12 (SLES for SAP 12).
-# Version 40 from 25.11.2021 in English
 
 [version]
-VERSION=40
-DATE=25.11.2021
+VERSION=42
+DATE=07.10.2022
 DESCRIPTION=SUSE LINUX Enterprise Server 12: Installation notes
 REFERENCES=https://launchpad.support.sap.com/#/notes/1984787
 
@@ -56,6 +55,7 @@ util-linux 12-SP1 2.25-22.1
 uuidd 12-SP1 2.25-22
 util-linux-systemd 12-SP1 2.25-22.1
 psmisc 12-SP5 22.21-6.19.1
+kernel-default 12-SP5 4.12.14-122.130
 
 [sysctl]
 # vm.dirty_bytes (indirect vm.dirty_ratio)

--- a/ospackage/usr/share/saptune/notes/2161991
+++ b/ospackage/usr/share/saptune/notes/2161991
@@ -1,6 +1,5 @@
 # 2161991 - VMware vSphere configuration guidelines
 # Description:    3. Recommendations for the guest operating system
-# Version 28 from 29.07.2021 in English
 
 [version]
 VERSION=28

--- a/ospackage/usr/share/saptune/notes/2205917
+++ b/ospackage/usr/share/saptune/notes/2205917
@@ -1,6 +1,5 @@
 # 2205917 - SAP HANA DB: Recommended OS settings for SLES 12 / SLES for SAP Applications 12
 # Description:    HANA DB settings
-# Version 63 from 18.05.2021 in English
 
 [version]
 VERSION=63

--- a/ospackage/usr/share/saptune/notes/2382421
+++ b/ospackage/usr/share/saptune/notes/2382421
@@ -1,9 +1,8 @@
 # 2382421 - Optimizing the Network Configuration on HANA- and OS-Level
-# Version 45 from 02.08.2023 in English
 
 [version]
-VERSION=44
-DATE=15.06.2023
+VERSION=45
+DATE=02.08.2023
 DESCRIPTION=Optimizing the Network Configuration on HANA- and OS-Level
 REFERENCES=https://launchpad.support.sap.com/#/notes/2382421
 

--- a/ospackage/usr/share/saptune/notes/2534844
+++ b/ospackage/usr/share/saptune/notes/2534844
@@ -1,5 +1,4 @@
 # 2534844 - Indexserver Crash During Startup due to Insufficient Shared Memory Segment
-# Version 15 from 26.05.2023 in English
 
 [version]
 VERSION=15

--- a/ospackage/usr/share/saptune/notes/2578899
+++ b/ospackage/usr/share/saptune/notes/2578899
@@ -1,10 +1,9 @@
 # 2578899 - SUSE Linux Enterprise Server 15: Installation Note
 # Description:    You want to use SAP software on SUSE Linux Enterprise Server 15 (SLES 15) or SUSE Linux Enterprise Server 15 for SAP Applications  (SLES for SAP 15).
-# Version 46 from 25.04.2023 in English
 
 [version]
-VERSION=46
-DATE=25.04.2023
+VERSION=47
+DATE=04.09.2023
 DESCRIPTION=SUSE Linux Enterprise Server 15: Installation Note
 REFERENCES=https://launchpad.support.sap.com/#/notes/2578899
 
@@ -54,6 +53,10 @@ glibc 2.31-150300.46.1
 
 [rpm:os=15-SP4:arch=x86_64]
 glibc 2.31-150300.46.1
+
+[rpm:os=15-SP4:arch=ppc64le]
+kernel-default 5.14.21-150400.24.11.1
+
 
 [sysctl]
 # vm.dirty_bytes (indirect vm.dirty_ratio)

--- a/ospackage/usr/share/saptune/notes/2684254
+++ b/ospackage/usr/share/saptune/notes/2684254
@@ -1,10 +1,9 @@
 # 2684254 - SAP HANA DB: Recommended OS settings for SLES 15 / SLES for SAP Applications 15
 # Description:    HANA DB settings
-# Version 23 from 03.05.2023 in English
 
 [version]
 VERSION=23
-DATE=18.04.2023
+DATE=03.05.2023
 DESCRIPTION=SAP HANA DB: Recommended OS settings for SLES 15 / SLES for SAP Applications 15
 REFERENCES=https://launchpad.support.sap.com/#/notes/2684254
 

--- a/ospackage/usr/share/saptune/notes/2993054
+++ b/ospackage/usr/share/saptune/notes/2993054
@@ -1,10 +1,9 @@
 # 2993054 - Recommended settings for SAP systems on Linux running in Azure virtual machines
 # Description:    Azure settings
-# Version 2 from 12.07.2021 in English
 
 [version]
 VERSION=2
-DATE=12.07.2021
+DATE=13.07.2021
 DESCRIPTION=Recommended settings for SAP systems on Linux running in Azure virtual machines
 REFERENCES=https://launchpad.support.sap.com/#/notes/2993054
 

--- a/ospackage/usr/share/saptune/notes/3024346
+++ b/ospackage/usr/share/saptune/notes/3024346
@@ -1,10 +1,9 @@
 # 3024346 - Linux Kernel Settings for NetApp NFS
-# Version 6 from 29.04.2022 in English
 # See TR-4290 (FAS) or TR-4435 (AFF).
 
 [version]
-VERSION=6
-DATE=29.04.2022
+VERSION=10
+DATE=09.02.2024
 DESCRIPTION=Linux Kernel Settings for NetApp NFS
 REFERENCES=https://launchpad.support.sap.com/#/notes/3024346 https://docs.netapp.com/us-en/netapp-solutions-sap/bp/saphana-fas-nfs_introduction.html https://docs.netapp.com/us-en/netapp-solutions-sap/bp/saphana_aff_nfs_introduction.html
 

--- a/ospackage/usr/share/saptune/notes/900929
+++ b/ospackage/usr/share/saptune/notes/900929
@@ -1,5 +1,4 @@
 # 900929 - Linux: STORAGE_PARAMETERS_WRONG_SET and "mmap() failed"
-# Version 7 from 31.07.2017 in English
 
 [version]
 VERSION=7

--- a/ospackage/usr/share/saptune/notes/941735
+++ b/ospackage/usr/share/saptune/notes/941735
@@ -1,6 +1,5 @@
 # 941735 - SAP memory management system for 64-bit Linux systems
 # Description:    Recommendation for parameterization of 64-bit Linux systems.
-# Version 11 from 04.05.2018 in English
 
 [version]
 VERSION=11

--- a/system/lock.go
+++ b/system/lock.go
@@ -11,6 +11,9 @@ import (
 // saptune lock file
 var stLockFile = "/run/.saptune.lock"
 
+// map of 'realm command' combinations to set the lock or not
+var lockCommands = map[string]bool{"daemon start": true, "daemon status": false, "daemon stop": true, "service apply": true, "service start": true, "service status": false, "service stop": true, "service restart": true, "service revert": true, "service reload": true, "service takeover": true, "service enable": false, "service disable": false, "service enablestart": true, "service disablestop": true, "note list": false, "note revertall": true, "note enabled": false, "note applied": false, "note apply": true, "note simulate": false, "note customise": true, "note create": true, "note edit": true, "note revert": true, "note show": false, "note delete": true, "note verify": false, "note rename": true, "solution list": false, "solution verify": false, "solution enabled": false, "solution applied": false, "solution apply": true, "solution change": true, "solution simulate": false, "solution customise": true, "solution create": true, "solution edit": true, "solution revert": true, "solution show": false, "solution delete": true, "solution rename": true, "staging status": true, "staging enable": true, "staging disable": true, "staging is-enabled": true, "staging list": true, "staging diff": true, "staging analysis": true, "staging release": true, "revert all": true, "lock remove": false, "check": false, "status": false, "version": false, "help": false}
+
 // isOwnLock return true, if lock file is from the current running process
 // pid inside the lock file is the pid of current running saptune instance
 func isOwnLock() bool {
@@ -36,13 +39,26 @@ func SaptuneLock() {
 	if saptuneIsLocked() {
 		ErrorExit("saptune currently in use, try later ...", 11)
 	}
-	stLock, err := os.OpenFile(stLockFile, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0600)
-	if err != nil {
-		ErrorExit("problems setting lock", 12)
+	lcmd := realmAndCmd()
+	setLock := false
+	if _, ok := lockCommands[lcmd]; !ok {
+		// not a valid combination of 'realm command'
+		ErrLog("not a valid combination of 'realm command' discovered - %s\n", lcmd)
+		setLock = true
 	} else {
-		fmt.Fprintf(stLock, "%d", os.Getpid())
+		setLock = lockCommands[lcmd]
 	}
-	stLock.Close()
+	if setLock {
+		stLock, err := os.OpenFile(stLockFile, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0600)
+		if err != nil {
+			ErrorExit("problems setting lock", 12)
+		} else {
+			fmt.Fprintf(stLock, "%d", os.Getpid())
+		}
+		stLock.Close()
+	} else {
+		InfoLog("no lock set for '%s'\n", lcmd)
+	}
 }
 
 // saptuneIsLocked checks, if the lock file for saptune exists

--- a/system/lock_test.go
+++ b/system/lock_test.go
@@ -17,6 +17,11 @@ func TestLock(t *testing.T) {
 			t.Errorf("saptune lock exists, but shouldn't\n")
 		}
 	}
+
+	os.Args = []string{"saptune", "note", "apply"}
+	// parse command line, to get the test parameters
+	saptArgs, saptFlags = ParseCliArgs()
+
 	SaptuneLock()
 	if !saptuneIsLocked() {
 		_, err := os.Stat(stLockFile)
@@ -43,6 +48,16 @@ func TestLock(t *testing.T) {
 			t.Errorf("saptune lock exists, but shouldn't\n")
 			os.Remove(stLockFile)
 		}
+	}
+
+	os.Args = []string{"saptune", "note", "list"}
+	// parse command line, to get the test parameters
+	saptArgs, saptFlags = ParseCliArgs()
+	SaptuneLock()
+	_, err := os.Stat(stLockFile)
+	if err == nil {
+		t.Errorf("saptune lock exists, but shouldn't\n")
+		os.Remove(stLockFile)
 	}
 
 	sl, _ := os.OpenFile(stLockFile, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0600)


### PR DESCRIPTION
limited the lock setting to commands having the potential to change anything in the system (bsc#1219500)
update notes to current versions available at SAP
remove redundant version information in header comment