### PR TITLE
fix findings of the last test cycle

### DIFF
--- a/main.go
+++ b/main.go
@@ -243,6 +243,9 @@ func checkSaptuneConfigFile(writer io.Writer, saptuneConf string, lswitch map[st
 
 	// set values read from the config file
 	saptuneVers := sconf.GetString("SAPTUNE_VERSION", "")
+	if saptuneVers != "1" && saptuneVers != "2" && saptuneVers != "3" {
+		system.ErrorExit("Wrong saptune version in file '/etc/sysconfig/saptune': %s", SaptuneVersion, 128)
+	}
 
 	// Switch Debug on ("on") or off ("off" - default)
 	// Switch verbose mode on ("on" - default) or off ("off")

--- a/main_test.go
+++ b/main_test.go
@@ -156,8 +156,8 @@ func TestCheckSaptuneConfigFile(t *testing.T) {
 	tstwriter = &errExitbuffer
 
 	// check missing variable
-	saptuneConf = fmt.Sprintf("%s/saptune_NoVersion", TstFilesInGOPATH)
-	matchTxt := fmt.Sprintf("Error: File '%s' is broken. Missing variables 'SAPTUNE_VERSION'\n", saptuneConf)
+	saptuneConf = fmt.Sprintf("%s/saptune_MissingVar", TstFilesInGOPATH)
+	matchTxt := fmt.Sprintf("Error: File '%s' is broken. Missing variables 'COLOR_SCHEME'\n", saptuneConf)
 	lSwitch = logSwitch
 	_ = checkSaptuneConfigFile(&buffer, saptuneConf, lSwitch)
 
@@ -168,7 +168,7 @@ func TestCheckSaptuneConfigFile(t *testing.T) {
 	}
 	errExOut := errExitbuffer.String()
 	if errExOut != "" {
-		t.Errorf("wrong text returned by ErrorExit: '%v' instead of ''\n", errExOut)
+		t.Errorf("wrong text returned by ErrorExit: '%v' instead of '%v'\n", errExOut, matchTxt)
 	}
 
 	// initialise next test

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -603,7 +603,7 @@ Concerning \fBsysstat.service\fP please be in mind: A running sysstat service ca
 .br
 See sar(1), sa2(8), sa1(8) for more information
 
-If a service is enabled or disabled by default or admin choice, saptune will NOT disable or enable this service, if only '\fBstart\fP' or '\fBstop\fP' is used. In this case it will only start/stop the service. If such a service is started by systemd during a system reboot \fBafter\fP the start of saptune.service it will be possible that a service is stopped/running even if it was started/stopped by saptune. To change this, the service can be additional enabled or disabled by using '\fBenable\fP' or '\fBdisable\fP' in the Note definition file.
+If a service is enabled or disabled by default or admin choice, saptune will NOT disable or enable this service, if only '\fBstart\fP' or '\fBstop\fP' is used. In this case it will only start/stop the service. If such a service is started by systemd during a system reboot \fBafter\fP the start of saptune.service it will be possible that a service is stopped/running even if it was started/stopped by saptune. To change this, the service can be additional enabled or disabled by using '\fBenable\fP' or '\fBdisable\fP' in the Note definition or Override file.
 \" section sysctl
 .SH "[sysctl]"
 The section "[sysctl]" can be used to modify kernel parameters. The parameters available are those listed under /proc/sys/.

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -15,7 +15,7 @@
 .\" */
 .\" 
 
-.TH "saptune-note" "5" "July 2024" "" "saptune note file format description"
+.TH "saptune-note" "5" "October 2024" "" "saptune note file format description"
 .SH NAME
 saptune\-note \- Note definition files for saptune version \fB3\fP
 .SH DESCRIPTION
@@ -122,6 +122,17 @@ Valid values for \fBcsp=\fP are \fBazure\fP and \fBaws\fP
 Example:
 .br
 [sysctl:csp=azure]
+.RE
+.TP
+.BI virt= <virtualization type>
+to define a special \fIvirtualization\fP type (as reported by \fI/usr/bin/systemd-detect-virt -v|-c|-r\fP)
+.br
+Valid values for \fBvirt=\fP are \fBvm\fP, \fBchroot\fP and \fBcontainer\fP
+
+.RS 4
+Example:
+.br
+[sysctl:virt=vm]
 .RE
 .TP
 .BI DMI interface tag: <filename>= <file content>

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -259,7 +259,9 @@ Success is reported on stdout, errors including systemd error messages are print
 
 If the action was successfully the exit code is 0, otherwise 1.
 
-ATTENTION:
+.TP
+.B ATTENTION:
+.br
 saptune is able to start/stop/enable/disable systemd units, but on boot the outcome depends on the order of execution.
 
 If saptune is starting (or stopping) a systemd service ([service] section) it might happen, that the action gets reverted later by systemd because that service is disabled (or enabled) and executed after saptune.service.

--- a/testdata/saptune_MissingVar
+++ b/testdata/saptune_MissingVar
@@ -31,7 +31,7 @@ NOTE_APPLY_ORDER="2205917 2684254 1680803"
 ## Default: "3"
 #
 # Version of saptune
-#SAPTUNE_VERSION="3"
+SAPTUNE_VERSION="3"
 
 ## Type:    boolean
 ## Default: "false"
@@ -48,7 +48,7 @@ STAGING="false"
 # 'cmpl-blue-zebra', 'full-red-noncmpl', 'red-noncmpl', 'full-yellow-noncmpl'
 # 'yellow-noncmpl'
 # Refer to the man page for a desciprion of the color schemes.
-COLOR_SCHEME=""
+#COLOR_SCHEME=""
 
 ## Type:    string
 ## Default: "/boot"

--- a/testdata/saptune_WrongStaging
+++ b/testdata/saptune_WrongStaging
@@ -31,7 +31,7 @@ NOTE_APPLY_ORDER="2205917 2684254 1680803"
 ## Default: "3"
 #
 # Version of saptune
-SAPTUNE_VERSION="5"
+SAPTUNE_VERSION="3"
 
 ## Type:    boolean
 ## Default: "false"

--- a/txtparser/tags.go
+++ b/txtparser/tags.go
@@ -54,6 +54,8 @@ func chkSecTags(secFields, blkDev []string) (bool, []string) {
 			ret = chkArchTags(tagField[1], secFields)
 		case "csp":
 			ret = chkCspTags(tagField[1], secFields)
+		case "virt":
+			ret = chkVirtTags(tagField[1], secFields)
 		case "blkvendor", "blkmodel", "blkpat":
 			ret, blkDev = chkBlkTags(tagField[0], tagField[1], secFields, blkDev)
 		case "vendor", "model":
@@ -128,6 +130,18 @@ func chkCspTags(tagField string, secFields []string) bool {
 			chkCsp = "not a cloud"
 		}
 		system.InfoLog("cloud service provider '%s' in section definition '%v' does not match the cloud service provider of the running system ('%s'). Skipping whole section with all lines till next valid section definition", tagField, secFields, chkCsp)
+		ret = false
+	}
+	return ret
+}
+
+// chkVirtTags checks if the virtualization type section tag is valid or not
+func chkVirtTags(tagField string, secFields []string) bool {
+	ret := true
+	chkVirt := system.GetVirtStatus()
+	if tagField != chkVirt {
+		// virtualization type does not match
+		system.InfoLog("virtualization type '%s' in section definition '%v' does not match the virtualization type of the running system ('%s'). Skipping whole section with all lines till next valid section definition", tagField, secFields, chkVirt)
 		ret = false
 	}
 	return ret


### PR DESCRIPTION
TEAM-5369 - fix identation error in saptune.8 and missing mention of override file in saptune-note.
move check of valid saptune version to an earlier state so that 'saptune version', 'saptune help' and 'saptune check' are covered too (SAPSOL-209)
Enhance section tagging. Adding support for the virtualization type of the system as reported by '/usr/bin/systemd-detect-virt -v|-c|-r'. Valid values for 'virt=' are 'vm', 'chroot' and 'container'(jsc#TEAM-6070)