### PR TITLE
fixes for next version 3.1.4

### DIFF
--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -1,5 +1,5 @@
 .\"/*
-.\" * Copyright (c) 2017-2022 SUSE LLC.
+.\" * Copyright (c) 2017-2024 SUSE LLC.
 .\" * All rights reserved
 .\" * Authors: Soeren Schmidt, Angela Briel
 .\" *
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\"
-.TH saptune "8" "August 2022" "" "System optimization For SAP"
+.TH saptune "8" "October 2024" "" "System optimization For SAP"
 .SH NAME
 saptune \- Comprehensive system optimization management for SAP solutions (\fBVersion 3\fP)
 
@@ -251,6 +251,17 @@ Calls '\fIsystemctl enablestart saptune.service\fP' after stopping and disabling
 Success is reported on stdout, errors including systemd error messages are printed on stderr. The action gets logged.
 
 If the action was successfully the exit code is 0, otherwise 1.
+
+.TP
+.B ATTENTION:
+.br
+saptune is able to start/stopp/enable/disable systemd units, but on boot the outcome depends on the order of execution.
+
+If saptune is starting (or stopping) a systemd service ([service] section) it might happen, that the action gets reverted later by systemd because that service is disabled (or enabled) and executed after saptune.service.
+
+Similar a service enabled (or disabled) by saptune might already be stopped (or started) by systemd, because it came before saptune.service.
+
+If the execution order cannot be assured by service dependencies, it is recommended to set both ('start,enable' or 'stop,disable') in a Note definition or an Override.
 
 .SH NOTE ACTIONS
 Note denotes either a SAP Note, a vendor specific tuning definition or SUSE recommendation article.

--- a/ospackage/usr/share/saptune/notes/1410736
+++ b/ospackage/usr/share/saptune/notes/1410736
@@ -5,7 +5,7 @@
 VERSION=6
 DATE=15.06.2020
 DESCRIPTION=TCP/IP: setting keepalive interval
-REFERENCES=https://launchpad.support.sap.com/#/notes/1410736
+REFERENCES=https://me.sap.com/notes/1410736
 
 [sysctl]
 net.ipv4.tcp_keepalive_time = 300

--- a/ospackage/usr/share/saptune/notes/1557506
+++ b/ospackage/usr/share/saptune/notes/1557506
@@ -5,7 +5,7 @@
 VERSION=16
 DATE=06.02.2020
 DESCRIPTION=Linux paging improvements
-REFERENCES=https://launchpad.support.sap.com/#/notes/1557506
+REFERENCES=https://me.sap.com/notes/1557506
 
 [pagecache]
 ## Type:    yesno

--- a/ospackage/usr/share/saptune/notes/1656250
+++ b/ospackage/usr/share/saptune/notes/1656250
@@ -1,10 +1,10 @@
 # 1656250 - SAP on AWS: Support prerequisites - only Linux Operating System IO Recommendations
 
 [version]
-VERSION=63
-DATE=05.02.2024
+VERSION=69
+DATE=10.10.2024
 DESCRIPTION=SAP on AWS: Support prerequisites - only Linux Operating System IO Recommendations
-REFERENCES=https://launchpad.support.sap.com/#/notes/1656250
+REFERENCES=https://me.sap.com/notes/1656250
 
 [sys:blkpat=nvme:csp=aws]
 # On linux operating systems the kernel parameter nvme_core.io_timeout controls

--- a/ospackage/usr/share/saptune/notes/1680803
+++ b/ospackage/usr/share/saptune/notes/1680803
@@ -5,104 +5,29 @@
 # 'Best Practice for SAP Business Suite and SAP BW' linked in the
 # 'Solution' section of the related SAP Note 1680803 on SAP launchpad
 #
-# chapter 3.2 Configuration for Linux
+# chapter Operating System Configuration - Prerequisites
 #
 # SAP Applications on SAP Adaptive Server Enterprise
 # - Best Practices for Migration and Runtime
-# Version 3.0 from 2020-07-31
 #
 # SAP ASE (Sybase)
-# Version 27 from 04.11.2021 in English
+# Version 28 from 26.10.2023 in English
 #
 
 [version]
-VERSION=27
-DATE=04.11.2021
+VERSION=28
+DATE=26.10.2023
 DESCRIPTION=Sybase - SAP Adaptive Server Enterprise
 REFERENCES=https://launchpad.support.sap.com/#/notes/1680803
 
-[block]
-## Type:    string
-## Default: noop, none
-#
-# The default I/O scheduler for single-queued block layer devices offers
-# satisfactory performance for wide range of I/O task, however choosing an
-# alternative scheduler may potentially yield better latency characteristics
-# and throughput.
-# "noop" is an alternative scheduler, in comparison to other schedulers it
-# may offer more consistent performance, lower computation overhead, and
-# potentially higher throughput.
-# For most SAP environments (RAID, storage arrays, virtualizaton) 'noop' is
-# the better choice.
-# With the new introduced multi-queue scheduler for block layer devices the
-# recommended I/O scheduler is 'none' as an equivalent to 'noop' for
-# single-queued block layer devices.
-#
-# So IO_SCHEDULER can now contain a comma separated list of possible
-# schedulers, which are checked from left to right. The first one which is
-# available in /sys/block/<device>/queue/scheduler will be used as new
-# scheduler setting for the respective block device.
-#
-# When set, all block devices on the system will be switched to one of the
-# chosen schedulers.
-IO_SCHEDULER=noop, none
-
-## Type:    integer
-## Default: depends on the used I/O scheduler
-#
-# IO nr_requests
-# Increasing the value will improve the I/O throughput, but will also
-# increase the memory usage.
-# Decreasing the value will benefit the real-time applications that are
-# sensitive to latency, but it also decreases the I/O throughput.
-#
-# possible maximum value depends on the chosen scheduler
-# When set, the number of requests for all block devices on the system will 
-# be switched to the chosen value
-NRREQ=
-
-[vm]
-# Disable transparent hugepages (THP)
-# changes /sys/kernel/mm/transparent_hugepage/enabled
-# 'never' to disable, 'always' to enable
-THP=never
-
 [sysctl]
-# maximum number of asynchronous I/Os.
-fs.aio-max-nr = 1048576
-
-# Increase system file descriptor limit
-fs.file-max = 6291456
-
-# Increase Linux autotuning TCP buffer limits
-# Set max to 16MB (16777216) for 1GE and 32M (33554432) or 54M (56623104) for 10GE
-# Don't set tcp_mem itself! Let the kernel scale it based on RAM.
-net.core.rmem_max = 16777216
-net.core.wmem_max = 16777216
-net.core.rmem_default = 16777216
-net.core.wmem_default = 16777216
-net.ipv4.tcp_rmem = 4096 87380 16777216
-net.ipv4.tcp_wmem = 4096 65536 16777216
-
 # Set the keepalive interval to a value higher than 1200 seconds.
 # The ABAP dispatcher initiates an empty network request to the database
 # connection every 1200 seconds. If the keepalive interval is lower, the
 # operating system might close the database connection.
 net.ipv4.tcp_keepalive_time = 1250
 
-# Increase the max packet backlog
-net.core.netdev_max_backlog = 30000
-
-# Discourage Linux from swapping idle processes to disk (default = 60)
-# value between 20 and 10
-vm.swappiness = 15
-
 [sysctl:csp=azure]
 net.ipv4.tcp_keepalive_time =
 
 [reminder]
-# DBMS data storage settings: use ext4 or xfs file system. 
-# For best performance, disable the journal via tune2fs ^has_journal.
-# For ext4 the recommended mount options are 'noatime,nodiratime', if journaling is disabled or 'noatime,nodiratime,cache=writeback,barrier=0', if journaling is not disabled
-# For xfs the recommended mount options are 'noatime,nodiratime,logbufs=8'.
-# network tuning including transmit queue (ifconfig <eth#> txqueuelen <value>). See the current online version of the best practice document 'Best Practice for SAP Business Suite and SAP BW' linked in the 'Solution' section of the related SAP Note 1680803 on SAP launchpad

--- a/ospackage/usr/share/saptune/notes/1680803
+++ b/ospackage/usr/share/saptune/notes/1680803
@@ -3,22 +3,20 @@
 #
 # as described in the current online version of the best practice document
 # 'Best Practice for SAP Business Suite and SAP BW' linked in the
-# 'Solution' section of the related SAP Note 1680803 on SAP launchpad
+# 'Solution' section of the related SAP Note 1680803 at SAP (me.sap.com)
 #
 # chapter Operating System Configuration - Prerequisites
 #
 # SAP Applications on SAP Adaptive Server Enterprise
 # - Best Practices for Migration and Runtime
-#
-# SAP ASE (Sybase)
-# Version 28 from 26.10.2023 in English
+# v3.2  2023-09-20
 #
 
 [version]
 VERSION=28
 DATE=26.10.2023
 DESCRIPTION=Sybase - SAP Adaptive Server Enterprise
-REFERENCES=https://launchpad.support.sap.com/#/notes/1680803
+REFERENCES=https://me.sap.com/notes/1680803
 
 [sysctl]
 # Set the keepalive interval to a value higher than 1200 seconds.
@@ -29,5 +27,3 @@ net.ipv4.tcp_keepalive_time = 1250
 
 [sysctl:csp=azure]
 net.ipv4.tcp_keepalive_time =
-
-[reminder]

--- a/ospackage/usr/share/saptune/notes/1771258
+++ b/ospackage/usr/share/saptune/notes/1771258
@@ -7,7 +7,7 @@
 VERSION=8
 DATE=05.01.2023
 DESCRIPTION=Linux: User and system resource limits
-REFERENCES=https://launchpad.support.sap.com/#/notes/1771258
+REFERENCES=https://me.sap.com/notes/1771258
 
 [limits]
 # /etc/security/limits.conf or drop-in file in /etc/securitty/limits.d

--- a/ospackage/usr/share/saptune/notes/1805750
+++ b/ospackage/usr/share/saptune/notes/1805750
@@ -3,10 +3,10 @@
 #
 
 [version]
-VERSION=9
-DATE=10.03.2020
+VERSION=10
+DATE=21.05.2024
 DESCRIPTION=SYB: Usage of HugePages on Linux Systems with Sybase ASE
-REFERENCES=https://launchpad.support.sap.com/#/notes/1805750
+REFERENCES=https://me.sap.com/notes/1805750
 
 [limits]
 # Allow Sybase ASE owner to make use of available HugePages.

--- a/ospackage/usr/share/saptune/notes/1868829
+++ b/ospackage/usr/share/saptune/notes/1868829
@@ -4,7 +4,7 @@
 VERSION=5
 DATE=29.03.2018
 DESCRIPTION=Startup Issues Because Number of Active I/O Requests to Queue Exceeds aio-max-nr Limit
-REFERENCES=https://launchpad.support.sap.com/#/notes/1868829
+REFERENCES=https://me.sap.com/notes/1868829
 
 [sysctl]
 # maximum number of asynchronous I/Os.

--- a/ospackage/usr/share/saptune/notes/1980196
+++ b/ospackage/usr/share/saptune/notes/1980196
@@ -4,7 +4,7 @@
 VERSION=7
 DATE=18.10.2017
 DESCRIPTION=Setting Linux Kernel Parameter /proc/sys/vm/max_map_count on SAP HANA Systems
-REFERENCES=https://launchpad.support.sap.com/#/notes/1980196
+REFERENCES=https://me.sap.com/notes/1980196
 
 [sysctl]
 # vm.max_map_count

--- a/ospackage/usr/share/saptune/notes/1984787
+++ b/ospackage/usr/share/saptune/notes/1984787
@@ -5,7 +5,7 @@
 VERSION=42
 DATE=07.10.2022
 DESCRIPTION=SUSE LINUX Enterprise Server 12: Installation notes
-REFERENCES=https://launchpad.support.sap.com/#/notes/1984787
+REFERENCES=https://me.sap.com/notes/1984787
 
 [login]
 # /etc/systemd/logind.conf.d/saptune-UserTasksMax.conf UserTasksMax setting

--- a/ospackage/usr/share/saptune/notes/2161991
+++ b/ospackage/usr/share/saptune/notes/2161991
@@ -5,7 +5,7 @@
 VERSION=28
 DATE=29.07.2021
 DESCRIPTION=VMware vSphere configuration guidelines
-REFERENCES=https://launchpad.support.sap.com/#/notes/2161991
+REFERENCES=https://me.sap.com/notes/2161991
 
 [block]
 ## Type:    string

--- a/ospackage/usr/share/saptune/notes/2205917
+++ b/ospackage/usr/share/saptune/notes/2205917
@@ -5,7 +5,7 @@
 VERSION=63
 DATE=18.05.2021
 DESCRIPTION=SAP HANA DB: Recommended OS settings for SLES 12 / SLES for SAP Applications 12
-REFERENCES=https://launchpad.support.sap.com/#/notes/2205917
+REFERENCES=https://me.sap.com/notes/2205917
 
 [login]
 # /etc/systemd/logind.conf.d/saptune-UserTasksMax.conf UserTasksMax setting

--- a/ospackage/usr/share/saptune/notes/2382421
+++ b/ospackage/usr/share/saptune/notes/2382421
@@ -1,23 +1,12 @@
 # 2382421 - Optimizing the Network Configuration on HANA- and OS-Level
 
 [version]
-VERSION=45
-DATE=02.08.2023
+VERSION=47
+DATE=12.03.2024
 DESCRIPTION=Optimizing the Network Configuration on HANA- and OS-Level
-REFERENCES=https://launchpad.support.sap.com/#/notes/2382421
+REFERENCES=https://me.sap.com/notes/2382421
 
 [sysctl]
-# This parameter limits the size of the accept backlog of a listening socket.
-# The Linux default of 128 is not sufficient. You need to set the parameter
-# to 4096 in order that the HANA system can use higher values.
-# There is an interdependency between this parameter and HANA configuration
-# parameter tcp_backlog. If net.core.somaxconn is set to a lower value than
-# tcp_backlog, tcp_backlog will be silently truncated to the value set for
-# net.core.somaxconn. Therefore, you need to ensure that net.core.somaxconn
-# is always set to a value equal to or greater than tcp_backlog.
-# net.core.somaxconn >= 4096
-net.core.somaxconn = 4096
-
 # This is the size of the SYN backlog.
 # To prevent the kernel from using SYN cookies in a situation where lots of
 # connection requests are sent in a short timeframe and to prevent a
@@ -156,6 +145,22 @@ net.ipv4.tcp_tw_reuse =
 # It also prevents processes to set a longer timeout. The recommended value is
 # 8, which translates into a timeout of 190 seconds.
 net.ipv4.tcp_syn_retries = 8
+
+[sysctl:os=15-SP3]
+# This parameter limits the size of the accept backlog of a listening socket.
+# The Linux default of 128 is not sufficient. You need to set the parameter
+# to 4096 in order that the HANA system can use higher values.
+# There is an interdependency between this parameter and HANA configuration
+# parameter tcp_backlog. If net.core.somaxconn is set to a lower value than
+# tcp_backlog, tcp_backlog will be silently truncated to the value set for
+# net.core.somaxconn. Therefore, you need to ensure that net.core.somaxconn
+# is always set to a value equal to or greater than tcp_backlog.
+# net.core.somaxconn >= 4096
+net.core.somaxconn = 4096
+[sysctl:os=15-SP2]
+net.core.somaxconn = 4096
+[sysctl:os=15-SP1]
+net.core.somaxconn = 4096
 
 [sysctl:os=12-SP3]
 # net.ipv4.tcp_tw_recycle

--- a/ospackage/usr/share/saptune/notes/2534844
+++ b/ospackage/usr/share/saptune/notes/2534844
@@ -4,7 +4,7 @@
 VERSION=15
 DATE=26.05.2023
 DESCRIPTION=Indexserver Crash During Startup due to Insufficient Shared Memory Segment
-REFERENCES=https://launchpad.support.sap.com/#/notes/2534844
+REFERENCES=https://me.sap.com/notes/2534844
 
 [sysctl]
 # kernel.shmmni

--- a/ospackage/usr/share/saptune/notes/2578899
+++ b/ospackage/usr/share/saptune/notes/2578899
@@ -2,10 +2,10 @@
 # Description:    You want to use SAP software on SUSE Linux Enterprise Server 15 (SLES 15) or SUSE Linux Enterprise Server 15 for SAP Applications  (SLES for SAP 15).
 
 [version]
-VERSION=48
-DATE=28.06.2024
+VERSION=50
+DATE=07.10.2024
 DESCRIPTION=SUSE Linux Enterprise Server 15: Installation Note
-REFERENCES=https://launchpad.support.sap.com/#/notes/2578899
+REFERENCES=https://me.sap.com/notes/2578899
 
 [service]
 # start the related services
@@ -14,11 +14,11 @@ sysstat.service=start
 
 [service:os=15-SP4]
 sysctl-logger.service=start
-
 [service:os=15-SP5]
 sysctl-logger.service=start
-
 [service:os=15-SP6]
+sysctl-logger.service=start
+[service:os=15-SP7]
 sysctl-logger.service=start
 
 [block]
@@ -56,6 +56,8 @@ binutils 15 2.35.1-6.20.1
 binutils 15-SP1 2.35.1-7.18.1
 binutils 15-SP2 2.35.1-7.18.1
 uuidd 15-SP3 2.36.2-150300.4.17.1
+polkit 0.114-1.12
+insserv-compat 0.1-2.15
 
 [rpm:os=15-SP3:arch=x86_64]
 glibc 2.31-150300.46.1

--- a/ospackage/usr/share/saptune/notes/2684254
+++ b/ospackage/usr/share/saptune/notes/2684254
@@ -2,10 +2,10 @@
 # Description:    HANA DB settings
 
 [version]
-VERSION=23
+VERSION=24
 DATE=03.05.2023
 DESCRIPTION=SAP HANA DB: Recommended OS settings for SLES 15 / SLES for SAP Applications 15
-REFERENCES=https://launchpad.support.sap.com/#/notes/2684254
+REFERENCES=https://me.sap.com/notes/2684254
 
 [vm]
 # Disable transparent hugepages (THP)
@@ -25,7 +25,21 @@ THP=never
 #
 KSM=0
 
-[cpu]
+[vm:os=15-SP5]
+# Enable transparent hugepages (THP)
+# changes /sys/kernel/mm/transparent_hugepage/enabled
+# 'never' to disable, 'always' to enable
+# 'madvise' will enter direct reclaim like 'always' but only for regions that
+# are have used madvise(MADV_HUGEPAGE). This is the default behaviour.
+# SAP Note 2131662, 2031375
+#
+THP=madvise
+[vm:os=15-SP6]
+THP=madvise
+[vm:os=15-SP7]
+THP=madvise
+
+[cpu:arch=x86_64]
 # Energy Performance Bias EPB (applies to Intel-based systems only)
 # energy_perf_bias: performance - 0, normal - 6, powersave - 15
 # cpupower set -b 0, if system supports Intel's performance bias setting
@@ -98,7 +112,7 @@ glibc 2.31-150300.46.1
 [rpm:os=15-SP4:arch=x86_64]
 glibc 2.31-150300.46.1
 
-[grub]
+[grub:arch=x86_64]
 # /etc/default/grub GRUB_CMDLINE_LINUX_DEFAULT
 # saptune only checks the values. Changing the grub configuration is not
 # supported by saptune

--- a/ospackage/usr/share/saptune/notes/2993054
+++ b/ospackage/usr/share/saptune/notes/2993054
@@ -2,10 +2,10 @@
 # Description:    Azure settings
 
 [version]
-VERSION=2
-DATE=13.07.2021
+VERSION=3
+DATE=06.08.2024
 DESCRIPTION=Recommended settings for SAP systems on Linux running in Azure virtual machines
-REFERENCES=https://launchpad.support.sap.com/#/notes/2993054
+REFERENCES=https://me.sap.com/notes/2993054
 
 [sysctl:csp=azure]
 net.ipv4.tcp_keepalive_time = 300

--- a/ospackage/usr/share/saptune/notes/3024346
+++ b/ospackage/usr/share/saptune/notes/3024346
@@ -2,10 +2,10 @@
 # See TR-4290 (FAS) or TR-4435 (AFF).
 
 [version]
-VERSION=10
-DATE=09.02.2024
+VERSION=12
+DATE=20.09.2024
 DESCRIPTION=Linux Kernel Settings for NetApp NFS
-REFERENCES=https://launchpad.support.sap.com/#/notes/3024346 https://docs.netapp.com/us-en/netapp-solutions-sap/bp/saphana-fas-nfs_introduction.html https://docs.netapp.com/us-en/netapp-solutions-sap/bp/saphana_aff_nfs_introduction.html
+REFERENCES=https://me.sap.com/notes/3024346 https://docs.netapp.com/us-en/netapp-solutions-sap/bp/saphana-fas-nfs_introduction.html https://docs.netapp.com/us-en/netapp-solutions-sap/bp/saphana_aff_nfs_introduction.html
 
 [sysctl]
 net.core.rmem_max = 16777216
@@ -19,7 +19,5 @@ net.ipv4.tcp_moderate_rcvbuf = 1
 net.ipv4.tcp_window_scaling = 1
 net.ipv4.tcp_timestamps = 1
 net.ipv4.tcp_sack = 1
+sunrpc.tcp_max_slot_table_entries = 128
 
-[reminder] 
-# NFS version 3 requires to limit the max TCP Slot Table entries.
-# Therefore add "options sunrpc tcp_max_slot_table_entries=128" into file "/etc/modprobe.d/sunrpc.conf".

--- a/ospackage/usr/share/saptune/notes/900929
+++ b/ospackage/usr/share/saptune/notes/900929
@@ -4,7 +4,7 @@
 VERSION=7
 DATE=31.07.2017
 DESCRIPTION=Linux: STORAGE_PARAMETERS_WRONG_SET and 'mmap() failed'
-REFERENCES=https://launchpad.support.sap.com/#/notes/900929
+REFERENCES=https://me.sap.com/notes/900929
 
 [sysctl]
 # vm.max_map_count

--- a/ospackage/usr/share/saptune/notes/941735
+++ b/ospackage/usr/share/saptune/notes/941735
@@ -5,7 +5,7 @@
 VERSION=11
 DATE=04.05.2018
 DESCRIPTION=SAP memory management system for 64-bit Linux systems
-REFERENCES=https://launchpad.support.sap.com/#/notes/941735
+REFERENCES=https://me.sap.com/notes/941735
 
 [mem]
 # /dev/shm


### PR DESCRIPTION
man page saptune.8 - add warning about race condition of systemd units during system boot. saptune-note.5 already contained a description, now saptune.8 was enhanced as well
(bsc#1190508)
Houskeeping of SAP Notes - update version and date
change link location to the new 'me.sap.com' location
add/change parameter for some notes
(bsc#1232212)