### PR TITLE
Read 1024 Byte from /proc/sys files instead of 512

### DIFF
--- a/sap/note/ini.go
+++ b/sap/note/ini.go
@@ -304,7 +304,7 @@ func (vend INISettings) Apply() error {
 			continue
 		}
 
-		if revertValues && vend.SysctlParams[param.Key] != "" {
+		if revertValues && vend.SysctlParams[param.Key] != "PNA" {
 			// revert parameter value
 			pvendID, flstates = vend.setRevertParamValues(param.Key)
 		}
@@ -416,7 +416,7 @@ func (vend INISettings) setRevertParamValues(key string) (string, string) {
 func (vend INISettings) createParamSavedStates(key, flstates string) {
 	// do not write parameter values to the saved state file during
 	// a pure 'verify' action
-	if _, ok := vend.ValuesToApply["verify"]; !ok && vend.SysctlParams[key] != "" {
+	if _, ok := vend.ValuesToApply["verify"]; !ok && vend.SysctlParams[key] != "PNA" {
 		start := vend.SysctlParams[key]
 		if key == "UserTasksMax" {
 			if system.SystemctlIsStarting() {
@@ -437,7 +437,7 @@ func (vend INISettings) createParamSavedStates(key, flstates string) {
 func (vend INISettings) addParamSavedStates(key string) {
 	// do not write parameter values to the saved state file during
 	// a pure 'verify' action
-	if _, ok := vend.ValuesToApply["verify"]; !ok && vend.SysctlParams[key] != "" {
+	if _, ok := vend.ValuesToApply["verify"]; !ok && vend.SysctlParams[key] != "PNA" {
 		AddParameterNoteValues(key, vend.SysctlParams[key], vend.ID)
 	}
 }

--- a/system/sysctl.go
+++ b/system/sysctl.go
@@ -224,6 +224,9 @@ func SetSysctlString(parameter, value string) error {
 		WarningLog("value is '%s', so sysctl key '%s' is/was not supported by os, skipping.", value, parameter)
 		return nil
 	}
+	if value == "" {
+		value = "\n"
+	}
 	err := os.WriteFile(path.Join("/proc/sys", strings.Replace(parameter, ".", "/", -1)), []byte(value), 0644)
 	if os.IsNotExist(err) {
 		WarningLog("sysctl key '%s' is not supported by os, skipping.", parameter)


### PR DESCRIPTION
os.ReadFile reads only 512 Bytes, if it can not detect the filesize, which is the case for /proc/sys files. They always return 0.
This might not be enough for sysctl parameter like 'net.ipv4.ip_local_reserved_ports'. So switch to read 1024 Bytes for now.

An entry of 
net.ipv4.ip_local_reserved_ports = 1089-1090,1095,1099,1200-1599,2000-2002,3200-3399,3500,3600-3699,3900-4001,4010-4013,4238-4241,4300-4399,4800-4912,5001-5002,5011-5012,5021-5022,5031-5032,5041-5042,5050-5052,5061-5062,5071-5072,5081-5082,5091-5092,5101-5102,5111-5112,5121-5122,5131-5132,5141-5142,5151-5152,5161-5162,5171-5172,5181-5182,5191-5192,5201-5202,5211-5212,5221-5222,5231-5232,5241-5242,5251-5252,5261-5262,5271-5272,5281-5282,5291-5292,5301-5302,5311-5312,5321-5322,5331-5332,5341-5342,5351-5352,5361-5362,5371-5372,5381-5382,5391-5399
will be written correctly to /proc/sys/net/ipv4/ip_local_reserved_ports (checked with 'sysctl net.ipv4.ip_local_reserved_ports'), but the read will only deliver
1089-1090,1095,1099,1200-1599,2000-2002,3200-3399,3500,3600-3699,3900-4001,4010-4013,4238-4241,4300-4399,4800-4912,5001-5002,5011-5012,5021-5022,5031-5032,5041-5042,5050-5052,5061-5062,5071-5072,5081-5082,5091-5092,5101-5102,5111-5112,5121-5122,5131-5132,5141-5142,5151-5152,5161-5162,5171-5172,5181-5182,5191-5192,5201-5202,5211-5212,5221-5222,5231-5232,5241-5242,5251-5252,5261-5262,5271-5272,5281-5282,5291-5292,5301-5302,5311-5312,5321-5322,5331-5332,5341-5342,5351-5352,5361-5362,5371-5372,5381-5382,5391-53

This is now fixed.