### PR TITLE
verify - wrap content of table columns

### DIFF
--- a/actions/table.go
+++ b/actions/table.go
@@ -338,6 +338,9 @@ func getInformSettings(nID string, nComparisons map[string]map[string]note.Field
 func setWidthOfColums(compare note.FieldComparison, c1, c2, c3, c4 int) (int, int, int, int) {
 	if len(compare.ReflectMapKey) != 0 {
 		if compare.ReflectFieldName == "OverrideParams" && len(compare.ActualValueJS) > c1 {
+			// in case of override content of ActualValueJS and
+			// ExpectedValueJS is the same, so one length check
+			// is sufficient
 			c1 = len(compare.ActualValueJS)
 			c1, c3, c4 = chkMaxWidthOfColums([]int{c1, c3, c4})
 			return c1, c2, c3, c4

--- a/actions/table.go
+++ b/actions/table.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 )
 
+// define max column width
+var fmtmax = 30
+
 // PrintNoteFields Print mismatching fields in the note comparison result.
 func PrintNoteFields(writer io.Writer, header string, noteComparisons map[string]map[string]note.FieldComparison, printComparison bool, result *system.JPNotes) {
 	// initialise
@@ -29,7 +32,6 @@ func PrintNoteFields(writer io.Writer, header string, noteComparisons map[string
 	noteList := []system.JPNotesLine{}
 
 	colorScheme := getColorScheme()
-
 	// sort output
 	sortkeys := sortNoteComparisonsOutput(noteComparisons)
 
@@ -73,6 +75,7 @@ func PrintNoteFields(writer io.Writer, header string, noteComparisons map[string
 		}
 		noteLine.ActValue = &pAct
 		pExp = strings.Replace(comparison.ExpectedValueJS, "\t", " ", -1)
+		tableColumns := make(map[string]string)
 		if printComparison {
 			// verify
 			if system.IsFlagSet("show-non-compliant") && (strings.Contains(compliant, "yes") || strings.Contains(compliant, "-")) {
@@ -80,11 +83,12 @@ func PrintNoteFields(writer io.Writer, header string, noteComparisons map[string
 				continue
 			}
 			colFormat, colCompliant = colorPrint(format, compliant, colorScheme)
-			fmt.Fprintf(writer, colFormat, noteField, comparison.ReflectMapKey, pExp, override, pAct, colCompliant)
+			tableColumns = map[string]string{"type": "verify", "colFormat": colFormat, "note": noteField, "parameter": comparison.ReflectMapKey, "expected": pExp, "override": override, "actual": pAct, "compliant": colCompliant}
 		} else {
 			// simulate
-			fmt.Fprintf(writer, format, comparison.ReflectMapKey, pAct, pExp, override, comment)
+			tableColumns = map[string]string{"type": "simulate", "colFormat": format, "parameter": comparison.ReflectMapKey, "actual": pAct, "expected": pExp, "override": override, "comment": comment}
 		}
+		printTableRow(writer, tableColumns)
 		noteLine = collectMRO(noteLine, compliant, noteID, noteComparisons, comparison, pExp, override, printComparison, comment, footnote, pAct)
 		noteList = append(noteList, noteLine)
 	}
@@ -335,6 +339,7 @@ func setWidthOfColums(compare note.FieldComparison, c1, c2, c3, c4 int) (int, in
 	if len(compare.ReflectMapKey) != 0 {
 		if compare.ReflectFieldName == "OverrideParams" && len(compare.ActualValueJS) > c1 {
 			c1 = len(compare.ActualValueJS)
+			c1, c3, c4 = chkMaxWidthOfColums([]int{c1, c3, c4})
 			return c1, c2, c3, c4
 		}
 		if len(compare.ReflectMapKey) > c2 {
@@ -347,7 +352,19 @@ func setWidthOfColums(compare note.FieldComparison, c1, c2, c3, c4 int) (int, in
 			c4 = len(compare.ActualValueJS)
 		}
 	}
+	c1, c3, c4 = chkMaxWidthOfColums([]int{c1, c3, c4})
 	return c1, c2, c3, c4
+}
+
+// chkMaxWidthOfColums limits the width of the columns for verify and simulate
+// to a defined value. Content of columns need to be wrapped
+func chkMaxWidthOfColums(fmts []int) (int, int, int) {
+	for w, width := range fmts {
+		if width > fmtmax {
+			fmts[w] = fmtmax
+		}
+	}
+	return fmts[0], fmts[1], fmts[2]
 }
 
 // getColorScheme reads the color scheme from CLI flag or from saptune
@@ -449,4 +466,93 @@ func colorFormating(colCmpl, colNonCmpl, txt, compliant string) string {
 		}
 	}
 	return colFormat
+}
+
+// printTableRow prints one row of the table
+// If needed the lines of the override column, the expected column and the
+// actual column will be wrapped after 'fmtmax' characters
+// if override exists, expected == override, so compare of width of expected and
+// actual column is sufficient
+func printTableRow(writer io.Writer, rowElements map[string]string) {
+	wrappedActual := system.WrapTxt(rowElements["actual"], fmtmax)
+	wrappedExpected := system.WrapTxt(rowElements["expected"], fmtmax)
+	wrappedOverride := system.WrapTxt(rowElements["override"], fmtmax)
+	linesAct := len(wrappedActual)
+	linesExp := len(wrappedExpected)
+	linesOver := len(wrappedOverride)
+	if linesAct == 1 && linesExp == 1 && linesOver == 1 {
+		if rowElements["type"] == "verify" {
+			fmt.Fprintf(writer, rowElements["colFormat"], rowElements["note"], rowElements["parameter"], rowElements["expected"], rowElements["override"], rowElements["actual"], rowElements["compliant"])
+		} else {
+			// simulate
+			fmt.Fprintf(writer, rowElements["colFormat"], rowElements["parameter"], rowElements["actual"], rowElements["expected"], rowElements["override"], rowElements["comment"])
+		}
+		return
+	}
+	wrappedElements := map[string][]string{"wrappedActual": wrappedActual, "wrappedExpected": wrappedExpected, "wrappedOverride": wrappedOverride}
+	printWrappedRow(writer, wrappedElements, rowElements)
+}
+
+// printWrappedRow prints the wrapped columns of one verify output row
+// twist - true - compare order ACT, EXP
+// twist - false - compare order EXP, ACT
+// if override exists, expected == override
+func printWrappedRow(writer io.Writer, wrappedElem map[string][]string, rowElements map[string]string) {
+	var wrappedA, wrappedB, wrappedC []string
+	firstLine := true
+	twist := false
+
+	if len(wrappedElem["wrappedActual"]) >= len(wrappedElem["wrappedExpected"]) {
+		twist = true
+	}
+	if twist {
+		wrappedA = wrappedElem["wrappedActual"]
+		wrappedB = wrappedElem["wrappedExpected"]
+	} else {
+		wrappedA = wrappedElem["wrappedExpected"]
+		wrappedB = wrappedElem["wrappedActual"]
+	}
+	wrappedC = wrappedElem["wrappedOverride"]
+	noLinesB := len(wrappedB)
+	noLinesC := len(wrappedC)
+	colB := ""
+	colC := ""
+
+	for c, colA := range wrappedA {
+		// ANGI todo <=
+		if c < noLinesB {
+			colB = wrappedB[c]
+		} else {
+			colB = ""
+		}
+		if c < noLinesC {
+			colC = wrappedC[c]
+		} else {
+			colC = ""
+		}
+		printRow(writer, twist, []string{colA, colB, colC}, rowElements)
+		if firstLine {
+			firstLine = false
+			rowElements["note"] = ""
+			rowElements["parameter"] = ""
+			rowElements["compliant"] = ""
+		}
+	}
+}
+
+// printRow prints now the row of the table
+func printRow (writer io.Writer, twist bool, cols []string, rowElements map[string]string) {
+	if twist {
+		if rowElements["type"] == "verify" {
+			fmt.Fprintf(writer, rowElements["colFormat"], rowElements["note"], rowElements["parameter"], cols[1], cols[2], cols[0], rowElements["compliant"])
+		} else {
+			fmt.Fprintf(writer, rowElements["colFormat"], rowElements["parameter"], cols[0], cols[1], cols[2], rowElements["comment"])
+		}
+	} else {
+		if rowElements["type"] == "verify" {
+			fmt.Fprintf(writer, rowElements["colFormat"], rowElements["note"], rowElements["parameter"], cols[0], cols[2], cols[1], rowElements["compliant"])
+		} else {
+			fmt.Fprintf(writer, rowElements["colFormat"], rowElements["parameter"], cols[1], cols[0], cols[2], rowElements["comment"])
+		}
+	}
 }

--- a/actions/table_test.go
+++ b/actions/table_test.go
@@ -18,40 +18,62 @@ func TestSetWidthOfColums(t *testing.T) {
 	w4 := 5
 	v1, v2, v3, v4 := setWidthOfColums(compare, w1, w2, w3, w4)
 	if v1 != w1 {
-		t.Fatal(v1, w1)
+		t.Error(v1, w1)
 	}
 	if v2 != 16 {
-		t.Fatal(v2, w2)
+		t.Error(v2, w2)
 	}
 	if v3 != w3 || v4 != w4 {
-		t.Fatal(v3, w3, v4, w4)
+		t.Error(v3, w3, v4, w4)
 	}
 	compare = note.FieldComparison{ReflectFieldName: "OverrideParams", ReflectMapKey: "IO_SCHEDULER_sr0", ActualValueJS: "cfq", ExpectedValueJS: "cfq"}
 	v1, v2, v3, v4 = setWidthOfColums(compare, w1, w2, w3, w4)
 	if v1 != 3 {
-		t.Fatal(v1, w1)
+		t.Error(v1, w1)
 	}
 	if v2 != w2 || v3 != w3 || v4 != w4 {
-		t.Fatal(v2, w2, v3, w3, v4, w4)
+		t.Error(v2, w2, v3, w3, v4, w4)
 	}
 	compare = note.FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "governor", ActualValueJS: "all-none", ExpectedValueJS: "all-performance"}
 	v1, v2, v3, v4 = setWidthOfColums(compare, w1, w2, w3, w4)
 	if v1 != w1 {
-		t.Fatal(v1, w1)
+		t.Error(v1, w1)
 	}
 	if v2 != 8 {
-		t.Fatal(v2, w2)
+		t.Error(v2, w2)
 	}
 	if v3 != 15 {
-		t.Fatal(v3, w3)
+		t.Error(v3, w3)
 	}
 	if v4 != 8 {
-		t.Fatal(v4, w4)
+		t.Error(v4, w4)
 	}
 	compare = note.FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "", ActualValueJS: "all-none", ExpectedValueJS: "all-performance"}
 	v1, v2, v3, v4 = setWidthOfColums(compare, w1, w2, w3, w4)
 	if v1 != w1 || v2 != w2 || v3 != w3 || v4 != w4 {
-		t.Fatal(v1, w1, v2, w2, v3, w3, v4, w4)
+		t.Error(v1, w1, v2, w2, v3, w3, v4, w4)
+	}
+	compare = note.FieldComparison{ReflectFieldName: "SysctlParams", ReflectMapKey: "net.ipv4.ip_local_reserved_ports", ActualValueJS: "", ExpectedValueJS: "1089-1090,1095,1099,1200-1599,2000-2002,3200-3399,3500,3600-3699,3900-4001"}
+	v1, v2, v3, v4 = setWidthOfColums(compare, w1, w2, w3, w4)
+	if v1 != w1 {
+		t.Error(v1, w1)
+	}
+	if v2 != 32 {
+		t.Error(v2, w2)
+	}
+	if v3 != 30 {
+		t.Error(v3, w3)
+	}
+	if v4 != w4 {
+		t.Error(v4, w4)
+	}
+	compare = note.FieldComparison{ReflectFieldName: "OverrideParams", ReflectMapKey: "net.ipv4.ip_local_reserved_ports", ActualValueJS: "1089-1090,1095,1099,1200-1599,2000-2002,3200-3399,3500,3600-3699,3900-4001", ExpectedValueJS: "1089-1090,1095,1099,1200-1599,2000-2002,3200-3399,3500,3600-3699,3900-4001"}
+	v1, v2, v3, v4 = setWidthOfColums(compare, w1, w2, w3, w4)
+	if v1 != 30 {
+		t.Error(v1, w1)
+	}
+	if v2 != w2 || v3 != w3 || v4 != w4 {
+		t.Error(v2, w2, v3, w3, v4, w4)
 	}
 }
 

--- a/system/system.go
+++ b/system/system.go
@@ -225,7 +225,16 @@ func SwitchOnOut(stdout *os.File, stderr *os.File) {
 // A given text string will be wrapped at word borders into
 // lines of a given width
 func WrapTxt(text string, width int) (folded []string) {
-	words := strings.Split(text, " ")
+	var words []string
+	fallback := false
+
+	if strings.Contains(text, " ") {
+		words = strings.Split(text, " ")
+	} else {
+		// fallback (e.g. net.ipv4.ip_local_reserved_ports)
+		words = strings.Split(text, ",")
+		fallback = true
+	}
 	if len(words) == 0 {
 		return
 	}
@@ -241,7 +250,11 @@ func WrapTxt(text string, width int) (folded []string) {
 		}
 		if len(word)+1 > spaceLeft {
 			// fold; start next row
-			foldedTxt += "\n" + word
+			if fallback {
+				foldedTxt += ",\n" + word
+			} else {
+				foldedTxt += "\n" + word
+			}
 			if strings.HasSuffix(word, "\n") {
 				spaceLeft = width
 				noSpace = true
@@ -254,6 +267,9 @@ func WrapTxt(text string, width int) (folded []string) {
 				foldedTxt += word
 				spaceLeft -= len(word)
 				noSpace = false
+			} else if fallback {
+				foldedTxt += "," + word
+				spaceLeft -= 1 + len(word)
 			} else {
 				foldedTxt += " " + word
 				spaceLeft -= 1 + len(word)


### PR DESCRIPTION
for verify and simulate output table - wrap content of the columns 'actual', 'expected' and 'override', if they exceed a width of 30 characters (e.g. net.ipv4.ip_local_reserved_ports)