### PR TITLE
Last, last minute fixes for 3.2.3

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -179,6 +179,8 @@ func VerifyAllParameters(writer io.Writer, tuneApp *app.App, chkApplied bool) {
 	}
 	if len(tuneApp.NoteApplyOrder) == 0 {
 		fmt.Fprintf(writer, "No notes or solutions enabled, nothing to verify.\n")
+	} else if chkApplied && len(tuneApp.AppliedNotes()) == 0 {
+		fmt.Fprintf(writer, "No notes or solutions applied, nothing to verify.\n")
 	} else {
 		unsatisfiedNotes, comparisons, err := tuneApp.VerifyAll(chkApplied)
 		if err != nil {
@@ -191,7 +193,11 @@ func VerifyAllParameters(writer io.Writer, tuneApp *app.App, chkApplied bool) {
 		sysComp := len(unsatisfiedNotes) == 0
 		result.SysCompliance = &sysComp
 		if len(unsatisfiedNotes) == 0 {
-			fmt.Fprintf(writer, "%s%sThe running system is currently well-tuned according to all of the enabled notes.%s%s\n", setGreenText, setBoldText, resetBoldText, resetTextColor)
+			if chkApplied {
+				fmt.Fprintf(writer, "%s%sThe running system is currently well-tuned according to all of the applied notes.%s%s\n", setGreenText, setBoldText, resetBoldText, resetTextColor)
+			} else {
+				fmt.Fprintf(writer, "%s%sThe running system is currently well-tuned according to all of the enabled notes.%s%s\n", setGreenText, setBoldText, resetBoldText, resetTextColor)
+			}
 		} else {
 			system.Jcollect(result)
 			system.ErrorExit("The parameters listed above have deviated from SAP/SUSE recommendations.", "colorPrint", setRedText, setBoldText, resetBoldText, resetTextColor)

--- a/actions/cmdsyntax.go
+++ b/actions/cmdsyntax.go
@@ -47,6 +47,7 @@ Deprecation list:
   'saptune solution simulate'
   'Solution SAP-ASE.sol and related Notes 1680803, 1805750'
   'Note 1771258 and PAM limits handling'
+  'Note 941735'
 `
 }
 
@@ -91,5 +92,6 @@ Print this message:
   saptune [--format FORMAT] [--force-color] [--fun] help
 
 Deprecation list:
+  'Note 941735'
 `
 }

--- a/main.go
+++ b/main.go
@@ -203,33 +203,26 @@ func callSaptuneCheckScript(arg string) {
 
 // checkSaptuneServiceDropIn checks on Azure cloud if saptune service drop-in
 // is available
-// if not, create the needed directories, the file and make it visible
+// if yes, remove the file and the directory
 func checkSaptuneServiceDropIn() {
 	if system.GetCSP() != "azure" {
-		// not on azure cloude, nothing to do
+		// not on azure cloud, nothing to do
 		return
 	}
 	saptuneServiceDir := "/etc/systemd/system/saptune.service.d"
 	saptuneServiceDropIn := fmt.Sprintf("%s/%s", saptuneServiceDir, "10-after_cloud-init.conf")
-	if _, err := os.Stat(saptuneServiceDropIn); err == nil {
-		// file exists, nothing to do
+	if _, err := os.Stat(saptuneServiceDropIn); err != nil {
+		// file does not exist, nothing to do
 		return
 	}
-	system.NoticeLog("creating saptune service drop-in file...")
-	if err := os.MkdirAll(saptuneServiceDir, 0755); err != nil {
-		system.ErrorLog("can not create directory '%s', so writing saptune service drop-in file '%s' will not work!", saptuneServiceDir, saptuneServiceDropIn)
+	system.NoticeLog("saptune service drop-in file still exists, removing now...")
+	if err := os.Remove(saptuneServiceDropIn); err != nil {
+		system.ErrorLog("can not remove saptune service drop-in file '%s' - %v", saptuneServiceDropIn, err)
 		return
 	}
-	dropInContent := fmt.Sprintf("[Unit]\nAfter=cloud-final.service\n")
-	if err := os.WriteFile(saptuneServiceDropIn, []byte(dropInContent), 0644); err == nil {
-		system.NoticeLog("file '%s' successfully created!", saptuneServiceDropIn)
-		// make drop-in visible for systemd
-		// errors are reported by the function, no need to react here
-		// is handled during next reboot
-		_ = system.SystemctlDaemonReload()
-	} else {
-		system.ErrorLog("can not write saptune service drop-in file '%s' - %v", saptuneServiceDropIn, err)
-	}
+	system.NoticeLog("file '%s' successfully removed! Inform systemd about the change", saptuneServiceDropIn)
+	// remove drop-in from systemd
+	_ = system.SystemctlDaemonReload()
 }
 
 // checkWorkingArea checks, if solution and note configs exist in the working

--- a/ospackage/man/saptune-note.5
+++ b/ospackage/man/saptune-note.5
@@ -531,6 +531,20 @@ Depending on the size of the virtual memory (physical+swap) the value is calcula
 If VSZ_TMPFS_PERCENT is set to '\fB0\fP', the value is calculated by (RAM + SWAP) * 75/100, as the default is 75.
 
 As this parameter is only used to calculate the value of \fIShmFileSystemSizeMB\fP it will not be checked and compared during the saptune operation 'verify'. A footnote is pointing this out.
+
+.TP
+.B Note:
+.br
+Newer \fIcloud-init\fP versions have a dependency of \fIcloud-final.service\fP to \fImulti-user.target\fP which prevents saptune to run on boot on Azure systems if the systemd service drop-in file '\fI/etc/systemd/system/saptune.service.d/10-after_cloud-init.conf\fP' is created by saptune.
+.br
+With 3.2.3 on each execution saptune will \fBnot\fP create this file anymore, but remove it if present!
+.br
+Additionally SAP Note \fB941735\fP contains a [mem:csp=azure] section with \fBdisabled\fP ShmFileSystemSizeMB and VSZ_TMPFS_PERCENT parameters because calculating the size of /dev/shm is not reliable possible anymore if swap is configured by \fIcloud-init\fP. This can lead to sporadic non-compliant verify reports.
+.br
+If you really still need to change the size of TMPFS for you SAP workload, please do it by \fBother\fP means.
+.br
+If you nevertheless prefer to use saptune to set the size of TMPFS \fBand\fP if you have a \fBpersistent\fP swap size during boot you can use an override file for Note \fB941735\fP to set your desired TMPFS parameter settings.
+
 \" _strm_3.2.0_start
 \" section pagecache
 .SH "[pagecache]"

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -282,10 +282,6 @@ Success is reported on stdout, errors including systemd error messages are print
 If the action was successfully the exit code is 0, otherwise 1.
 
 .TP
-.B Note:
-On Azure cloud we create a saptune service drop-in file to start saptune.service after cloud-final.service to tune the system after the swap space was added by cloud-init.
-
-.TP
 .B ATTENTION:
 .br
 saptune is able to start/stop/enable/disable systemd units, but on boot the outcome depends on the order of execution.

--- a/ospackage/man/saptune.8
+++ b/ospackage/man/saptune.8
@@ -1050,6 +1050,9 @@ Additional the Solution \fBSAP-ASE.sol\fP and the related Notes \fB1680803\fP an
 SAP Note \fB1771258\fP not relevant/valid anymore on SLE 16, we \fBdeprecated\fP the Note and the support for setting PAM limits in SLES for SAP 12 and 15 and removed both in SLE 16
 .br
 The already deprecated actions 'daemon', 'note simulate' and 'solution simulate' are removed in SLE16
+.TP
+.B version 3.2.3
+SAP Note \fB941735\fP not relevant/valid anymore, we \fBdeprecated\fP the Note with the update to saptune version 3.2.3 on SLES for SAP 12, 15 and 16 and on plain SLES 16.
 
 .SH FILES
 .PP

--- a/ospackage/usr/share/saptune/delete_in_16/1680803
+++ b/ospackage/usr/share/saptune/delete_in_16/1680803
@@ -1,0 +1,1 @@
+1680803 deprecated

--- a/ospackage/usr/share/saptune/delete_in_16/1771258
+++ b/ospackage/usr/share/saptune/delete_in_16/1771258
@@ -1,0 +1,1 @@
+1771258 deprecated

--- a/ospackage/usr/share/saptune/delete_in_16/1805750
+++ b/ospackage/usr/share/saptune/delete_in_16/1805750
@@ -1,0 +1,1 @@
+1805750 deprecated

--- a/ospackage/usr/share/saptune/delete_in_16/SAP-ASE.sol
+++ b/ospackage/usr/share/saptune/delete_in_16/SAP-ASE.sol
@@ -1,0 +1,6 @@
+[ArchX86]
+deprecated
+
+[ArchPPC64LE]
+deprecated
+

--- a/ospackage/usr/share/saptune/deprecated/941735
+++ b/ospackage/usr/share/saptune/deprecated/941735
@@ -1,0 +1,1 @@
+941735 deprecated

--- a/ospackage/usr/share/saptune/deprecated_16/941735
+++ b/ospackage/usr/share/saptune/deprecated_16/941735
@@ -1,0 +1,1 @@
+941735 deprecated

--- a/ospackage/usr/share/saptune/notes/941735
+++ b/ospackage/usr/share/saptune/notes/941735
@@ -33,6 +33,17 @@ ShmFileSystemSizeMB=0
 #
 VSZ_TMPFS_PERCENT=75
 
+[mem:csp=azure]
+# Bug 1260498
+# see man page saptune-note.5 section 'mem' for more information about the
+# cloud-init impact for this change.
+# If you prefer to use saptune to set the size of TMPFS and you have a
+# persistent swap size during boot you can use an override file for this Note
+# to set your desired TMPFS parameter settings.
+#
+ShmFileSystemSizeMB=
+VSZ_TMPFS_PERCENT=
+
 [sysctl]
 # kernel.shmmax
 # This value can be set the run time limit on the maximum shared memory


### PR DESCRIPTION
* Fix output of 'saptune verify applied' in case of enabled notes, but nothing is applied (jsc#SAPSOL-1051)
* On Azure the upcoming cloud-init update breaks saptune due to ordering cycle changes. To fix this we remove the dependency from saptune.service to cloud-final.service (bsc#1260498, jsc#SAPSOL-1050)
*  deprecate SAP Note 941735 on 12, 15 and 16 (jsc#SAPSOL-1048)
