### PR TITLE
Fixes for the next maintenance update

### DIFF
--- a/actions/table.go
+++ b/actions/table.go
@@ -544,7 +544,7 @@ func printWrappedRow(writer io.Writer, wrappedElem map[string][]string, rowEleme
 }
 
 // printRow prints now the row of the table
-func printRow (writer io.Writer, twist bool, cols []string, rowElements map[string]string) {
+func printRow(writer io.Writer, twist bool, cols []string, rowElements map[string]string) {
 	if twist {
 		if rowElements["type"] == "verify" {
 			fmt.Fprintf(writer, rowElements["colFormat"], rowElements["note"], rowElements["parameter"], cols[1], cols[2], cols[0], rowElements["compliant"])

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -207,7 +207,7 @@ All fields are separated by spaces. But please do not use spaces around the equa
 
 The <noteId> must be a text string without spaces. It was planned for future use, but this field was never used.
 
-The internal used NoteID - the unique identifier of a Note definition - was always taken from the filename of the Note definition file without extention '.conf'. It will be displayed during the action 'saptune note list' and used for all other actions, where the NoteID is needed as parameter.
+The internal used NoteID - the unique identifier of a Note definition - was always taken from the filename of the Note definition file without extension '.conf'. It will be displayed during the action 'saptune note list' and used for all other actions, where the NoteID is needed as parameter.
 
 The CATEGORY is for future use. So we do not have defined CATEGORIES at the moment. It must be a text string without spaces.
 

--- a/ospackage/usr/share/saptune/schemas/1.0/templates/README.md
+++ b/ospackage/usr/share/saptune/schemas/1.0/templates/README.md
@@ -15,7 +15,7 @@ FORCE=1 ./generate_unsupported.sh
 With FORCE=1 the script will not override existing templates. To do so use FORCE=2.
 
 !!! Update `UNSUPPORTED_COMMANDS` first, if the list of supported commands has changed. !!!
-!!! See aslo table below.                                                               !!!
+!!! See also table below.                                                               !!!
 
 After creating the templates, the schemas can be generated with build.py (see next section).
 

--- a/sap/note/ini.go
+++ b/sap/note/ini.go
@@ -325,7 +325,7 @@ func (vend INISettings) Apply() error {
 		case INISectionMEM:
 			errs = append(errs, SetMemVal(param.Key, vend.SysctlParams[param.Key]))
 		case INISectionCPU:
-			errs = append(errs, SetCPUVal(param.Key, vend.SysctlParams[param.Key], vend.ID, flstates, vend.OverrideParams[param.Key], vend.Inform[param.Key], revertValues))
+			errs = append(errs, SetCPUVal(param.Key, vend.SysctlParams[param.Key], vend.ID, flstates, vend.OverrideParams[param.Key], revertValues))
 		case INISectionPagecache:
 			if revertValues {
 				switch param.Key {

--- a/sap/note/sectCPU.go
+++ b/sap/note/sectCPU.go
@@ -82,12 +82,12 @@ func OptCPUVal(key, actval, cfgval string) string {
 }
 
 // SetCPUVal applies the settings to the system
-func SetCPUVal(key, value, noteID, savedStates, oval, info string, revert bool) error {
+func SetCPUVal(key, value, noteID, savedStates, oval string, revert bool) error {
 	var err error
 	switch key {
 	case "force_latency":
 		if oval != "untouched" {
-			err = system.SetForceLatency(value, savedStates, info, revert)
+			err = system.SetForceLatency(value, savedStates, revert)
 			if !revert {
 				// the cpu state values of the note need to be stored
 				// after they are set. Special for 'force_latency'
@@ -101,7 +101,7 @@ func SetCPUVal(key, value, noteID, savedStates, oval, info string, revert bool) 
 	case "energy_perf_bias":
 		err = system.SetPerfBias(value)
 	case "governor":
-		err = system.SetGovernor(value, info)
+		err = system.SetGovernor(value)
 	}
 
 	return err

--- a/system/cpu.go
+++ b/system/cpu.go
@@ -185,7 +185,7 @@ func GetGovernor() map[string]string {
 
 	dirCont, err := ioutil.ReadDir(cpuDir)
 	if err != nil {
-		WarningLog("governor settings not supported by the system")
+		WarningLog("Governor settings not supported by the system")
 		gGov["all"] = "none"
 		return gGov
 	}
@@ -269,7 +269,7 @@ func supportsGovernorSettings(value string) bool {
 		setGov = false
 	} else if _, err := os.Stat(path.Join(cpuDir, "cpu0/cpufreq/scaling_governor")); os.IsNotExist(err) {
 		// check only first cpu - cpu0, not all
-		WarningLog("governor settings not supported by the system")
+		WarningLog("Governor settings not supported by the system")
 		setGov = false
 	}
 	return setGov
@@ -305,7 +305,7 @@ func GetFLInfo() (string, string, bool) {
 	// read /sys/devices/system/cpu
 	dirCont, err := ioutil.ReadDir(cpuDir)
 	if err != nil {
-		WarningLog("latency settings not supported by the system")
+		WarningLog("Latency settings not supported by the system")
 		return "all:none", "all:none", cpuStateDiffer
 	}
 	for _, entry := range dirCont {
@@ -430,17 +430,17 @@ func supportsForceLatencySettings(value string) bool {
 		setLatency = false
 	} else if runtime.GOARCH == "ppc64le" {
 		// latency settings are only relevant for Intel-based systems
-		WarningLog("latency settings not relevant for '%s' systems", runtime.GOARCH)
+		WarningLog("Latency settings not relevant for '%s' systems", runtime.GOARCH)
 		setLatency = false
 	} else if value == "all:none" {
 		WarningLog("latency settings not supported by the system")
 		setLatency = false
 	} else if _, err := os.Stat(path.Join(cpuDir, "cpu0")); os.IsNotExist(err) {
 		// check only first cpu - cpu0, not all
-		WarningLog("latency settings not supported by the system")
+		WarningLog("Latency settings not supported by the system")
 		setLatency = false
 	} else if currentCPUDriver() == "none" {
-		WarningLog("latency settings not supported by the system, no active cpuidle driver")
+		WarningLog("Latency settings not supported by the system, no active cpuidle driver")
 		setLatency = false
 	}
 	return setLatency

--- a/system/cpu_test.go
+++ b/system/cpu_test.go
@@ -16,11 +16,11 @@ func TestCheckCPUState(t *testing.T) {
 
 	differ := checkCPUState(tstEqualMap)
 	if differ {
-		t.Fatal(differ)
+		t.Error(differ)
 	}
 	differ = checkCPUState(tstDiffMap)
 	if !differ {
-		t.Fatal(differ)
+		t.Error(differ)
 	}
 }
 
@@ -37,7 +37,7 @@ func TestSupportsPerfBias(t *testing.T) {
 
 	cmdOut, err := exec.Command(cmdName, cmdArgs...).CombinedOutput()
 	if err != nil || (err == nil && (strings.Contains(string(cmdOut), notSupportedX86) || strings.Contains(string(cmdOut), notSupportedIBM))) {
-		t.Fatal(string(cmdOut))
+		t.Error(string(cmdOut))
 	}
 }
 
@@ -48,11 +48,11 @@ func TestGetPerfBias(t *testing.T) {
 	value := GetPerfBias()
 	if !supportsPerfBias() {
 		if value != "all:none" {
-			t.Fatal(value)
+			t.Error(value)
 		}
 	} else {
 		if len(value) < 3 {
-			t.Fatal(value)
+			t.Error(value)
 		}
 	}
 }
@@ -64,17 +64,17 @@ func TestSetPerfBias(t *testing.T) {
 	oldPerf := GetPerfBias()
 	err := SetPerfBias("all:15")
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	val := GetPerfBias()
 	if val != "all:15" && val != "all:none" {
-		t.Fatal(val)
+		t.Error(val)
 	}
 	if oldPerf != "" && oldPerf != "all:none" {
 		// set test value back
 		err := SetPerfBias(oldPerf)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 	}
 }
@@ -86,13 +86,13 @@ func TestIsValidGovernor(t *testing.T) {
 	}
 	gov, _ := GetSysString("devices/system/cpu/cpu0/cpufreq/scaling_governor")
 	if !isValidGovernor("cpu0", gov) {
-		t.Fatal(gov)
+		t.Error(gov)
 	}
 	if isValidGovernor("not_avail", gov) {
-		t.Fatal(gov)
+		t.Error(gov)
 	}
 	if isValidGovernor("cpu0", "not_avail") {
-		t.Fatalf("governor 'not_avail' reported as supported, but shouldn't")
+		t.Errorf("governor 'not_avail' reported as supported, but shouldn't")
 	}
 }
 
@@ -104,10 +104,10 @@ func TestGetGovernor(t *testing.T) {
 	gov, _ := GetSysString("devices/system/cpu/cpu0/cpufreq/scaling_governor")
 	for k, v := range GetGovernor() {
 		if k == "cpu0" && v != gov {
-			t.Fatalf("cpu0: expected '%s', actual '%s'\n", gov, v)
+			t.Errorf("cpu0: expected '%s', actual '%s'\n", gov, v)
 		}
 		if k == "all" && v != gov {
-			t.Fatalf("all: expected '%s', actual '%s'\n", gov, v)
+			t.Errorf("all: expected '%s', actual '%s'\n", gov, v)
 		}
 	}
 }
@@ -115,23 +115,22 @@ func TestGetGovernor(t *testing.T) {
 func TestSetGovernor(t *testing.T) {
 	oldGov := GetGovernor()
 	gov := "performance"
-	info := ""
-	err := SetGovernor("all:performance", info)
+	err := SetGovernor("all:performance")
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	for k, v := range GetGovernor() {
 		if k == "all" && (v != gov && v != "none") {
-			t.Fatalf("all: expected '%s', actual '%s'\n", gov, v)
+			t.Errorf("all: expected '%s', actual '%s'\n", gov, v)
 		}
 	}
-	err = SetGovernor("cpu0:performance", info)
+	err = SetGovernor("cpu0:performance")
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	for k, v := range GetGovernor() {
 		if k == "cpu0" && (v != gov && v != "none") {
-			t.Fatalf("cpu0: expected '%s', actual '%s'\n", gov, v)
+			t.Errorf("cpu0: expected '%s', actual '%s'\n", gov, v)
 		}
 	}
 	// set test value back
@@ -139,14 +138,13 @@ func TestSetGovernor(t *testing.T) {
 	for k, v := range oldGov {
 		val = val + fmt.Sprintf("%s:%s ", k, v)
 	}
-	err = SetGovernor(val, info)
+	err = SetGovernor(val)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
-	info = "notSupported"
-	err = SetGovernor("cpu0:performance", info)
+	err = SetGovernor("cpu0:performance")
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -173,24 +171,24 @@ func TestSetForceLatency(t *testing.T) {
 		t.Skip("the test requires root access")
 	}
 	oldLat, _, _ := GetFLInfo()
-	err := SetForceLatency("all:none", "cpu1:state0:0 cpu1:state1:0", "", false)
+	err := SetForceLatency("all:none", "cpu1:state0:0 cpu1:state1:0", false)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
-	err = SetForceLatency("70", "cpu1:state0:0 cpu1:state1:0", "notSupported", false)
+	err = SetForceLatency("70", "cpu1:state0:0 cpu1:state1:0", false)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
-	err = SetForceLatency("70", "cpu1:state0:0 cpu1:state1:0", "", false)
+	err = SetForceLatency("70", "cpu1:state0:0 cpu1:state1:0", false)
 	t.Log(err)
-	err = SetForceLatency("70", "cpu1:state0:0 cpu1:state1:0", "", true)
+	err = SetForceLatency("70", "cpu1:state0:0 cpu1:state1:0", true)
 	t.Log(err)
 
 	if oldLat != "" {
 		// set test value back
-		err := SetForceLatency(oldLat, "", "", false)
+		err := SetForceLatency(oldLat, "", false)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 	}
 }
@@ -200,23 +198,23 @@ func TestMissingCmd(t *testing.T) {
 	cmdName := "/usr/bin/cpupower"
 	savName := "/usr/bin/cpupower_SAVE"
 	if err := os.Rename(cmdName, savName); err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	value := GetPerfBias()
 	if value != "all:none" {
-		t.Fatal(value)
+		t.Error(value)
 	}
 	if err := SetPerfBias("all:15"); err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if supportsPerfBias() {
-		t.Fatalf("reports supported, but shouldn't")
+		t.Errorf("reports supported, but shouldn't")
 	}
-	if err := SetGovernor("all:performance", ""); err != nil {
-		t.Fatal(err)
+	if err := SetGovernor("all:performance"); err != nil {
+		t.Error(err)
 	}
 	if err := os.Rename(savName, cmdName); err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -232,11 +230,11 @@ func TestCPUErrorCases(t *testing.T) {
 		t.Errorf("should return 'nil' and not '%v'\n", err)
 	}
 	if isValidGovernor("cpu0", "performance") {
-		if err := SetGovernor("all:performance", ""); err == nil {
+		if err := SetGovernor("all:performance"); err == nil {
 			t.Error("should return an error and not 'nil'")
 		}
 	} else {
-		if err := SetGovernor("all:performance", ""); err != nil {
+		if err := SetGovernor("all:performance"); err != nil {
 			t.Errorf("should return 'nil' and not '%v'\n", err)
 		}
 	}
@@ -249,11 +247,16 @@ func TestCPUErrorCases(t *testing.T) {
 	defer func() { cpuDir = oldCPUDir }()
 	cpuDir = "/unknownDir"
 	gval := GetGovernor()
-	if len(gval) != 0 {
-		t.Errorf("should return an empty value, but returns: %+v", gval)
+	if len(gval) != 1 {
+		t.Errorf("should return only one entry, but returns: %+v", gval)
 	}
-	if canSetForceLatency("70", "") {
-		if err := SetForceLatency("70", "cpu1:state0:0 cpu1:state1:0", "", false); err == nil {
+	for k, v := range gval {
+		if k != "all" && v != "none" {
+			t.Errorf("expected 'all:none', actual '%s:%s'\n", k, v)
+		}
+	}
+	if supportsForceLatencySettings("70") {
+		if err := SetForceLatency("70", "cpu1:state0:0 cpu1:state1:0", false); err == nil {
 			t.Error("should return an error and not 'nil'")
 		}
 	}

--- a/system/logging.go
+++ b/system/logging.go
@@ -25,16 +25,16 @@ var severErrorFormat = "ERROR    "
 var logpidFormat = fmt.Sprintf("saptune[%v] ", os.Getpid()) // format to add pid of current saptune process to the log message
 var debugSwitch = os.Getenv("SAPTUNE_DEBUG")                // Switch Debug on or off
 
-//define log format
+// define log format
 func logTimeFormat() string {
 	return time.Now().Format("2006-01-02 15:04:05.000 ")
 }
-	
+
 // DebugLog sends text to the debugLogger and stderr
 func DebugLog(txt string, stuff ...interface{}) {
 	if debugSwitch == "on" {
 		if debugLogger != nil {
-			debugLogger.SetPrefix(logTimeFormat()+severDebugFormat+logpidFormat)
+			debugLogger.SetPrefix(logTimeFormat() + severDebugFormat + logpidFormat)
 			debugLogger.Printf(CalledFrom()+txt+"\n", stuff...)
 		}
 		fmt.Fprintf(os.Stderr, "DEBUG: "+txt+"\n", stuff...)
@@ -44,7 +44,7 @@ func DebugLog(txt string, stuff ...interface{}) {
 // NoticeLog sends text to the noticeLogger and stdout
 func NoticeLog(txt string, stuff ...interface{}) {
 	if noticeLogger != nil {
-		noticeLogger.SetPrefix(logTimeFormat()+severNoticeFormat+logpidFormat)
+		noticeLogger.SetPrefix(logTimeFormat() + severNoticeFormat + logpidFormat)
 		noticeLogger.Printf(CalledFrom()+txt+"\n", stuff...)
 		jWriteMsg("NOTICE", fmt.Sprintf(CalledFrom()+txt+"\n", stuff...))
 		if verboseSwitch == "on" {
@@ -56,7 +56,7 @@ func NoticeLog(txt string, stuff ...interface{}) {
 // InfoLog sends text only to the infoLogger
 func InfoLog(txt string, stuff ...interface{}) {
 	if infoLogger != nil {
-		infoLogger.SetPrefix(logTimeFormat()+severInfoFormat+logpidFormat)
+		infoLogger.SetPrefix(logTimeFormat() + severInfoFormat + logpidFormat)
 		infoLogger.Printf(CalledFrom()+txt+"\n", stuff...)
 	}
 }
@@ -64,7 +64,7 @@ func InfoLog(txt string, stuff ...interface{}) {
 // WarningLog sends text to the warningLogger and stderr
 func WarningLog(txt string, stuff ...interface{}) {
 	if warningLogger != nil {
-		warningLogger.SetPrefix(logTimeFormat()+severWarnFormat+logpidFormat)
+		warningLogger.SetPrefix(logTimeFormat() + severWarnFormat + logpidFormat)
 		warningLogger.Printf(CalledFrom()+txt+"\n", stuff...)
 		jWriteMsg("WARNING", fmt.Sprintf(CalledFrom()+txt+"\n", stuff...))
 		if verboseSwitch == "on" {
@@ -76,7 +76,7 @@ func WarningLog(txt string, stuff ...interface{}) {
 // ErrLog sends text only to the errorLogger
 func ErrLog(txt string, stuff ...interface{}) {
 	if errorLogger != nil {
-		errorLogger.SetPrefix(logTimeFormat()+severErrorFormat+logpidFormat)
+		errorLogger.SetPrefix(logTimeFormat() + severErrorFormat + logpidFormat)
 		errorLogger.Printf(CalledFrom()+txt+"\n", stuff...)
 		jWriteMsg("ERROR", fmt.Sprintf(CalledFrom()+txt+"\n", stuff...))
 	}
@@ -85,7 +85,7 @@ func ErrLog(txt string, stuff ...interface{}) {
 // ErrorLog sends text to the errorLogger and stderr
 func ErrorLog(txt string, stuff ...interface{}) error {
 	if errorLogger != nil {
-		errorLogger.SetPrefix(logTimeFormat()+severErrorFormat+logpidFormat)
+		errorLogger.SetPrefix(logTimeFormat() + severErrorFormat + logpidFormat)
 		errorLogger.Printf(CalledFrom()+txt+"\n", stuff...)
 		jWriteMsg("ERROR", fmt.Sprintf(CalledFrom()+txt+"\n", stuff...))
 		if errorSwitch == "on" {

--- a/txtparser/sysconfig.go
+++ b/txtparser/sysconfig.go
@@ -51,6 +51,8 @@ func ParseSysconfig(input string) (*Sysconfig, error) {
 			leadingComments = append(leadingComments, line)
 		} else if eqChar := strings.IndexRune(line, '='); eqChar != -1 {
 			// Line is a key-value pair
+			// remove trailing comments from line
+			line = system.StripComment(line, `\s#[^#]|"\s#[^#]`)
 			key := strings.TrimSpace(line[0:eqChar])
 			value := strings.Trim(strings.TrimSpace(line[eqChar+1:]), `"`)
 			kv := &SysconfigEntry{


### PR DESCRIPTION
change handling of the performance options (cpu governor, perf bias and force latency)
Check, if the settings are supported, in the get-Functions too.
This should fix the problem with some special Azure VMs (E20d_v5) on newer SLES SPs (jsc#SAPSOL-110)

support inline comments in /etc/sysconfig/saptune
fix formating and typos