### PR TITLE
fix(.github): workflows deprecation of nodejs16

### DIFF
--- a/.github/workflows/saptune-ut.yml
+++ b/.github/workflows/saptune-ut.yml
@@ -17,7 +17,7 @@ jobs:
   saptuneUt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set ENV for codeclimate (pull_request)
         run: |


### PR DESCRIPTION
with the checkout@v4 version it should fix this: https://github.com/SUSE/saptune/actions/runs/9740240271

<img width="1419" alt="image" src="https://github.com/SUSE/saptune/assets/12409541/a83b6930-f73b-48d3-b9ac-4f4f154ce632">
