### PR TITLE
next bunch of fixes for 3.2

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -104,6 +104,9 @@ func SelectAction(writer io.Writer, stApp *app.App, saptuneVers string) {
 	case "staging":
 		StagingAction(system.CliArg(2), system.CliArgs(3), stApp)
 	case "status":
+		if system.CliArg(2) != "" {
+			PrintHelpAndExit(writer, 1)
+		}
 		ServiceAction(writer, "status", saptuneVers, stApp)
 	case "verify":
 		VerifyAction(writer, system.CliArg(2), stApp)

--- a/actions/serviceacts.go
+++ b/actions/serviceacts.go
@@ -20,6 +20,10 @@ var orphanedOverrides []string
 // ServiceAction handles service actions like start, stop, status, enable, disable
 // it controls the systemd saptune.service
 func ServiceAction(writer io.Writer, actionName, saptuneVersion string, tApp *app.App) {
+	// check command line syntax
+	if system.CliArg(3) != "" {
+		PrintHelpAndExit(writer, 1)
+	}
 	preventReload()
 	switch actionName {
 	case "apply":

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -64,7 +64,7 @@ rename SOLUTIONNAME NEWSOLUTIONNAME
 release [--force|--dry-run] [ ( NOTEID | SOLUTIONNAME.sol )... | all ]
 
 \fBsaptune\fP [--format FORMAT] [--force-color] [--fun] \fBconfigure\fP
-( COLOR_SCHEME | SKIP_SYSCTL_FILES | IGNORE_RELOAD | DEBUG ) Value
+( COLOR_SCHEME | SKIP_SYSCTL_FILES | IGNORE_RELOAD | DEBUG | TrentoASDP ) Value
 
 \fBsaptune\fP [--format FORMAT] [--force-color] [--fun] \fBconfigure\fP
 ( reset | show )

--- a/ospackage/usr/lib/supportconfig/plugins/saptune
+++ b/ospackage/usr/lib/supportconfig/plugins/saptune
@@ -101,7 +101,6 @@ function display_log() {
 
 # ---- Main ----
 display_cmd saptune_check
-display_cmd saptune_check --json
 display_package_info tuned
 display_file_stat /usr/lib/tuned/functions
 display_systemd_status tuned

--- a/ospackage/usr/lib/supportconfig/plugins/saptune
+++ b/ospackage/usr/lib/supportconfig/plugins/saptune
@@ -147,6 +147,8 @@ display_cmd mokutil --sb-state
 display_file_stat /sys/firmware/efi/efivars/SecureBoot-*
 # intel_idle or intel_pstate?
 display_file /proc/cmdline
+display_file /sys/devices/system/cpu/offline
+display_file /sys/devices/system/cpu/online
 display_ls /sys/devices/system/cpu/intel_pstate
 display_file /sys/devices/system/cpu/intel_pstate/status
 display_file /sys/devices/system/cpu/cpuidle/current_driver
@@ -155,6 +157,7 @@ for file in /sys/devices/system/cpu/cpu*; do
     [ -e "${file}/cpufreq/scaling_available_governors" ] && display_file ${file}/cpufreq/scaling_available_governors
     [ -e "${file}/cpufreq/scaling_governor" ] && display_file ${file}/cpufreq/scaling_governor
     [ -e "${file}/cpufreq/scaling_driver" ] && display_file ${file}/cpufreq/scaling_driver
+    [ -e "${file}/online" ] && display_file ${file}/online
 done
 display_cmd /usr/bin/cpupower -c all info
 display_cmd /usr/bin/cpupower -c all frequency-info

--- a/ospackage/usr/share/saptune/notes/2684254
+++ b/ospackage/usr/share/saptune/notes/2684254
@@ -127,7 +127,17 @@ processor.max_cstate=1
 # Turn off autoNUMA balancing - see kernel.numa_balancing in section [sysctl]
 numa_balancing=disable
 # Disable transparent hugepages - see THP in section [vm]
+# recommended for systems <=15SP4
 transparent_hugepage=never
+
+# Configure transparent hugepages (THP)
+# recommended for systems >=15SP5
+[grub:os=15-SP5:arch=x86_64]
+transparent_hugepage=madvise
+[grub:os=15-SP6:arch=x86_64]
+transparent_hugepage=madvise
+[grub:os=15-SP7:arch=x86_64]
+transparent_hugepage=madvise
 
 [filesystem:os=15-SP2]
 xfs_options= -nobarrier, -barrier

--- a/system/commandsMap.go
+++ b/system/commandsMap.go
@@ -94,6 +94,7 @@ func supportedRACMap() map[string]bool {
 	supportedRAC["solution enabled"] = true
 	supportedRAC["solution applied"] = true
 	supportedRAC["status"] = true
+	supportedRAC["verify applied"] = true
 	supportedRAC["version"] = true
 	supportedRAC["check"] = true
 

--- a/system/file.go
+++ b/system/file.go
@@ -19,7 +19,7 @@ func ReadConfigFile(fileName string, autoCreate bool) ([]byte, error) {
 		content = []byte{}
 		err = os.MkdirAll(path.Dir(fileName), 0755)
 		if err == nil {
-			err = os.WriteFile(fileName, []byte{}, 0600)
+			err = os.WriteFile(fileName, []byte{}, 0644)
 		}
 	}
 	return content, err
@@ -46,7 +46,7 @@ func readConfValue(file, entry string) string {
 		if strings.HasPrefix(line, entry) {
 			// entry found
 			fields := strings.Fields(line)
-			if fields[0] == entry && len (fields) > 1 {
+			if fields[0] == entry && len(fields) > 1 {
 				value = fields[1]
 			}
 		}

--- a/system/json.go
+++ b/system/json.go
@@ -357,8 +357,7 @@ func realmAndCmd() string {
 func racIsSupported(rac string) bool {
 	if _, ok := supportedRAC[rac]; !ok {
 		// rac not a valid combination
-		// return true to let PrintHelpAndExit later do it's job
-		return true
+		JInvalid(1)
 	}
 	return supportedRAC[rac]
 }

--- a/system/trento.go
+++ b/system/trento.go
@@ -49,7 +49,7 @@ func CheckAndSetTrento(entry, val string, change bool) error {
 			} else {
 				// logging not initialised
 				fmt.Fprintf(os.Stderr, "WARNING: Value '%s' of entry '%s' in Trento config file '%s' differs from the value configured with saptune ('%s'). Please check.\n", value, param, trentoFile, val)
-			}	
+			}
 		}
 		if value != "" && change {
 			// entry available in config file but value differs
@@ -60,7 +60,7 @@ func CheckAndSetTrento(entry, val string, change bool) error {
 		if value == "" && change {
 			InfoLog("Entry '%s' not yet available in Trento config file '%s'. Adding entry with value '%s'....", param, trentoFile, val)
 			// entry not found in config file, append with comment
-			err = appendEntry(trentoFile, param + " " + val, comment)
+			err = appendEntry(trentoFile, param+" "+val, comment)
 		}
 	}
 	return err
@@ -78,8 +78,8 @@ func checkForValidValue(value string, logSwitch bool) error {
 		WarningLog(errorTXT, value)
 	} else {
 		// logging not initialised
-		fmt.Fprintf(os.Stderr, "WARNING: " + errorTXT + "\n", value)
-	}	
+		fmt.Fprintf(os.Stderr, "WARNING: "+errorTXT+"\n", value)
+	}
 	return fmt.Errorf(errorTXT, value)
 }
 


### PR DESCRIPTION
- fix Nvme detection (bsc#1233126)
- support offline cpu handline, skip offline cpu when setting/verifying governor and force_latency (bsc#1221020, jsc#TEAM-8427)
- enhance CPU handling with additional warnings and skip governor settings, if intel_idle and intel_pstate are disabled (jsc#TEAM-3759, jsc#TEAM-8427)
- add the recommendation for 'madvise' to the grub commandline entries too (bsc#1235579)
- enable json support for 'saptune verify applied'
- fix wrong service action handling related to the combination of wrong syntax and json output