### PR TITLE
fix(workflows): missing checkout on cc after build

### DIFF
--- a/.github/workflows/saptune-ut.yml
+++ b/.github/workflows/saptune-ut.yml
@@ -106,6 +106,8 @@ jobs:
     needs: [Setup_Git_Env, Saptune_unit_test]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           name: coverprofile


### PR DESCRIPTION
Last build: https://github.com/SUSE/saptune/actions/runs/10269477763
Error: `fatal: not a git repository (or any of the parent directories): .git`

I missed the checkout action..... I think this is the last fix!