### PR TITLE
fix /etc/security/limits.conf handling

### DIFF
--- a/ospackage/usr/share/saptune/notes/2684254
+++ b/ospackage/usr/share/saptune/notes/2684254
@@ -129,6 +129,14 @@ numa_balancing=disable
 # Disable transparent hugepages - see THP in section [vm]
 transparent_hugepage=never
 
+[grub:os=15-SP5:arch=x86_64]
+# Configure transparent hugepages (THP)
+transparent_hugepage=madvise
+[grub:os=15-SP6:arch=x86_64]
+transparent_hugepage=madvise
+[grub:os=15-SP7:arch=x86_64]
+transparent_hugepage=madvise
+
 [filesystem:os=15-SP2]
 xfs_options= -nobarrier, -barrier
 

--- a/sap/note/sectLimits.go
+++ b/sap/note/sectLimits.go
@@ -34,7 +34,7 @@ func GetLimitsVal(value string) (string, string, error) {
 		secLimits, err := system.ParseSecLimitsFile(dropInFile)
 		if err != nil {
 			//ANGI TODO - check, if other files in /etc/security/limits.d contain a value for the touple "<domain>-<item>-<type>"
-			return "", info, err
+			return "NA", info, err
 		}
 		lim[3], _ = secLimits.Get(lim[0], lim[1], lim[2])
 		if lim[3] == "" {

--- a/system/blockdev.go
+++ b/system/blockdev.go
@@ -40,6 +40,26 @@ var isVD = regexp.MustCompile(`^x?vd\w+$`)
 //	nvme0n1p1: first registered device's first namespace's first partition
 var isNvme = regexp.MustCompile(`^nvme\d+n\d+$`)
 
+// isValidDisk checks, if the device is a valid disk for us
+func isValidDisk(dev string) bool {
+	if isVD.FindStringSubmatch(dev) == nil && isNvme.FindStringSubmatch(dev) == nil {
+		// not a virtual disk or Nvme
+		return false
+	}
+	if isNvme.FindStringSubmatch(dev) != nil {
+		// check for valid Nvme
+		fname := fmt.Sprintf("/sys/block/%s/queue/scheduler", dev)
+		if _, err := os.Stat(fname); err != nil {
+			return false
+		}
+		fname = fmt.Sprintf("/sys/block/%s/queue/nr_requests", dev)
+		if _, err := os.Stat(fname); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
 // BlockDeviceIsDisk checks, if a block device is a disk
 // /sys/block/*/device/type (TYPE_DISK / 0x00)
 // does not work for virtio and nvme block devices, needs workaround
@@ -47,7 +67,8 @@ func BlockDeviceIsDisk(dev string) bool {
 	fname := fmt.Sprintf("/sys/block/%s/device/type", dev)
 	dtype, err := ioutil.ReadFile(fname)
 	if err != nil || strings.TrimSpace(string(dtype)) != "0" {
-		if isVD.FindStringSubmatch(dev) == nil && isNvme.FindStringSubmatch(dev) == nil {
+		// check for virtio and nvme block devices
+		if !isValidDisk(dev) {
 			// unsupported device
 			return false
 		}

--- a/system/limits.go
+++ b/system/limits.go
@@ -56,15 +56,32 @@ type SecLimits struct {
 	Entries []*SecLimitsEntry
 }
 
+// systemLimitsConfFile reads the system limits.conf file
+// on SLE12 and SLE15
+func systemLimitsConfFile() ([]byte, error) {
+	var content []byte
+	var err error
+	if IsSLE12() || IsSLE15() {
+		limitsConfFile := "/etc/security/limits.conf"
+		DebugLog("Try '%s' instead.", limitsConfFile)
+		content, err = os.ReadFile(limitsConfFile)
+		if err != nil {
+			DebugLog("Failed to read system limits config file '%s': %v", limitsConfFile, err)
+		}
+	}
+	return content, err
+}
+
 // ParseSecLimitsFile read limits.conf and parse the file content into memory
 // structures.
 func ParseSecLimitsFile(fileName string) (*SecLimits, error) {
-	limitsConfFile := "/etc/security/limits.conf"
+	limits := &SecLimits{Entries: make([]*SecLimitsEntry, 0)}
 	content, err := ioutil.ReadFile(fileName)
 	if err != nil {
-		content, err = ioutil.ReadFile(limitsConfFile)
+		DebugLog("ParseSecLimitsFile - failed to read drop in file '%s': '%v'.", fileName, err)
+		content, err = systemLimitsConfFile()
 		if err != nil {
-			return nil, ErrorLog("failed to open limits config file: %v", err)
+			return limits, nil
 		}
 	}
 	return ParseSecLimits(string(content)), nil


### PR DESCRIPTION
* fix NVMe device detection (bsc#1233126)
* fix wrong error handling, if system limits.conf file is missing and skip reading system limits.conf file on SLES 16 as it can not contain customer changes (bsc#1236232)
 * fix value for grub transparent_hugepage entries in Note 2684254 (bsc#1235579)
