### PR TITLE
Fix proposal: ioutil deprecation

### DIFF
--- a/actions/noteacts.go
+++ b/actions/noteacts.go
@@ -7,7 +7,6 @@ import (
 	"github.com/SUSE/saptune/sap/note"
 	"github.com/SUSE/saptune/system"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -306,7 +305,7 @@ func NoteActionShow(writer io.Writer, noteID string, tuneApp *app.App) {
 		system.ErrorExit("%v", err)
 	}
 	fileName, _ := getFileName(noteID, NoteTuningSheets, ExtraTuningSheets)
-	cont, err := ioutil.ReadFile(fileName)
+	cont, err := os.ReadFile(fileName)
 	if err != nil {
 		system.ErrorExit("Failed to read file '%s' - %v", fileName, err)
 	}

--- a/actions/solutionacts.go
+++ b/actions/solutionacts.go
@@ -8,7 +8,6 @@ import (
 	"github.com/SUSE/saptune/sap/solution"
 	"github.com/SUSE/saptune/system"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"sort"
@@ -420,7 +419,7 @@ func SolutionActionShow(writer io.Writer, solName string) {
 	}
 	solFName := fmt.Sprintf("%s.sol", solName)
 	fileName, _ := getFileName(solFName, SolutionSheets, ExtraTuningSheets)
-	cont, err := ioutil.ReadFile(fileName)
+	cont, err := os.ReadFile(fileName)
 	if err != nil {
 		system.ErrorExit("Failed to read file '%s' - %v", fileName, err)
 	}
@@ -536,7 +535,7 @@ func rewriteSolName(oldName, newName, newFile string) {
 	}
 	defer fn.Close()
 	// create temp file
-	tmpfn, err := ioutil.TempFile("", "replace-*")
+	tmpfn, err := os.CreateTemp("", "replace-*")
 	if err != nil {
 		system.ErrorExit("Unable to create temporary file - %v", err)
 	}

--- a/actions/stagingacts.go
+++ b/actions/stagingacts.go
@@ -8,7 +8,6 @@ import (
 	"github.com/SUSE/saptune/system"
 	"github.com/SUSE/saptune/txtparser"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
@@ -521,7 +520,7 @@ func writeStagingToConf(staging string) error {
 		return err
 	}
 	sconf.Set("STAGING", staging)
-	return ioutil.WriteFile(saptuneSysconfig, []byte(sconf.ToText()), 0644)
+	return os.WriteFile(saptuneSysconfig, []byte(sconf.ToText()), 0644)
 }
 
 // collectStageFileInfo is collecting all needed info about the file

--- a/app/app.go
+++ b/app/app.go
@@ -8,7 +8,6 @@ import (
 	"github.com/SUSE/saptune/system"
 	"github.com/SUSE/saptune/txtparser"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -99,7 +98,7 @@ func (app *App) SaveConfig() error {
 	sysconf.SetStrArray(TuneForSolutionsKey, app.TuneForSolutions)
 	sysconf.SetStrArray(TuneForNotesKey, app.TuneForNotes)
 	sysconf.SetStrArray(NoteApplyOrderKey, app.NoteApplyOrder)
-	return ioutil.WriteFile(path.Join(app.SysconfigPrefix, SysconfigSaptuneFile), []byte(sysconf.ToText()), 0644)
+	return os.WriteFile(path.Join(app.SysconfigPrefix, SysconfigSaptuneFile), []byte(sysconf.ToText()), 0644)
 }
 
 // GetSortedSolutionEnabledNotes returns the number of all solution-enabled
@@ -256,7 +255,7 @@ func (app *App) NoteSanityCheck() error {
 		// file handling exists
 		fileName := fmt.Sprintf("/run/saptune/sections/%s.sections", note)
 		// check, if empty state file exists
-		if content, err := ioutil.ReadFile(app.State.GetPathToNote(note)); err == nil && len(content) == 0 {
+		if content, err := os.ReadFile(app.State.GetPathToNote(note)); err == nil && len(content) == 0 {
 			// remove empty state file
 			_ = app.State.Remove(note)
 			if _, err := os.Stat(fileName); err == nil {
@@ -579,7 +578,7 @@ func (app *App) RevertAll(permanent bool) error {
 	if err == nil {
 		for _, otherNoteID := range otherNotes {
 			// check, if empty state file exists
-			if content, err := ioutil.ReadFile(app.State.GetPathToNote(otherNoteID)); err == nil && len(content) == 0 {
+			if content, err := os.ReadFile(app.State.GetPathToNote(otherNoteID)); err == nil && len(content) == 0 {
 				// remove empty state file
 				_ = app.State.Remove(otherNoteID)
 				continue

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/SUSE/saptune/sap/param"
 	"github.com/SUSE/saptune/sap/solution"
 	"github.com/SUSE/saptune/system"
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -30,7 +29,7 @@ func (pa SampleParam) Name() string {
 	return "Sample parameter"
 }
 func (pa SampleParam) Inspect() (param.Parameter, error) {
-	content, _ := ioutil.ReadFile(SampleParamFile)
+	content, _ := os.ReadFile(SampleParamFile)
 	pa.Data = string(content)
 	return pa, nil
 }
@@ -39,7 +38,7 @@ func (pa SampleParam) Optimise(way interface{}) (param.Parameter, error) {
 	return pa, nil
 }
 func (pa SampleParam) Apply(way interface{}) error {
-	return ioutil.WriteFile(SampleParamFile, []byte(pa.Data), 0644)
+	return os.WriteFile(SampleParamFile, []byte(pa.Data), 0644)
 }
 
 type SampleNote1 struct {
@@ -109,14 +108,14 @@ func VerifyConfig(t *testing.T, app *App, hasNotes []string, hasSolutions []stri
 }
 
 func WriteFileOrPanic(filePath, content string) {
-	if err := ioutil.WriteFile(filePath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
 		panic(err)
 	}
 }
 
 // Verify that the file content is exactly as specified.
 func VerifyFileContent(t *testing.T, filePath, content, no string) {
-	if fileContent, err := ioutil.ReadFile(filePath); err != nil {
+	if fileContent, err := os.ReadFile(filePath); err != nil {
 		t.Fatal(err)
 	} else if string(fileContent) != content {
 		t.Errorf("%s - file content mismatch\nexpected:%s\nactual:%s", no, content, string(fileContent))

--- a/app/state.go
+++ b/app/state.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/SUSE/saptune/sap/note"
-	"io/ioutil"
 	"os"
 	"path"
 )
@@ -33,7 +32,7 @@ func (state *State) Store(noteID string, obj note.Note, overwriteExisting bool) 
 		return err
 	}
 	if _, err := os.Stat(state.GetPathToNote(noteID)); os.IsNotExist(err) || overwriteExisting {
-		return ioutil.WriteFile(state.GetPathToNote(noteID), content, 0644)
+		return os.WriteFile(state.GetPathToNote(noteID), content, 0644)
 	}
 	return nil
 }
@@ -44,7 +43,7 @@ func (state *State) List() (ret []string, err error) {
 		return
 	}
 	// List SaptuneStateDir and collect number from file names
-	dirContent, err := ioutil.ReadDir(path.Join(state.StateDirPrefix, SaptuneStateDir))
+	dirContent, err := os.ReadDir(path.Join(state.StateDirPrefix, SaptuneStateDir))
 	if os.IsNotExist(err) {
 		return []string{}, nil
 	} else if err != nil {
@@ -60,7 +59,7 @@ func (state *State) List() (ret []string, err error) {
 // Retrieve deserialises a SAP note into the destination pointer.
 // The destination must be a pointer.
 func (state *State) Retrieve(noteID string, dest interface{}) error {
-	content, err := ioutil.ReadFile(state.GetPathToNote(noteID))
+	content, err := os.ReadFile(state.GetPathToNote(noteID))
 	if err != nil {
 		return err
 	}

--- a/sap/note/parameter.go
+++ b/sap/note/parameter.go
@@ -3,7 +3,6 @@ package note
 import (
 	"encoding/json"
 	"github.com/SUSE/saptune/system"
-	"io/ioutil"
 	"os"
 	"path"
 )
@@ -44,7 +43,7 @@ func ListParams() (ret []string, err error) {
 		return
 	}
 	// List SaptuneParameterStateDir and collect parameter names from file names
-	dirContent, err := ioutil.ReadDir(SaptuneParameterStateDir)
+	dirContent, err := os.ReadDir(SaptuneParameterStateDir)
 	if os.IsNotExist(err) {
 		return []string{}, nil
 	} else if err != nil {
@@ -106,7 +105,7 @@ func GetSavedParameterNotes(param string) ParameterNotes {
 	pEntries := ParameterNotes{
 		AllNotes: make([]ParameterNoteEntry, 0, 64),
 	}
-	content, err := ioutil.ReadFile(GetPathToParameter(param))
+	content, err := os.ReadFile(GetPathToParameter(param))
 	if err != nil {
 		return pEntries
 	}
@@ -145,7 +144,7 @@ func StoreParameter(param string, obj ParameterNotes, overwriteExisting bool) er
 		return err
 	}
 	if _, err := os.Stat(GetPathToParameter(param)); os.IsNotExist(err) || overwriteExisting {
-		return ioutil.WriteFile(GetPathToParameter(param), content, 0644)
+		return os.WriteFile(GetPathToParameter(param), content, 0644)
 	}
 	return nil
 }

--- a/sap/note/sectLogin.go
+++ b/sap/note/sectLogin.go
@@ -3,7 +3,6 @@ package note
 import (
 	"fmt"
 	"github.com/SUSE/saptune/system"
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -19,7 +18,7 @@ func GetLoginVal(key string) (string, error) {
 	var utmPat = regexp.MustCompile(`UserTasksMax=(.*)`)
 	switch key {
 	case "UserTasksMax":
-		logindContent, err := ioutil.ReadFile(path.Join(LogindConfDir, LogindSAPConfFile))
+		logindContent, err := os.ReadFile(path.Join(LogindConfDir, LogindSAPConfFile))
 		if err != nil && !os.IsNotExist(err) {
 			return "", err
 		}
@@ -97,7 +96,7 @@ func SetLoginVal(key, value string, revert bool) error {
 			if err := os.MkdirAll(LogindConfDir, 0755); err != nil {
 				return err
 			}
-			if err := ioutil.WriteFile(path.Join(LogindConfDir, LogindSAPConfFile), []byte(LogindSAPConfContent), 0644); err != nil {
+			if err := os.WriteFile(path.Join(LogindConfDir, LogindSAPConfFile), []byte(LogindSAPConfContent), 0644); err != nil {
 				return err
 			}
 			// reload-or-try-restart systemd-logind.service

--- a/sap/param/io_test.go
+++ b/sap/param/io_test.go
@@ -2,7 +2,7 @@ package param
 
 import (
 	"github.com/SUSE/saptune/system"
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 )
@@ -35,7 +35,7 @@ func TestIOElevators(t *testing.T) {
 	t.Logf("oldvals - '%+v'\n", oldvals)
 
 	// ANGI TODO - better solution
-	_, err = ioutil.ReadDir("/sys/block/sda/mq")
+	_, err = os.ReadDir("/sys/block/sda/mq")
 	if err != nil {
 		// single queue scheduler (values: noop deadline cfq)
 		scheduler = "noop"
@@ -398,12 +398,12 @@ func TestMaxSectorsKB(t *testing.T) {
 
 func TestIsValidScheduler(t *testing.T) {
 	scheduler := ""
-	dirCont, err := ioutil.ReadDir("/sys/block")
+	dirCont, err := os.ReadDir("/sys/block")
 	if err != nil {
 		t.Skip("no block files available. Skip test.")
 	}
 	for _, entry := range dirCont {
-		_, err := ioutil.ReadDir(path.Join("/sys/block/", entry.Name(), "mq"))
+		_, err := os.ReadDir(path.Join("/sys/block/", entry.Name(), "mq"))
 		if err != nil {
 			// single queue scheduler (values: noop deadline cfq)
 			scheduler = "cfq"
@@ -431,7 +431,7 @@ func TestIsValidScheduler(t *testing.T) {
 }
 
 func TestIsValidforNrRequests(t *testing.T) {
-	dirCont, err := ioutil.ReadDir("/sys/block")
+	dirCont, err := os.ReadDir("/sys/block")
 	if err != nil {
 		t.Skip("no block files available. Skip test.")
 	}
@@ -459,7 +459,7 @@ func TestIsValidforNrRequests(t *testing.T) {
 }
 
 func TestIsValidforReadAheadKB(t *testing.T) {
-	dirCont, err := ioutil.ReadDir("/sys/block")
+	dirCont, err := os.ReadDir("/sys/block")
 	if err != nil {
 		t.Skip("no block files available. Skip test.")
 	}

--- a/system/cmdline.go
+++ b/system/cmdline.go
@@ -3,7 +3,7 @@ package system
 // Gather information about kernel cmdline
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -11,7 +11,7 @@ import (
 // return value for given boot option or 'NA', if not available
 func ParseCmdline(fileName, option string) string {
 	opt := "NA"
-	cmdLine, err := ioutil.ReadFile(fileName)
+	cmdLine, err := os.ReadFile(fileName)
 	if err != nil {
 		WarningLog("ParseCmdline: failed to read  %s: %v", fileName, err)
 		return opt

--- a/system/cpu.go
+++ b/system/cpu.go
@@ -5,7 +5,6 @@ package system
 import (
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -139,7 +138,7 @@ func SecureBootEnabled() bool {
 		return false
 	}
 
-	content, err := ioutil.ReadFile(secureBootFile)
+	content, err := os.ReadFile(secureBootFile)
 	if err != nil {
 		InfoLog("failed to read EFI SecureBoot file '%s': %v", secureBootFile, err)
 		return false
@@ -183,7 +182,7 @@ func GetGovernor() map[string]string {
 		return gGov
 	}
 
-	dirCont, err := ioutil.ReadDir(cpuDir)
+	dirCont, err := os.ReadDir(cpuDir)
 	if err != nil {
 		WarningLog("Governor settings not supported by the system")
 		gGov["all"] = "none"
@@ -278,7 +277,7 @@ func supportsGovernorSettings(value string) bool {
 
 // isValidGovernor check, if the system will support CPU frequency settings
 func isValidGovernor(cpu, gov string) bool {
-	val, err := ioutil.ReadFile(path.Join(cpuDir, cpu, "/cpufreq/scaling_available_governors"))
+	val, err := os.ReadFile(path.Join(cpuDir, cpu, "/cpufreq/scaling_available_governors"))
 	if err == nil && strings.Contains(string(val), gov) {
 		return true
 	}
@@ -304,7 +303,7 @@ func GetFLInfo() (string, string, bool) {
 	}
 
 	// read /sys/devices/system/cpu
-	dirCont, err := ioutil.ReadDir(cpuDir)
+	dirCont, err := os.ReadDir(cpuDir)
 	if err != nil {
 		WarningLog("Latency settings not supported by the system")
 		return "all:none", "all:none", cpuStateDiffer
@@ -314,7 +313,7 @@ func GetFLInfo() (string, string, bool) {
 		cpuName := entry.Name()
 		if isCPU.MatchString(cpuName) {
 			// read /sys/devices/system/cpu/cpu*/cpuidle
-			cpudirCont, err := ioutil.ReadDir(path.Join(cpuDir, cpuName, "cpuidle"))
+			cpudirCont, err := os.ReadDir(path.Join(cpuDir, cpuName, "cpuidle"))
 			if err != nil {
 				// idle settings not supported for cpuName
 				continue
@@ -370,7 +369,7 @@ func SetForceLatency(value, savedStates string, revert bool) error {
 
 	flval, _ := strconv.Atoi(value) // decimal value for force latency
 
-	dirCont, err := ioutil.ReadDir(cpuDir)
+	dirCont, err := os.ReadDir(cpuDir)
 	if err != nil {
 		WarningLog("Latency settings not supported by the system")
 		return err
@@ -379,7 +378,7 @@ func SetForceLatency(value, savedStates string, revert bool) error {
 		// cpu0 ... cpuXY
 		cpuName := entry.Name()
 		if isCPU.MatchString(cpuName) {
-			cpudirCont, errns := ioutil.ReadDir(path.Join(cpuDir, cpuName, "cpuidle"))
+			cpudirCont, errns := os.ReadDir(path.Join(cpuDir, cpuName, "cpuidle"))
 			if errns != nil {
 				WarningLog("idle settings not supported for '%s'", cpuName)
 				continue
@@ -460,7 +459,7 @@ func currentCPUDriver() string {
 		InfoLog("File '%s' not found - %v", cpuDriverFile, err)
 		return cpuDriver
 	}
-	if val, err := ioutil.ReadFile(cpuDriverFile); err != nil {
+	if val, err := os.ReadFile(cpuDriverFile); err != nil {
 		InfoLog("Problems reading file '%s' - %+v\n", cpuDriverFile, err)
 	} else {
 		cpuDriver = string(val)

--- a/system/cpu_test.go
+++ b/system/cpu_test.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -80,7 +79,7 @@ func TestSetPerfBias(t *testing.T) {
 }
 
 func TestIsValidGovernor(t *testing.T) {
-	_, err := ioutil.ReadDir("/sys/devices/system/cpu/cpu0/cpufreq")
+	_, err := os.ReadDir("/sys/devices/system/cpu/cpu0/cpufreq")
 	if err != nil {
 		t.Skip("directory '/sys/devices/system/cpu/cpu0/cpufreq' does not exist. System does not support scaling governor, skipping test")
 	}
@@ -97,7 +96,7 @@ func TestIsValidGovernor(t *testing.T) {
 }
 
 func TestGetGovernor(t *testing.T) {
-	_, err := ioutil.ReadDir("/sys/devices/system/cpu/cpu0/cpufreq")
+	_, err := os.ReadDir("/sys/devices/system/cpu/cpu0/cpufreq")
 	if err != nil {
 		t.Skip("directory '/sys/devices/system/cpu/cpu0/cpufreq' does not exist. System does not support scaling governor, skipping test")
 	}

--- a/system/csp.go
+++ b/system/csp.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"io/ioutil"
 	"os"
 	"regexp"
 )
@@ -70,7 +69,7 @@ var allManufacturerProviders = [...]manufacturerProviders{
 func GetCSP() string {
 	cloudServiceProvider := ""
 	getCloudServiceProvider := func(manufacturer string, providers map[*regexp.Regexp]string) string {
-		if content, err := ioutil.ReadFile(manufacturer); err == nil {
+		if content, err := os.ReadFile(manufacturer); err == nil {
 			for providerRegex, provider := range providers {
 				matches := providerRegex.FindStringSubmatch(string(content))
 				if len(matches) != 0 {

--- a/system/daemon.go
+++ b/system/daemon.go
@@ -2,7 +2,7 @@ package system
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -316,7 +316,7 @@ func CmpServiceStates(actStates, expStates string) bool {
 // WriteTunedAdmProfile write new profile to tuned, used instead of sometimes
 // unreliable 'tuned-adm' command
 func WriteTunedAdmProfile(profileName string) error {
-	err := ioutil.WriteFile(actTunedProfile, []byte(profileName), 0644)
+	err := os.WriteFile(actTunedProfile, []byte(profileName), 0644)
 	if err != nil {
 		return ErrorLog("Failed to write tuned profile '%s' to '%s': %v", profileName, actTunedProfile, err)
 	}
@@ -328,7 +328,7 @@ func WriteTunedAdmProfile(profileName string) error {
 // may be unreliable in newer tuned versions, so better use 'tuned-adm active'
 // Return empty string if it cannot be determined.
 func GetTunedProfile() string {
-	content, err := ioutil.ReadFile(actTunedProfile)
+	content, err := os.ReadFile(actTunedProfile)
 	if err != nil {
 		return ""
 	}

--- a/system/file.go
+++ b/system/file.go
@@ -4,7 +4,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -13,12 +12,12 @@ import (
 
 // ReadConfigFile read content of config file
 func ReadConfigFile(fileName string, autoCreate bool) ([]byte, error) {
-	content, err := ioutil.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if os.IsNotExist(err) && autoCreate {
 		content = []byte{}
 		err = os.MkdirAll(path.Dir(fileName), 0755)
 		if err == nil {
-			err = ioutil.WriteFile(fileName, []byte{}, 0644)
+			err = os.WriteFile(fileName, []byte{}, 0644)
 		}
 	}
 	return content, err
@@ -149,7 +148,7 @@ func CopyFile(srcFile, destFile string) error {
 // skip directories
 func GetFiles(dir string) map[string]string {
 	files := make(map[string]string)
-	entries, err := ioutil.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		DebugLog("failed to read %s, called from '%v' - %v", dir, CalledFrom(), err)
 	}
@@ -164,7 +163,7 @@ func GetFiles(dir string) map[string]string {
 // ListDir list directory content and returns a slice for the directory names
 // and a slice for the file names.
 func ListDir(dirPath, logMsg string) (dirNames, fileNames []string) {
-	entries, err := ioutil.ReadDir(dirPath)
+	entries, err := os.ReadDir(dirPath)
 	if err != nil && logMsg != "" {
 		// Not a fatal error
 		WarningLog("failed to read %s - %v", logMsg, err)
@@ -184,7 +183,7 @@ func ListDir(dirPath, logMsg string) (dirNames, fileNames []string) {
 // CleanUpRun cleans up runtime files
 func CleanUpRun() {
 	var runfile = regexp.MustCompile(`.*\.run$`)
-	content, _ := ioutil.ReadDir(SaptuneSectionDir)
+	content, _ := os.ReadDir(SaptuneSectionDir)
 	for _, entry := range content {
 		if runfile.MatchString(entry.Name()) {
 			// remove runtime file
@@ -197,7 +196,7 @@ func CleanUpRun() {
 // currently used for the former start TasksMax value
 func GetBackupValue(fileName string) string {
 	value := ""
-	content, err := ioutil.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if err != nil {
 		DebugLog("reading backup file '%s' failed - '%v'", fileName, err)
 		return "NA"
@@ -212,7 +211,7 @@ func GetBackupValue(fileName string) string {
 // WriteBackupValue writes a value into the backup file
 // currently used for the former start TasksMax value
 func WriteBackupValue(value, fileName string) {
-	err := ioutil.WriteFile(fileName, []byte(value), 0600)
+	err := os.WriteFile(fileName, []byte(value), 0600)
 	if err != nil {
 		DebugLog("writing backup file '%s' for value '%s' failed - '%v'", fileName, value, err)
 	}

--- a/system/file_test.go
+++ b/system/file_test.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -68,7 +67,8 @@ func TestCopyFile(t *testing.T) {
 }
 
 func TestListDir(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "test")
+	tmpDirRaw, err := os.CreateTemp("", "test")
+	tmpDir := tmpDirRaw.Name()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/system/file_test.go
+++ b/system/file_test.go
@@ -67,8 +67,7 @@ func TestCopyFile(t *testing.T) {
 }
 
 func TestListDir(t *testing.T) {
-	tmpDirRaw, err := os.CreateTemp("", "test")
-	tmpDir := tmpDirRaw.Name()
+	tmpDir, err := os.MkdirTemp("", "test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/system/fs.go
+++ b/system/fs.go
@@ -2,7 +2,7 @@ package system
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"reflect"
 	"regexp"
@@ -136,7 +136,7 @@ func ParseMounts(txt string) (mounts MountPoints) {
 // Returns empty list of mount points on error
 func ParseMtab(file string) MountPoints {
 	mounts := ""
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		ErrorLog("failed to read file '%s': %v", file, err)
 	} else {

--- a/system/limits.go
+++ b/system/limits.go
@@ -5,7 +5,6 @@ package system
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -60,9 +59,9 @@ type SecLimits struct {
 // structures.
 func ParseSecLimitsFile(fileName string) (*SecLimits, error) {
 	limitsConfFile := "/etc/security/limits.conf"
-	content, err := ioutil.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if err != nil {
-		content, err = ioutil.ReadFile(limitsConfFile)
+		content, err = os.ReadFile(limitsConfFile)
 		if err != nil {
 			return nil, ErrorLog("failed to open limits config file: %v", err)
 		}
@@ -191,10 +190,10 @@ func (limits *SecLimits) ApplyDropIn(lim []string, noteID string) error {
 			return ErrorLog("failed to create needed directories for the limits drop in file: %v", err)
 		}
 	}
-	return ioutil.WriteFile(dropInFile, []byte(limits.ToDropIn(lim, noteID, dropInFile)), 0644)
+	return os.WriteFile(dropInFile, []byte(limits.ToDropIn(lim, noteID, dropInFile)), 0644)
 }
 
 // Apply overwrite /etc/security/limits.conf with the content of this structure.
 func (limits *SecLimits) Apply() error {
-	return ioutil.WriteFile("/etc/security/limits.conf", []byte(limits.ToText()), 0644)
+	return os.WriteFile("/etc/security/limits.conf", []byte(limits.ToText()), 0644)
 }

--- a/system/lock.go
+++ b/system/lock.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"syscall"
@@ -21,7 +20,7 @@ func isOwnLock() bool {
 		// no lock file found, return false
 		return false
 	}
-	p, err := ioutil.ReadFile(stLockFile)
+	p, err := os.ReadFile(stLockFile)
 	if err != nil {
 		ErrorLog("problems during reading the lock file - '%v'", err)
 		ReleaseSaptuneLock()
@@ -73,7 +72,7 @@ func saptuneIsLocked() bool {
 		return false
 	}
 	// file exists, read content
-	p, err := ioutil.ReadFile(stLockFile)
+	p, err := os.ReadFile(stLockFile)
 	if err != nil {
 		ErrorLog("problems during reading the lock file - '%v'", err)
 		ReleaseSaptuneLock()

--- a/system/lock_test.go
+++ b/system/lock_test.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
@@ -33,7 +32,7 @@ func TestLock(t *testing.T) {
 	}
 	if !isOwnLock() {
 		pid := -1
-		p, err := ioutil.ReadFile(stLockFile)
+		p, err := os.ReadFile(stLockFile)
 		if err == nil {
 			pid, _ = strconv.Atoi(string(p))
 		}

--- a/system/logging.go
+++ b/system/logging.go
@@ -3,7 +3,6 @@ package system
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -124,5 +123,5 @@ func SwitchOffLogging() {
 	debugSwitch = "off"
 	verboseSwitch = "off"
 	errorSwitch = "off"
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 }

--- a/system/mem.go
+++ b/system/mem.go
@@ -4,7 +4,6 @@ package system
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -20,7 +19,7 @@ const (
 // Panic on error.
 func ParseMeminfo() (infoMap map[string]uint64) {
 	infoMap = make(map[string]uint64)
-	memInfo, err := ioutil.ReadFile("/proc/meminfo")
+	memInfo, err := os.ReadFile("/proc/meminfo")
 	if err != nil {
 		panic(fmt.Errorf("failed to read /proc/meminfo: %v", err))
 	}

--- a/system/sys.go
+++ b/system/sys.go
@@ -3,7 +3,6 @@ package system
 // Manipulate /sys/ switches.
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -18,7 +17,7 @@ func GetSysString(parameter string) (string, error) {
 
 // getKeyStringFromPath generalizes the extraction of a string from path
 func getKeyStringFromPath(basePath string, parameter string, logFrom string) (string, error) {
-	val, err := ioutil.ReadFile(path.Join(basePath, strings.Replace(parameter, ".", "/", -1)))
+	val, err := os.ReadFile(path.Join(basePath, strings.Replace(parameter, ".", "/", -1)))
 	if err != nil {
 		WarningLog("failed to read %v string key '%s': %v", logFrom, parameter, err)
 		return "PNA", err
@@ -29,7 +28,7 @@ func getKeyStringFromPath(basePath string, parameter string, logFrom string) (st
 // GetSysChoice read a /sys/ key that comes with current value and alternative
 // choices, return the current choice or empty string.
 func GetSysChoice(parameter string) (string, error) {
-	val, err := ioutil.ReadFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)))
+	val, err := os.ReadFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)))
 	if err != nil {
 		WarningLog("failed to read sys key of choices '%s': %v", parameter, err)
 		return "PNA", err
@@ -60,7 +59,7 @@ func SetSysString(parameter, value string) error {
 		WarningLog("value is '%s', so sys key '%s' is/was not supported by os, skipping.", value, parameter)
 		return nil
 	}
-	err := ioutil.WriteFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644)
+	err := os.WriteFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644)
 	if os.IsNotExist(err) {
 		WarningLog("sys key '%s' is not supported by os, skipping.", parameter)
 	} else if err != nil {
@@ -82,9 +81,9 @@ func TestSysString(parameter, value string) error {
 		WarningLog("failed to get sys key '%s': %v", parameter, err)
 		return err
 	}
-	if err = ioutil.WriteFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644); err == nil {
+	if err = os.WriteFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644); err == nil {
 		// set key back to previous value, because this was only a test
-		err = ioutil.WriteFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)), []byte(save), 0644)
+		err = os.WriteFile(path.Join("/sys", strings.Replace(parameter, ".", "/", -1)), []byte(save), 0644)
 	}
 	return err
 }

--- a/system/sysctl.go
+++ b/system/sysctl.go
@@ -4,7 +4,6 @@ package system
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -225,7 +224,7 @@ func SetSysctlString(parameter, value string) error {
 		WarningLog("value is '%s', so sysctl key '%s' is/was not supported by os, skipping.", value, parameter)
 		return nil
 	}
-	err := ioutil.WriteFile(path.Join("/proc/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644)
+	err := os.WriteFile(path.Join("/proc/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644)
 	if os.IsNotExist(err) {
 		WarningLog("sysctl key '%s' is not supported by os, skipping.", parameter)
 	} else if err != nil {
@@ -265,6 +264,6 @@ func SetSysctlUint64Field(param string, field int, value uint64) error {
 
 // IsPagecacheAvailable check, if system supports pagecache limit
 func IsPagecacheAvailable() bool {
-	_, err := ioutil.ReadFile(path.Join("/proc/sys", strings.Replace(SysctlPagecacheLimitMB, ".", "/", -1)))
+	_, err := os.ReadFile(path.Join("/proc/sys", strings.Replace(SysctlPagecacheLimitMB, ".", "/", -1)))
 	return err == nil
 }

--- a/system/system.go
+++ b/system/system.go
@@ -3,7 +3,6 @@ package system
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -69,7 +68,7 @@ func GetOsVers() string {
 	// VERSION="12", VERSION="15"
 	// VERSION="12-SP1", VERSION="12-SP2", VERSION="12-SP3"
 	var re = regexp.MustCompile(`VERSION="([\w-]+)"`)
-	val, err := ioutil.ReadFile("/etc/os-release")
+	val, err := os.ReadFile("/etc/os-release")
 	if err != nil {
 		return ""
 	}
@@ -84,7 +83,7 @@ func GetOsVers() string {
 func GetOsName() string {
 	// NAME="SLES"
 	var re = regexp.MustCompile(`NAME="([\w\s]+)"`)
-	val, err := ioutil.ReadFile("/etc/os-release")
+	val, err := os.ReadFile("/etc/os-release")
 	if err != nil {
 		return ""
 	}
@@ -119,7 +118,7 @@ func CheckForPattern(file, pattern string) bool {
 	if _, err := os.Stat(file); os.IsNotExist(err) {
 		return false
 	}
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		return false
 	}
@@ -291,7 +290,7 @@ func GetDmiID(file string) (string, error) {
 	var content []byte
 	ret := ""
 	fileName := fmt.Sprintf("%s/%s", DmiID, file)
-	if content, err = ioutil.ReadFile(fileName); err == nil {
+	if content, err = os.ReadFile(fileName); err == nil {
 		ret = strings.TrimSpace(string(content))
 	} else {
 		InfoLog("failed to read %s - %v", fileName, err)
@@ -325,7 +324,7 @@ func GetHWIdentity(info string) (string, error) {
 		}
 	}
 	if fileName != "" {
-		if content, err = ioutil.ReadFile(fileName); err == nil {
+		if content, err = os.ReadFile(fileName); err == nil {
 			ret = strings.TrimSpace(string(content))
 		} else {
 			InfoLog("failed to read %s - %v", fileName, err)

--- a/txtparser/ini_test.go
+++ b/txtparser/ini_test.go
@@ -3,7 +3,6 @@ package txtparser
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -201,13 +200,13 @@ func TestParseINI(t *testing.T) {
 	if !reflect.DeepEqual(*actualINI, expectedINI) {
 		t.Errorf("\n%+v\n%+v\n", *actualINI, expectedINI)
 	}
-	content, err := ioutil.ReadFile(tstFile)
+	content, err := os.ReadFile(tstFile)
 	if err != nil {
 		t.Error(err)
 	}
 	_ = ParseINI(string(content))
 
-	content, err = ioutil.ReadFile(tst2File)
+	content, err = os.ReadFile(tst2File)
 	if err != nil {
 		t.Error(err)
 	}

--- a/txtparser/section.go
+++ b/txtparser/section.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/SUSE/saptune/system"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -42,7 +41,7 @@ func StoreSectionInfo(obj *INIFile, file, ID string, overwriteExisting bool) err
 		return err
 	}
 	if _, err := os.Stat(iniFileName); os.IsNotExist(err) || overwriteExisting {
-		return ioutil.WriteFile(iniFileName, content, 0644)
+		return os.WriteFile(iniFileName, content, 0644)
 	}
 	return nil
 }
@@ -63,7 +62,7 @@ func GetSectionInfo(initype, ID string, fileSelect bool) (*INIFile, error) {
 		KeyValue:  make(map[string]map[string]INIEntry),
 	}
 
-	content, err := ioutil.ReadFile(iniFileName)
+	content, err := os.ReadFile(iniFileName)
 	if err == nil {
 		// do not remove section runtime file, but remove section
 		// saved state file after reading
@@ -112,7 +111,7 @@ func readVersionSection(fileName string) ([]string, bool, error) {
 	if _, err := os.Stat(versRun); err == nil && !staging {
 		return getVersionRunInfo(versRun)
 	}
-	content, err := ioutil.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if err != nil {
 		return vsection, chkVersEntries["isNew"], err
 	}
@@ -168,7 +167,7 @@ func getVersionRunInfo(versRun string) ([]string, bool, error) {
 	var dest []string
 	var vsection []string
 	isNew := true
-	content, err := ioutil.ReadFile(versRun)
+	content, err := os.ReadFile(versRun)
 	if err == nil && len(content) != 0 {
 		err = json.Unmarshal(content, &dest)
 		vsection = dest[0 : len(dest)-1]
@@ -197,7 +196,7 @@ func storeVersionRunInfo(versRun string, vsection []string, isNew bool) error {
 		return err
 	}
 	if _, err := os.Stat(versRun); os.IsNotExist(err) || overwriteExisting {
-		return ioutil.WriteFile(versRun, content, 0644)
+		return os.WriteFile(versRun, content, 0644)
 	}
 	return nil
 }


### PR DESCRIPTION
refactor(ioutil): ioutil is deprecated after 1.16
- [go#40025](https://github.com/golang/go/issues/42025)
- [go#40026](https://github.com/golang/go/issues/42026)

This pr is dependent from #127, I'll move to pr ready from draft when that pr is merged