### PR TITLE
Fix/Refactor: update permission for report and run cc only when secret token is set

### DIFF
--- a/.github/workflows/saptune-ut.yml
+++ b/.github/workflows/saptune-ut.yml
@@ -46,14 +46,15 @@ jobs:
     needs: Setup_Git_Env
     steps:
       - name: Download test coverage reporter
-        run: |
-          curl -L $CC_TEST_REPORTER_URL > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
+        run: curl -L $CC_TEST_REPORTER_URL > ./cc-test-reporter
 
       - uses: actions/upload-artifact@v4
         with:
           name: codeclimate-reporter
           path: cc-test-reporter
+
+      - name: Grant execution permission to cc-test-reporter
+        run: chmod +x ./cc-test-reporter
 
       - name: Run the test reporter before-build
         env:
@@ -90,9 +91,15 @@ jobs:
           docker rm saptune-ci
 
   Code_climate_report_after_build:
-    needs: Saptune_unit_test
+    needs: [Saptune_unit_test, Setup_Git_Env]
     runs-on: ubuntu-latest
     steps:
+      - name: DEBUG
+        env:
+          GIT_BRANCH: ${{needs.Setup_Git_Env.outputs.branch}}
+          GIT_COMMIT_SHA: ${{needs.Setup_Git_Env.outputs.commit_sha}}
+        run: echo "$GIT_BRANCH - $GIT_COMMIT_SHA"
+
       - uses: actions/download-artifact@v4
         with:
           name: coverprofile
@@ -100,6 +107,9 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: codeclimate-reporter
+
+      - name: Grant execution permission to cc-test-reporter
+        run: chmod +x ./cc-test-reporter
 
       - name: Code Climate report coverage
         env:

--- a/.github/workflows/saptune-ut.yml
+++ b/.github/workflows/saptune-ut.yml
@@ -14,11 +14,21 @@ env:
   CC_PREFIX: github.com/SUSE/saptune/
 
 jobs:
+  Check_secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      run_cc: ${{ steps.run_cc.outputs.run_cc }}
+    steps:
+      - id: run_cc
+        run: if [ -z ${CC_TEST_REPORTER_ID} ]; then echo "run_cc=false" >> "$GITHUB_OUTPUT"; else echo "run_cc=true" >> "$GITHUB_OUTPUT"; fi
+
   Setup_Git_Env:
     runs-on: ubuntu-latest
+    needs: Check_secrets
     outputs:
       branch: ${{ steps.branch.outputs.GIT_BRANCH }}
       commit_sha: ${{ steps.commit_sha.outputs.GIT_COMMIT_SHA }}
+    if: ${{ needs.Check_secrets.outputs.run_cc == 'true' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -63,8 +73,9 @@ jobs:
         run: ./cc-test-reporter before-build
 
   Saptune_unit_test:
-    needs: Code_climate_report_before_build
     runs-on: ubuntu-latest
+    needs: Code_climate_report_before_build
+    if: ${{ always() }}
     steps:
       - uses: actions/checkout@v4
 
@@ -84,6 +95,7 @@ jobs:
         with:
           name: coverprofile
           path: c.out
+        if: ${{ env.CC_TEST_REPORTER_ID != '' }}
 
       - name: Stop and remove Container Image
         run: |
@@ -91,15 +103,9 @@ jobs:
           docker rm saptune-ci
 
   Code_climate_report_after_build:
-    needs: [Saptune_unit_test, Setup_Git_Env]
+    needs: [Setup_Git_Env, Saptune_unit_test]
     runs-on: ubuntu-latest
     steps:
-      - name: DEBUG
-        env:
-          GIT_BRANCH: ${{needs.Setup_Git_Env.outputs.branch}}
-          GIT_COMMIT_SHA: ${{needs.Setup_Git_Env.outputs.commit_sha}}
-        run: echo "$GIT_BRANCH - $GIT_COMMIT_SHA"
-
       - uses: actions/download-artifact@v4
         with:
           name: coverprofile
@@ -116,4 +122,3 @@ jobs:
           GIT_BRANCH: ${{needs.Setup_Git_Env.outputs.branch}}
           GIT_COMMIT_SHA: ${{needs.Setup_Git_Env.outputs.commit_sha}}
         run: ./cc-test-reporter after-build --debug --prefix ${{ env.CC_PREFIX }} --exit-code $?
-        if: env.CC_TEST_REPORTER_ID != ''


### PR DESCRIPTION
- I've solve the permission problem for the cc-test-reporter. 
- I've also add a `check_secret` job to check if all the codeclimate report is necessary to run or not

The `Saptune_unit_test` in case of CC_TEST_REPORTER_ID is set it will wait the end of `Code_climate_report_before_build` to finish, if not will run anyway thanks to the `always()` condition added. This will reduce the time spent in running the cc-test-reporter when not necessary and saving 30~60sec for every build.