### PR TITLE
Task 1291: saptune should support extended operators

### DIFF
--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -14,6 +14,7 @@ const (
 	OperatorMoreThan      = ">"
 	OperatorMoreThanEqual = ">="
 	OperatorEqual         = "="
+	OperatorNotEqual      = "!="
 )
 
 // Operator is the comparison or assignment operator used in an INI file entry
@@ -23,7 +24,7 @@ type Operator string
 var RegexKeyOperatorValue = regexp.MustCompile(`([\w.+_-]+)\s*([<=>]+)\s*["']*(.*?)["']*$`)
 
 // regKey gives the parameter part of the line from the note definition file
-var regKey = regexp.MustCompile(`(.*)\s*[<=>]+\s*["']*.*?["']*$`)
+var regKey = regexp.MustCompile(`^(.*?)\s*([!<=>]+)\s*["']*.*?["']*$`)
 
 // counter to control the [login] section info message
 var loginCnt = 0

--- a/txtparser/ini.go
+++ b/txtparser/ini.go
@@ -21,7 +21,7 @@ const (
 type Operator string
 
 // RegexKeyOperatorValue breaks up a line into key, operator, value.
-var RegexKeyOperatorValue = regexp.MustCompile(`([\w.+_-]+)\s*([<=>]+)\s*["']*(.*?)["']*$`)
+var RegexKeyOperatorValue = regexp.MustCompile(`([\w.+_-]+)\s*([!<=>]+)\s*["']*(.*?)["']*$`)
 
 // regKey gives the parameter part of the line from the note definition file
 var regKey = regexp.MustCompile(`^(.*?)\s*([!<=>]+)\s*["']*.*?["']*$`)


### PR DESCRIPTION
## Description

I've changed the two regex that take care of KOV and Key extraction.

The operators that will be accepted are: `< > = != >= <=`